### PR TITLE
Always select foreign keys and never check them on parent type

### DIFF
--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -106,6 +106,13 @@ class SelectFields {
                 continue;
             }
 
+            // Always select foreign key
+            if ($field === 'foreignKey')
+            {
+                self::addFieldToSelect($key, $select, $parentTable, false);
+                continue;
+            }
+
             $fieldObject = $parentType->getField($key);
 
             // First check if the field is even accessible
@@ -144,7 +151,7 @@ class SelectFields {
                         $foreignKey = explode('.', $foreignKey)[2];
                         if( ! array_key_exists($foreignKey, $field))
                         {
-                            $field[$foreignKey] = true;
+                            $field[$foreignKey] = 'foreignKey';
                         }
                     }
 

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -19,6 +19,8 @@ class SelectFields {
     private $select = [];
     /* @var $relations array */
     private $relations = [];
+    
+    const FOREIGN_KEY = 'foreignKey';
 
     /**
      * @param ResolveInfo $info
@@ -107,7 +109,7 @@ class SelectFields {
             }
 
             // Always select foreign key
-            if ($field === 'foreignKey')
+            if ($field === self::FOREIGN_KEY)
             {
                 self::addFieldToSelect($key, $select, $parentTable, false);
                 continue;
@@ -151,7 +153,7 @@ class SelectFields {
                         $foreignKey = explode('.', $foreignKey)[2];
                         if( ! array_key_exists($foreignKey, $field))
                         {
-                            $field[$foreignKey] = 'foreignKey';
+                            $field[$foreignKey] = self::FOREIGN_KEY;
                         }
                     }
 


### PR DESCRIPTION
This simple change allows you to remove the foreign keys from your type definitions.
Instead of
```php
namespace App\GraphQL\Type;

use GraphQL;
use App\NewsArticle;
use GraphQL\Type\Definition\Type;
use Rebing\GraphQL\Support\Type as GraphQLType;
class NewsArticleType extends GraphQLType {
				
	protected $attributes = [
		'name'          => 'news_article',
		'description'   => 'A news article',
		'model'         => NewsArticle::class,
	];
		
	public function fields()
	{
		return [
			'id' => [
				'type' => Type::nonNull(Type::string()),
				'description' => 'The id of the user',
			],
			'user_id' => [
				'type' => Type::int(),
				'description' => 'User id of the author'
			]
		];
	}		
}
```
you can do
```php
namespace App\GraphQL\Type;

use GraphQL;
use App\NewsArticle;
use GraphQL\Type\Definition\Type;
use Rebing\GraphQL\Support\Type as GraphQLType;
class NewsArticleType extends GraphQLType {
				
	protected $attributes = [
		'name'          => 'news_article',
		'description'   => 'A news article',
		'model'         => NewsArticle::class,
	];
		
	public function fields()
	{
		return [
			'id' => [
				'type' => Type::nonNull(Type::string()),
				'description' => 'The id of the user',
			],
		];
	}		
}
```