### PR TITLE
Fixing undefined method with embedded array of objects

### DIFF
--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -121,7 +121,11 @@ class SelectFields {
 
             // If field doesn't exist on definition we don't select it
             try {
-                $fieldObject = $parentType->getField($key);
+                if ($parentType instanceof \GraphQL\Type\Definition\ListOfType) {
+                    continue;
+                } else {
+                    $fieldObject = $parentType->getField($key);
+                }
             } catch (InvariantViolation $e) {
                 continue;
             }


### PR DESCRIPTION
*Example Query*
```
query {
  Me {
    email, first_name, last_name, agreed, subscriptions {
      name
      start
      end
      trial
    }
  }
}
```

*Type Definition*
```
...
'subscriptions' => [
    'type' => Type::listOf(\GraphQL::type('Subscription')),
    'description' => 'Active subscriptions'
],
...
```

I found that the `$parentType` does not have a `getFields` method on it. By just bypassing this call for a `ListOfType` class, the problem is solved.