### PR TITLE
Use a a different column name when selecting a field

### DIFF
--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -198,6 +198,10 @@ class SelectFields {
                 // Select
                 else
                 {
+                    // If an alias for the field is set, use it as DB column
+                    $columnNameProperty = config('graphql.column_name_attribute');
+                    $key = isset($fieldObject->config[$columnNameProperty]) ? $fieldObject->config[$columnNameProperty] : $key;
+
                     self::addFieldToSelect($key, $select, $parentTable, false);
 
                     self::addAlwaysFields($fieldObject, $select, $parentTable);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -126,5 +126,8 @@ return [
 
     // You can set the key, which will be used to retrieve the dynamic variables
     'params_key'    => 'params',
+
+    // Field attribute to change column name of a field
+    'column_name_attribute'  => 'aliasFor'
     
 ];

--- a/src/example/Type/UserType.php
+++ b/src/example/Type/UserType.php
@@ -44,6 +44,11 @@ class UserType extends GraphQLType {
                 'type'          => Type::string(),
                 'description'   => 'Pin (ID code) of the user',
             ],
+            'registered_on'     =>  [
+                'type'          => Type::string(),
+                'description'   => 'Date of the user registration',
+                'aliasFor'      => 'created_at' // This field correspond to the created_at column in the model table
+            ]
 
             /* RELATIONS */
             'profile' => [


### PR DESCRIPTION
Hello!

I have just started using your package but I'm using a legacy database with non consistent columns naming conventions.

This simple PR adds the possibility to set the column name of a field when it is linked to an Eloquent model, so that the fields name can be different than the columns name in the Eloquent table.

I've made the attribute key configurable and I also updated the UserType example.