### PR TITLE
Update Query.php

### DIFF
--- a/src/Rebing/GraphQL/Support/Query.php
+++ b/src/Rebing/GraphQL/Support/Query.php
@@ -3,5 +3,33 @@
 namespace Rebing\GraphQL\Support;
 
 class Query extends Field {
-    
+ 
+    protected function rules(array $args = [])
+    {
+        return [];
+    }
+
+    public function getRules()
+    {
+        $arguments = func_get_args();
+
+        $rules = call_user_func_array([$this, 'rules'], $arguments);
+        $argsRules = [];
+        foreach($this->args() as $name => $arg)
+        {
+            if(isset($arg['rules']))
+            {
+                if(is_callable($arg['rules']))
+                {
+                    $argsRules[$name] = call_user_func_array($arg['rules'], $arguments);
+                }
+                else
+                {
+                    $argsRules[$name] = $arg['rules'];
+                }
+            }
+        }
+
+        return array_merge($argsRules, $rules);
+    }
 }


### PR DESCRIPTION
Validation Rules should also apply to queries, just like it is for mutations.
The server should be able to catch validation errors and return proper messages whether the request is a query or a mutation.