### PR TITLE
Add support for Unions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,7 @@ config/graphql.php
 - [Pagination](docs/advanced.md#pagination)
 - [Batching](docs/advanced.md#batching)
 - [Enums](docs/advanced.md#enums)
+- [Unions](docs/advanced.md#unions)
 
 ### Schemas
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -554,15 +554,19 @@ class TestType extends GraphQLType {
 
 ### Unions
 
+A Union is an abstract type that simply enumerates other Object Types. The value of Union Type is actually a value of one of included Object Types.
+
+It's useful if you need to return unrelated types in the same Query. For example when implementing a search for multiple different entities.
+
+Example for defining a UnionType:
+
 ```php
 // app/GraphQL/Unions/SearchResultUnion.php
 namespace App\GraphQL\Unions;
 
-use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Support\UnionType;
 
-class SearchResultUnion extends GraphQLType {
-
-    protected $unionType = true;
+class SearchResultUnion extends UnionType {
 
     protected $attributes = [
         'name' => 'SearchResult',

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,6 +9,7 @@
 - [Pagination](#pagination)
 - [Batching](#batching)
 - [Enums](#enums)
+- [Unions](#unions)
 
 ### Authorization
 
@@ -548,4 +549,41 @@ class TestType extends GraphQLType {
    }
    
 }
+```
+
+
+### Unions
+
+```php
+// app/GraphQL/Unions/SearchResultUnion.php
+namespace App\GraphQL\Unions;
+
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class SearchResultUnion extends GraphQLType {
+
+    protected $unionType = true;
+
+    protected $attributes = [
+        'name' => 'SearchResult',
+    ];
+
+    public function types()
+    {
+        return [
+            \GraphQL::type('Post'),
+            \GraphQL::type('Episode'),
+        ];
+    }
+
+    public function resolveType($value)
+    {
+        if ($value instanceof Post) {
+            return \GraphQL::type('Post');
+        } elseif ($value instanceof Episode) {
+            return \GraphQL::type('Episode');
+        }
+    }
+}
+
 ```

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -7,6 +7,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\UnionType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -123,6 +124,8 @@ class SelectFields {
             try {
                 if ($parentType instanceof \GraphQL\Type\Definition\ListOfType) {
                     continue;
+                } elseif ($parentType instanceof \GraphQL\Type\Definition\UnionType) {
+                    continue;
                 } else {
                     $fieldObject = $parentType->getField($key);
                 }
@@ -222,10 +225,10 @@ class SelectFields {
             }
         }
 
-        // If parent type is an interface we select all fields
+        // If parent type is an interface or union we select all fields
         // because we don't know which other fields are required
         // from types which implement this interface
-        if(is_a($parentType, InterfaceType::class))
+        if(is_a($parentType, InterfaceType::class) || is_a($parentType, UnionType::class))
         {
             $select = ['*'];
         }

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -5,6 +5,7 @@ namespace Rebing\GraphQL\Support;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\UnionType;
 use Illuminate\Support\Fluent;
 
 class Type extends Fluent {
@@ -13,6 +14,7 @@ class Type extends Fluent {
     
     protected $inputObject = false;
     protected $enumObject = false;
+    protected $unionType = false;
 
     public function attributes()
     {
@@ -25,6 +27,11 @@ class Type extends Fluent {
     }
     
     public function interfaces()
+    {
+        return [];
+    }
+
+    public function types()
     {
         return [];
     }
@@ -86,6 +93,7 @@ class Type extends Fluent {
     {
         $attributes = $this->attributes();
         $interfaces = $this->interfaces();
+        $types = $this->types();
         
         $attributes = array_merge($this->attributes, [
             'fields' => function () {
@@ -96,6 +104,15 @@ class Type extends Fluent {
         if(sizeof($interfaces))
         {
             $attributes['interfaces'] = $interfaces;
+        }
+
+        if (sizeof($types)) {
+            $attributes['types'] = $types;
+
+            if(method_exists($this, 'resolveType'))
+            {
+                $attributes['resolveType'] = [$this, 'resolveType'];
+            }
         }
         
         return $attributes;
@@ -119,6 +136,9 @@ class Type extends Fluent {
         }
         if ($this->enumObject) {
             return new EnumType($this->toArray());
+        }
+        if ($this->unionType) {
+            return new UnionType($this->toArray());
         }
         return new ObjectType($this->toArray());
     }

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -31,11 +31,6 @@ class Type extends Fluent {
         return [];
     }
 
-    public function types()
-    {
-        return [];
-    }
-    
     protected function getFieldResolver($name, $field)
     {
         if(isset($field['resolve']))
@@ -93,7 +88,6 @@ class Type extends Fluent {
     {
         $attributes = $this->attributes();
         $interfaces = $this->interfaces();
-        $types = $this->types();
         
         $attributes = array_merge($this->attributes, [
             'fields' => function () {
@@ -106,15 +100,6 @@ class Type extends Fluent {
             $attributes['interfaces'] = $interfaces;
         }
 
-        if (sizeof($types)) {
-            $attributes['types'] = $types;
-
-            if(method_exists($this, 'resolveType'))
-            {
-                $attributes['resolveType'] = [$this, 'resolveType'];
-            }
-        }
-        
         return $attributes;
     }
 
@@ -136,9 +121,6 @@ class Type extends Fluent {
         }
         if ($this->enumObject) {
             return new EnumType($this->toArray());
-        }
-        if ($this->unionType) {
-            return new UnionType($this->toArray());
         }
         return new ObjectType($this->toArray());
     }

--- a/src/Rebing/GraphQL/Support/UnionType.php
+++ b/src/Rebing/GraphQL/Support/UnionType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rebing\GraphQL\Support;
+
+use GraphQL\Type\Definition\UnionType as BaseUnionType;
+
+class UnionType extends Type {
+
+    public function types()
+    {
+        return [];
+    }
+
+    /**
+     * Get the attributes from the container.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        $attributes = parent::getAttributes();
+        $types = $this->types();
+
+        if (sizeof($types)) {
+            $attributes['types'] = $types;
+        }
+        
+        if(method_exists($this, 'resolveType'))
+        {
+            $attributes['resolveType'] = [$this, 'resolveType'];
+        }
+        
+        return $attributes;
+    }
+    
+    public function toType()
+    {
+        return new BaseUnionType($this->toArray());
+    }
+    
+}


### PR DESCRIPTION
This PR improves/fixes support for Unions:

- simplifies the definition of Union Types when using the rebing `Support\Type` base class
- skip SelectFields for union types (same as for Interfaces)
- add basic example to documentation

This is not ideal. It would be great to preserve the `SelectFields` feature. Also it might be better to use a new class `Rebing\Graphql\Support\UnionType` instead of using a boolean attribute in `Support\Type`.

So this is more for reference for others having issues with booleans (#63) and open for discussion. 
@rebing It would be great if you could review this PR and give some feedback. I'm willing to fix and improve this PR until it's ready to get merged.
Thanks