### PR TITLE
Add Support for FieldDefinition instance in fields array

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,7 @@ config/graphql.php
 - [Pagination](docs/advanced.md#pagination)
 - [Batching](docs/advanced.md#batching)
 - [Enums](docs/advanced.md#enums)
+- [Interfaces](docs/advanced.md#interfaces)
 
 ### Schemas
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,6 +9,7 @@
 - [Pagination](#pagination)
 - [Batching](#batching)
 - [Enums](#enums)
+- [Interfaces](#interfaces)
 
 ### Authorization
 
@@ -547,5 +548,142 @@ class TestType extends GraphQLType {
         ]
    }
    
+}
+```
+
+### Interfaces
+
+You can use interfaces to abstract a set of fields. Read more about Interfaces [here](http://graphql.org/learn/schema/#interfaces)
+
+An implementation of an interface:
+
+```php
+<?php
+// app/GraphQL/Interfaces/CharacterInterface.php
+namespace App\GraphQL\Interfaces;
+
+use GraphQL;
+use Rebing\GraphQL\Support\InterfaceType;
+use GraphQL\Type\Definition\Type;
+
+class CharacterInterface extends InterfaceType {
+    protected $attributes = [
+        'name' => 'Character',
+        'description' => 'Character interface.',
+    ];
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The id of the character.'
+            ],
+            'name' => Type::string(),
+            'appearsIn' => [
+                'type' => Type::nonNull(Type::listOf(GraphQL::type('Episode'))),
+                'description' => 'A list of episodes in which the character has an appearance.'
+            ],
+        ];
+    }
+
+    public function resolveType($root)
+    {
+        // Use the resolveType to resolve the Type which is implemented trough this interface
+        $type = $root['type'];
+        if ($type === 'human') {
+            return GraphQL::type('Human');
+        } else if  ($type === 'droid') {
+            return GraphQL::type('Droid');
+        }
+    }
+}
+```
+
+A Type that implements an interface:
+
+```php
+<?php
+// app/GraphQL/Types/HumanType.php
+namespace App\GraphQL\Types;
+
+use GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use GraphQL\Type\Definition\Type;
+
+class HumanType extends GraphQLType {
+
+    protected $attributes = [
+        'name' => 'Human',
+        'description' => 'A human.'
+    ];
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The id of the human.',
+            ],
+            'name' => Type::string(),
+            'appearsIn' => [
+                'type' => Type::nonNull(Type::listOf(GraphQL::type('Episode'))),
+                'description' => 'A list of episodes in which the human has an appearance.'
+            ],
+            'totalCredits' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The total amount of credits this human owns.'
+            ]
+        ];
+    }
+
+    public function interfaces()
+    {
+        return [
+            GraphQL::type('Character')
+        ];
+    }
+}
+```
+
+#### Sharing Interface fields
+
+Since you often have to repeat many of the field definitons of the Interface in the concrete types, it makes sense to share the definitions of the Interface.
+You can access and reuse specific interface fields with the method `getField(string fieldName): FieldDefinition`. To get all fields as an array use `getFields(): array`
+
+With this you could write the `fields` method of your `HumanType` class like this:
+
+
+```php
+public function fields()
+{
+    $interface = GraphQL::type('Character');
+
+    return [
+        $interface->getField('id'),
+        $interface->getField('name'),
+        $interface->getField('appearsIn'),
+
+        'totalCredits' => [
+            'type' => Type::nonNull(Type::int()),
+            'description' => 'The total amount of credits this human owns.'
+        ]
+    ];
+}
+```
+
+Or by using the `getFields` method:
+
+```php
+public function fields()
+{
+    $interface = GraphQL::type('Character');
+
+    return array_merge($interface->getFields(), [
+        'totalCredits' => [
+            'type' => Type::nonNull(Type::int()),
+            'description' => 'The total amount of credits this human owns.'
+        ]
+    ]);
 }
 ```

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -3,6 +3,7 @@
 namespace Rebing\GraphQL\Support;
 
 use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use Illuminate\Support\Fluent;
@@ -62,6 +63,10 @@ class Type extends Fluent {
                 $field = app($field);
                 $field->name = $name;
                 $allFields[$name] = $field->toArray();
+            }
+            elseif ($field instanceof FieldDefinition)
+            {
+                $allFields[$field->name] = $field;
             }
             else
             {


### PR DESCRIPTION
This PR allows using instances of `GraphQL\Type\Definition\FieldDefinition` in the `fields` array of a type.
This is very useful when using Interfaces as the `InterfaceType` has a `getField` and `getFields` method for sharing interface fields.

This is documented on http://webonyx.github.io/graphql-php/type-system/interfaces/#sharing-interface-fields

Example:

```php
class SubType extends GraphQLType
{
    protected $attributes = ['name' => 'SubType'

    function interfaces()
    {
        return [GraphQL::type('SomeInterface')];
    }

    public function fields()
    {
        $interfaceFields = GraphQL::type('UserInterface')->getFields();
        $additionalFields = [
            'special_field' => Type::string(),
        ];
        array_merge($interfaceFields, $additionalFields);
    }
```
or:
```php
    public function fields()
    {
        $interface = GraphQL::type('UserInterface');
        return [
            $interface->getField('id'),
            $interface->getField('name'),
            'special_field' => Type::string(),
        ];
    }
```