### PR TITLE
Added ability to customise validation errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -461,6 +461,28 @@ When you execute a mutation, it will return any validation errors that occur. Si
 	}
 ```
 
+
+The validation errors returned can be customised by overriding the `validationErrorMessages` method on the mutation. This method should return an array of custom validation
+messages in the same way documented by Laravel's validation. For example, to check an `email` argument doesn't conflict with any existing data, you could perform the following -
+
+Note: the keys should be in `field_name`.`validator_type` format so you can return specific errors per validation type.
+
+
+````php
+
+    public function validationErrorMessages ($args = []) {
+        return [
+            'name.required' => 'Please enter your full name',
+            'name.string' => 'Your name must be a valid string',
+            'email.required' => 'Please enter your email address',
+            'email.email' => 'Please enter a valid email address',
+            'email.exists' => 'Sorry, this email address is already in use',                     
+        ];
+    }
+
+````
+
+
 #### File uploads
 
 For uploading new files just use `UploadType`. This support of uploading files is base on https://github.com/jaydenseric/graphql-multipart-request-spec

--- a/Readme.md
+++ b/Readme.md
@@ -462,15 +462,15 @@ When you execute a mutation, it will return any validation errors that occur. Si
 ```
 
 
-The validation errors returned can be customised by overriding the `validationErrorMessages` method on the mutation. This method should return an array of custom validation
-messages in the same way documented by Laravel's validation. For example, to check an `email` argument doesn't conflict with any existing data, you could perform the following -
+The validation errors returned can be customised by overriding the `validationErrorMessages` method on the mutation. This method should return an array of custom validation messages in the same way documented by Laravel's validation. For example, to check an `email` argument doesn't conflict with any existing data, you could perform the following -
 
 Note: the keys should be in `field_name`.`validator_type` format so you can return specific errors per validation type.
 
 
 ````php
 
-    public function validationErrorMessages ($args = []) {
+    public function validationErrorMessages ($args = []) 
+    {
         return [
             'name.required' => 'Please enter your full name',
             'name.string' => 'Your name must be a valid string',

--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -155,7 +155,14 @@ class Field extends Fluent {
                 $rules = call_user_func_array([$this, 'getRules'], [$args]);
                 if(sizeof($rules))
                 {
-                    $validator = Validator::make($args, $rules);
+
+                    // allow our error messages to be customised
+                    $messages = [];
+                    if(method_exists($this, 'validationErrorMessages')) {
+                        $messages = call_user_func_array([$this, 'validationErrorMessages'], [$args]);
+                    }
+
+                    $validator = Validator::make($args, $rules, $messages);
                     if($validator->fails())
                     {
                         throw with(new ValidationError('validation'))->setValidator($validator);

--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -36,6 +36,16 @@ class Field extends Fluent {
         return [];
     }
 
+    /**
+     * Define custom Laravel Validator messages as per Laravel 'custom error messages'
+     * @param array $args submitted arguments
+     * @return array
+     */
+    public function validationErrorMessages ($args = []) {
+        return [];
+    }
+
+
     protected function rules(array $args = [])
     {
         return [];
@@ -157,10 +167,7 @@ class Field extends Fluent {
                 {
 
                     // allow our error messages to be customised
-                    $messages = [];
-                    if(method_exists($this, 'validationErrorMessages')) {
-                        $messages = call_user_func_array([$this, 'validationErrorMessages'], [$args]);
-                    }
+                    $messages = $this->validationErrorMessages($args);
 
                     $validator = Validator::make($args, $rules, $messages);
                     if($validator->fails())

--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -41,7 +41,8 @@ class Field extends Fluent {
      * @param array $args submitted arguments
      * @return array
      */
-    public function validationErrorMessages ($args = []) {
+    public function validationErrorMessages(array $args = [])
+    {
         return [];
     }
 


### PR DESCRIPTION
Currently, with validation there is no way to customise the errors that come back. This simple update, allows a method to be created within the mutation allows the creation of a method called `validationErrorMessages`.

`validationErrorMessages` should return an array of rules. For example -

```
public function validationErrorMessages($args = array ()) {
    return [
        'role_id.required' => 'Please select a valid user role',
    ];
}
```

This is in accordance with the Laravel Validator - https://laravel.com/docs/5.6/validation#custom-error-messages