### PR TITLE
Fix compatibility issue with php 7.2

### DIFF
--- a/src/Rebing/GraphQL/GraphQLController.php
+++ b/src/Rebing/GraphQL/GraphQLController.php
@@ -14,7 +14,7 @@ class GraphQLController extends Controller {
 
         // If there are multiple route params we can expect that there
         // will be a schema name that has to be built
-        if (count($request->route()->parameters) > 1) {
+        if ($request->route()->parameters && count($request->route()->parameters) > 1) {
             $schema = implode('/', $request->route()->parameters);
         }
 


### PR DESCRIPTION
Hi I found that this package is not working on php 7.2 because it will throw an error:

```
local.ERROR: ErrorException: count(): Parameter must be an array or an object that implements Countable in .../vendor/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLController.php:21
```

The reason why this happen is that on php 7.1 will count behave different:
```
count(NULL); // 0
```

but on php 7.2:

```
count(NULL); // PHP Warning:  count(): Parameter must be an array or an object that implements Countable 
```