### PR TITLE
Added "non_relation_field" to types with documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -906,7 +906,8 @@ class UserType extends GraphQLType {
                 'description'   => 'A list of posts written by the user',
                 // Now this will simply request the "posts" column, and it won't 
                 // query for all the underlying columns in the "post" object
-                'non_relation_field' => true
+                // The value defaults to true
+                'is_relation' => false
             ]
         ];
     }

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -12,6 +12,7 @@
 - [Unions](#unions)
 - [Interfaces](#interfaces)
 - [Input Object](#input-object)
+- [JSON Columns](#json-columns)
 
 ### Authorization
 
@@ -879,5 +880,36 @@ class TestMutation extends GraphQLType {
         ]
    }
    
+}
+```
+
+### JSON Columns
+
+When using JSON columns in your database, the field won't be defined as a "relationship", 
+but rather a simple column with nested data. To get a nested object that's not a database relationship, 
+use the `non_relation_field` attribute in your Type:
+
+```php
+class UserType extends GraphQLType {
+
+    ...
+    
+    public function fields()
+    {
+        return [
+            
+            ...
+            
+            // JSON column containing all posts made by this user
+            'posts' => [
+                'type'          => Type::listOf(GraphQL::type('post')),
+                'description'   => 'A list of posts written by the user',
+                // Now this will simply request the "posts" column, and it won't 
+                // query for all the underlying columns in the "post" object
+                'non_relation_field' => true
+            ]
+        ];
+    }
+
 }
 ```

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -140,13 +140,16 @@ class SelectFields {
                 // Add a query, if it exists
                 $customQuery = array_get($fieldObject->config, 'query');
 
+                // Check if the field is a relation that needs to be requested from the DB
+                $queryable = !isset($fieldObject->config['non_relation_field']) || $fieldObject->config['non_relation_field'] === false;
+
                 // Pagination
                 if(is_a($parentType, PaginationType::class))
                 {
                     self::handleFields($field, $fieldObject->config['type']->getWrappedType(), $select, $with);
                 }
                 // With
-                elseif(is_array($field))
+                elseif(is_array($field) && $queryable)
                 {
                     if (isset($parentType->config['model']))
                     {

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -98,6 +98,19 @@ class SelectFields {
     }
 
     /**
+     * Determines whether the fieldObject is queryable.
+     *
+     * @param $fieldObject
+     * @return bool
+     */
+    private static function isQueryable($fieldObject) {
+        $is_specified_relation = isset($fieldObject->config['is_relation']) && $fieldObject->config['is_relation'] === true;
+        $is_default_relation = !isset($fieldObject->config['is_relation']);
+
+        return $is_specified_relation || $is_default_relation;
+    }
+
+    /**
      * Get the selects and withs from the given fields
      * and recurse if necessary
      */
@@ -141,7 +154,7 @@ class SelectFields {
                 $customQuery = array_get($fieldObject->config, 'query');
 
                 // Check if the field is a relation that needs to be requested from the DB
-                $queryable = !isset($fieldObject->config['non_relation_field']) || $fieldObject->config['non_relation_field'] === false;
+                $queryable = self::isQueryable($fieldObject);
 
                 // Pagination
                 if(is_a($parentType, PaginationType::class))

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -98,19 +98,6 @@ class SelectFields {
     }
 
     /**
-     * Determines whether the fieldObject is queryable.
-     *
-     * @param $fieldObject
-     * @return bool
-     */
-    private static function isQueryable($fieldObject) {
-        $is_specified_relation = isset($fieldObject->config['is_relation']) && $fieldObject->config['is_relation'] === true;
-        $is_default_relation = !isset($fieldObject->config['is_relation']);
-
-        return $is_specified_relation || $is_default_relation;
-    }
-
-    /**
      * Get the selects and withs from the given fields
      * and recurse if necessary
      */
@@ -311,6 +298,16 @@ class SelectFields {
         }
 
         return $selectable;
+    }
+
+    /**
+     * Determines whether the fieldObject is queryable.
+     *
+     * @param $fieldObject
+     * @return bool
+     */
+    private static function isQueryable($fieldObject) {
+        return array_get($fieldObject, 'is_relation', true) === true;
     }
 
     /**


### PR DESCRIPTION
This extra configuration field takes care of querying nested JSON database columns. 
What it does is effectively requesting to query a specific nested object, but not query any of the underlying columns, because it's not a "relationship", but an attribute of the parent. 

The problem I had, that this implementation solves, was that when specifying a model on a type, any nested arrays are seen as a database relationship, even when one of the properties of the type is a nested JSON object, and not actually a relationship. This implementation makes sure to add the key of the nested object to the select fields but ignores any of the underlying columns, practically making SelectFields view the column as a single valued field.

If I missed a feature that already takes care of this, I'd love to hear how it's done, but this solved the problem for me, so perhaps it'll help others.

**My solution**

OLD
```
'persons' => [
    'type' => Type::listOf(GraphQL::type('crew_list_member')),
    'description' => 'The members of the party of the booking',
    'resolve' => function($root) {
         // I have to get the full model a second time here
         $list = \App\Models\CrewList::find($root->id);
         return $list->persons;
    },
    'selectable' => false
]
```

NEW
```
'persons' => [
    'type' => Type::listOf(GraphQL::type('crew_list_member')),
    'description' => 'The members of the party of the booking',
    'is_relation' => false
]
```