### PR TITLE
Do not use calls deprecated upstream

### DIFF
--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -3,7 +3,7 @@
 use GraphQL\Error\Error;
 use Rebing\GraphQL\Error\ValidationError;
 use GraphQL\GraphQL as GraphQLBase;
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use Rebing\GraphQL\Events\SchemaAdded;
 use Rebing\GraphQL\Exception\SchemaNotFound;
@@ -115,7 +115,7 @@ class GraphQL {
 
         $schema = $this->schema($schemaName);
 
-        $result = GraphQLBase::executeAndReturnResult($schema, $query, null, $context, $params, $operationName);
+        $result = GraphQLBase::executeQuery($schema, $query, null, $context, $params, $operationName);
         return $result;
     }
 


### PR DESCRIPTION
This PR simply replaces usage of calls deprecated in webonyx/graphql 0.10.x with new suggested interfaces.

[Source](https://github.com/webonyx/graphql-php/blob/v0.10.0/UPGRADE.md)

Sadly, I noticed that (at least in my environment) two tests are failing from the very beginning. I'll try to address that in following pull request but nonetheless tests suite (as well as my manual testing) did not expose any regressions