### PR TITLE
Revamp the docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,8 +3,6 @@
 [![Latest Stable Version](https://poser.pugx.org/rebing/graphql-laravel/v/stable)](https://packagist.org/packages/rebing/graphql-laravel)
 [![License](https://poser.pugx.org/rebing/graphql-laravel/license)](https://packagist.org/packages/rebing/graphql-laravel)
 
-Core code is from [Folklore's laravel-graphql](https://github.com/Folkloreatelier/laravel-graphql)
-
 Uses Facebook GraphQL with Laravel 5. It is based on the PHP implementation [here](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](http://facebook.github.io/react/blog/2015/05/01/graphql-introduction.html) on the [React](http://facebook.github.io/react) blog or you can read the [GraphQL specifications](https://facebook.github.io/graphql/). This is a work in progress.
 
 This package is compatible with Eloquent models or any other data source.
@@ -12,6 +10,15 @@ This package is compatible with Eloquent models or any other data source.
 * Custom **middleware** can be defined for each query/mutation
 * Queries return **types**, which can have custom **privacy** settings.
 * The queried fields will have the option to be retrieved **dynamically** from the database with the help of the `SelectFields` class.
+
+It offers following features and improvements over the original package by
+[Folklore](https://github.com/Folkloreatelier/laravel-graphql):
+* Per-operation authorization
+* Per-field callback defining its visibility (e.g. hiding from unauthenticated users)
+* `SelectFields` abstraction available in `resolve()`, allowing for advanced eager loading
+  and thus dealing with n+1 problems
+* Pagination support
+* Server-side support for [query batching](https://blog.apollographql.com/batching-client-graphql-queries-a685f5bcd41b)
 
 ## Installation
 
@@ -23,45 +30,30 @@ This package is compatible with Eloquent models or any other data source.
 
 #### Installation:
 
-**1-** Require the package via Composer in your `composer.json`.
-```json
-{
-  "require": {
-    "rebing/graphql-laravel": "~1.14"
-  }
-}
-```
-
-**2-** Run Composer to install or update the new requirement.
-
+**1.** Require the package via Composer
 ```bash
-$ composer install
+composer require rebing/graphql-laravel
 ```
 
-or
-
-```bash
-$ composer update
-```
-
-**3-** Add the service provider to your `app/config/app.php` file
+**2.** Laravel 5.5+ will autodiscover the package, for older versions add the
+following service provider
 ```php
 Rebing\GraphQL\GraphQLServiceProvider::class,
 ```
 
-**4-** Add the facade to your `app/config/app.php` file
+and alias
 ```php
 'GraphQL' => 'Rebing\GraphQL\Support\Facades\GraphQL',
 ```
 
-**5-** Publish the configuration file
+in your `config/app.php` file.
 
+**3.** Publish the configuration file
 ```bash
 $ php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider"
 ```
 
-**6-** Review the configuration file
-
+**4.** Review the configuration file
 ```
 config/graphql.php
 ```
@@ -88,13 +80,14 @@ config/graphql.php
 - [Unions](docs/advanced.md#unions)
 - [Interfaces](docs/advanced.md#interfaces)
 - [Input Object](docs/advanced.md#input-object)
+- [JSON Columns](docs/advanced.md#json-columns)
 
 ### Schemas
 
 Schemas are required for defining GraphQL endpoints. You can define multiple schemas and assign different **middleware** to them,
 in addition to the global middleware. For example:
 
-```
+```php
 'schema' => 'default_schema',
 
 'schemas' => [
@@ -108,7 +101,7 @@ in addition to the global middleware. For example:
     ],
     'user' => [
         'query' => [
-            'profile' => 'App\GraphQL\Query\ProfileQuery'
+            'profile' => App\GraphQL\Query\ProfileQuery::class
         ],
         'mutation' => [
         
@@ -122,141 +115,136 @@ in addition to the global middleware. For example:
 
 First you need to create a type. The Eloquent Model is only required, if specifying relations.
 
-**NB! The `selectable` key is required, if it's a non-database field or not a relation**
+> **Note:** The `selectable` key is required, if it's a non-database field or not a relation
 
 ```php
-	namespace App\GraphQL\Type;
-	
-	use GraphQL\Type\Definition\Type;
-	use Rebing\GraphQL\Support\Type as GraphQLType;
-    
-    class UserType extends GraphQLType {
-        
-        protected $attributes = [
-            'name'          => 'User',
-            'description'   => 'A user',
-            'model'         => UserModel::class,
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\User;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class UserType extends GraphQLType
+{    
+    protected $attributes = [
+        'name'          => 'User',
+        'description'   => 'A user',
+        'model'         => User::class,
+    ];
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The id of the user',
+                'alias' => 'user_id', // Use 'alias', if the database column is different from the type name
+            ],
+            'email' => [
+                'type' => Type::string(),
+                'description' => 'The email of user',
+            ],
+            // Uses the 'getIsMeAttribute' function on our custom User model
+            'isMe' => [
+                'type' => Type::boolean(),
+                'description' => 'True, if the queried user is the current user',
+                'selectable' => false, // Does not try to query this from the database
+            ]
         ];
-		
-        public function fields()
-        {
-            return [
-                'id' => [
-                    'type' => Type::nonNull(Type::string()),
-                    'description' => 'The id of the user',
-                    'alias' => 'user_id', // Use 'alias', if the database column is different from the type name
-                ],
-                'email' => [
-                    'type' => Type::string(),
-                    'description' => 'The email of user',
-                ],
-                // Uses the 'getIsMeAttribute' function on our custom User model
-                'isMe' => [
-                    'type' => Type::boolean(),
-                    'description' => 'True, if the queried user is the current user',
-                    'selectable' => false, // Does not try to query this from the database
-                ]
-            ];
-        }
-            
-            
-        // If you want to resolve the field yourself, you can declare a method
-        // with the following format resolve[FIELD_NAME]Field()
-        protected function resolveEmailField($root, $args)
-        {
-            return strtolower($root->email);
-        }
-        
     }
 
+    // If you want to resolve the field yourself, you can declare a method
+    // with the following format resolve[FIELD_NAME]Field()
+    protected function resolveEmailField($root, $args)
+    {
+        return strtolower($root->email);
+    }    
+}
 ```
 
 Add the type to the `config/graphql.php` configuration file
 
 ```php
-	'types' => [
-		'user' => 'App\GraphQL\Type\UserType'
-	]
-
+'types' => [
+    'user' => App\GraphQL\Type\UserType::class
+]
 ```
 
 You could also add the type with the `GraphQL` Facade, in a service provider for example.
 
 ```php
-	GraphQL::addType('App\GraphQL\Type\UserType', 'user');
-
+GraphQL::addType(\App\GraphQL\Type\UserType::class, 'user');
 ```
 
 Then you need to define a query that returns this type (or a list). You can also specify arguments that you can use in the resolve method.
 ```php
-	namespace App\GraphQL\Query;
-	
-	use GraphQL;
-	use GraphQL\Type\Definition\Type;
-	use Rebing\GraphQL\Support\Query;    
-	use App\User;
-	
-	class UsersQuery extends Query {
-	
-		protected $attributes = [
-			'name' => 'Users query'
-		];
-		
-		public function type()
-		{
-			return Type::listOf(GraphQL::type('user'));
-		}
-		
-		public function args()
-		{
-			return [
-				'id' => ['name' => 'id', 'type' => Type::string()],
-				'email' => ['name' => 'email', 'type' => Type::string()]
-			];
-		}
-		
-		public function resolve($root, $args)
-		{
-			if(isset($args['id']))
-			{
-				return User::where('id' , $args['id'])->get();
-			}
-			else if(isset($args['email']))
-			{
-				return User::where('email', $args['email'])->get();
-			}
-			else
-			{
-				return User::all();
-			}
-		}
-	
-	}
+<?php
 
+namespace App\GraphQL\Query;
+
+use App\User;
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Users query'
+    ];
+
+    public function type()
+    {
+        return Type::listOf(GraphQL::type('user'));
+    }
+
+    public function args()
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::string()],
+            'email' => ['name' => 'email', 'type' => Type::string()]
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        if (isset($args['id'])) {
+            return User::where('id' , $args['id'])->get();
+        }
+
+        if (isset($args['email'])) {
+            return User::where('email', $args['email'])->get();
+        }
+
+        return User::all();
+    }
+}
 ```
 
 Add the query to the `config/graphql.php` configuration file
 
 ```php
-    'schemas' => [
-		'default' => [
-		    'query' => [
-                'users' => 'App\GraphQL\Query\UsersQuery'
-            ],
-            // ...
-		]
-	]
+'schemas' => [
+    'default' => [
+        'query' => [
+            'users' => App\GraphQL\Query\UsersQuery::class
+        ],
+        // ...
+    ]
+]
 ```
 
 And that's it. You should be able to query GraphQL with a request to the url `/graphql` (or anything you choose in your config). Try a GET request with the following `query` input
 
 ```
-    query FetchUsers {
-        users {
-            id
-            email
-        }
+query FetchUsers {
+    users {
+        id
+        email
     }
+}
 ```
 
 For example, if you use homestead:
@@ -271,74 +259,73 @@ A mutation is like any other query. It accepts arguments (which will be used to 
 For example, a mutation to update the password of a user. First you need to define the Mutation:
 
 ```php
-	namespace App\GraphQL\Mutation;
-	
-	use GraphQL;
-	use GraphQL\Type\Definition\Type;
-	use Rebing\GraphQL\Support\Mutation;    
-	use App\User;
-	
-	class UpdateUserPasswordMutation extends Mutation {
-	
-		protected $attributes = [
-			'name' => 'UpdateUserPassword'
-		];
-		
-		public function type()
-		{
-			return GraphQL::type('user');
-		}
-		
-		public function args()
-		{
-			return [
-				'id' => ['name' => 'id', 'type' => Type::nonNull(Type::string())],
-				'password' => ['name' => 'password', 'type' => Type::nonNull(Type::string())]
-			];
-		}
-		
-		public function resolve($root, $args)
-		{
-			$user = User::find($args['id']);
-			if(!$user)
-			{
-				return null;
-			}
-			
-			$user->password = bcrypt($args['password']);
-			$user->save();
-			
-			return $user;
-		}
-	
-	}
+<?php
 
+namespace App\GraphQL\Mutation;
+
+use App\User;
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;    
+
+class UpdateUserPasswordMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'UpdateUserPassword'
+    ];
+
+    public function type()
+    {
+        return GraphQL::type('user');
+    }
+
+    public function args()
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::nonNull(Type::string())],
+            'password' => ['name' => 'password', 'type' => Type::nonNull(Type::string())]
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $user = User::find($args['id']);
+        if(!$user) {
+            return null;
+        }
+
+        $user->password = bcrypt($args['password']);
+        $user->save();
+
+        return $user;
+    }
+}
 ```
 
-As you can see in the `resolve` method, you use the arguments to update your model and return it.
+As you can see in the `resolve()` method, you use the arguments to update your model and return it.
 
 You should then add the mutation to the `config/graphql.php` configuration file:
 
 ```php
-    'schemas' => [
-		'default' => [
-		    'mutation' => [
-                'updateUserPassword' => 'App\GraphQL\Mutation\UpdateUserPasswordMutation'
-            ],
-            // ...
-		]
-	]
+'schemas' => [
+    'default' => [
+        'mutation' => [
+            'updateUserPassword' => App\GraphQL\Mutation\UpdateUserPasswordMutation::class
+        ],
+        // ...
+    ]
+]
 ```
 
 You should then be able to use the following query on your endpoint to do the mutation:
 
 ```
-    mutation users {
-        updateUserPassword(id: "1", password: "newpassword") {
-            id
-            email
-        }
+mutation users {
+    updateUserPassword(id: "1", password: "newpassword") {
+        id
+        email
     }
+}
 ```
 
 if you use homestead:
@@ -353,183 +340,180 @@ It is possible to add validation rules to a mutation. It uses the Laravel `Valid
 When creating a mutation, you can add a method to define the validation rules that apply by doing the following:
 
 ```php
-	namespace App\GraphQL\Mutation;
-	
-	use GraphQL;
-	use GraphQL\Type\Definition\Type;
-	use Rebing\GraphQL\Support\Mutation;    
-	use App\User;
-	
-	class UpdateUserEmailMutation extends Mutation {
-	
-		protected $attributes = [
-			'name' => 'UpdateUserEmail'
-		];
-		
-		public function type()
-		{
-			return GraphQL::type('user');
-		}
-		
-		public function args()
-		{
-			return [
-				'id' => ['name' => 'id', 'type' => Type::string()],
-				'email' => ['name' => 'password', 'type' => Type::string()]
-			];
-		}
-		
-		public function rules(array $args = [])
-		{
-			return [
-				'id' => ['required'],
-				'email' => ['required', 'email']
-			];
-		}
-		
-		public function resolve($root, $args)
-		{
-			$user = User::find($args['id']);
-			if(!$user)
-			{
-				return null;
-			}
-			
-			$user->email = $args['email'];
-			$user->save();
-			
-			return $user;
-		}
-	
-	}
+<?php
 
+namespace App\GraphQL\Mutation;
+
+use App\User;
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class UpdateUserEmailMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'UpdateUserEmail'
+    ];
+
+    public function type()
+    {
+        return GraphQL::type('user');
+    }
+
+    public function args()
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::string()],
+            'email' => ['name' => 'password', 'type' => Type::string()]
+        ];
+    }
+
+    public function rules(array $args = [])
+    {
+        return [
+            'id' => ['required'],
+            'email' => ['required', 'email']
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $user = User::find($args['id']);
+        if (!$user) {
+            return null;
+        }
+
+        $user->email = $args['email'];
+        $user->save();
+
+        return $user;
+    }
+}
 ```
 
 Alternatively, you can define rules on each argument:
 
-```php
-	
-	class UpdateUserEmailMutation extends Mutation {
-	
-		//...
-		
-		public function args()
-		{
-			return [
-				'id' => [
-					'name' => 'id',
-					'type' => Type::string(),
-					'rules' => ['required']
-				],
-				'email' => [
-					'name' => 'email',
-					'type' => Type::string(),
-					'rules' => ['required', 'email']
-				]
-			];
-		}
-		
-		//...
-	
-	}
+```php	
+class UpdateUserEmailMutation extends Mutation
+{
 
+    //...
+
+    public function args()
+    {
+        return [
+            'id' => [
+                'name' => 'id',
+                'type' => Type::string(),
+                'rules' => ['required']
+            ],
+            'email' => [
+                'name' => 'email',
+                'type' => Type::string(),
+                'rules' => ['required', 'email']
+            ]
+        ];
+    }
+
+    //...
+
+}
 ```
 
 When you execute a mutation, it will return any validation errors that occur. Since the GraphQL specification defines a certain format for errors, the validation errors are added to the error object as a extra `validation` attribute. To find the validation error, you should check for the error with a `message` equals to `'validation'`, then the `validation` attribute will contain the normal errors messages returned by the Laravel Validator:
 
 ```json
-	{
-		"data": {
-			"updateUserEmail": null
-		},
-		"errors": [
-			{
-				"message": "validation",
-				"locations": [
-					{
-						"line": 1,
-						"column": 20
-					}
-				],
-				"validation": {
-					"email": [
-						"The email is invalid."
-					]
-				}
-			}
-		]
-	}
+{
+    "data": {
+        "updateUserEmail": null
+    },
+    "errors": [
+        {
+            "message": "validation",
+            "locations": [
+                {
+                    "line": 1,
+                    "column": 20
+                }
+            ],
+            "validation": {
+                "email": [
+                    "The email is invalid."
+                ]
+            }
+        }
+    ]
+}
 ```
 
+The validation errors returned can be customised by overriding the `validationErrorMessages`
+method on the mutation. This method should return an array of custom validation messages
+in the same way documented by Laravel's validation. For example, to check an `email`
+argument doesn't conflict with any existing data, you could perform the following:
 
-The validation errors returned can be customised by overriding the `validationErrorMessages` method on the mutation. This method should return an array of custom validation messages in the same way documented by Laravel's validation. For example, to check an `email` argument doesn't conflict with any existing data, you could perform the following -
-
-Note: the keys should be in `field_name`.`validator_type` format so you can return specific errors per validation type.
-
+> **Note:** the keys should be in `field_name`.`validator_type` format so you can
+> return specific errors per validation type.
 
 ````php
-
-    public function validationErrorMessages ($args = []) 
-    {
-        return [
-            'name.required' => 'Please enter your full name',
-            'name.string' => 'Your name must be a valid string',
-            'email.required' => 'Please enter your email address',
-            'email.email' => 'Please enter a valid email address',
-            'email.exists' => 'Sorry, this email address is already in use',                     
-        ];
-    }
-
+public function validationErrorMessages ($args = []) 
+{
+    return [
+        'name.required' => 'Please enter your full name',
+        'name.string' => 'Your name must be a valid string',
+        'email.required' => 'Please enter your email address',
+        'email.email' => 'Please enter a valid email address',
+        'email.exists' => 'Sorry, this email address is already in use',                     
+    ];
+}
 ````
 
 
 #### File uploads
 
-For uploading new files just use `UploadType`. This support of uploading files is base on https://github.com/jaydenseric/graphql-multipart-request-spec
+For uploading new files just use `UploadType`. This support of uploading files is
+based on https://github.com/jaydenseric/graphql-multipart-request-spec
 so you have to upload them as multipart form:
 
-**WARNING:** when you are uploading files, Laravel will use FormRequest - it means that middlewares which are changing request, will not have
-any effect...
-
+> **WARNING:** when you are uploading files, Laravel will use FormRequest - it means
+> that middlewares which are changing request, will not have any effect.
 
 ```php
+<?php
 
-	use GraphQL;
-	use GraphQL\Type\Definition\Type;
-	use Rebing\GraphQL\Support\UploadType;
-	use Rebing\GraphQL\Support\Mutation;
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\UploadType;
+use Rebing\GraphQL\Support\Mutation;
 
-	class UserProfilePhotoMutation extends Mutation
-	{
+class UserProfilePhotoMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'UpdateUserProfilePhoto'
+    ];
 
-		protected $attributes = [
-			'name' => 'UpdateUserProfilePhoto'
-		];
-		
-		public function type()
-		{
-			return GraphQL::type('user');
-		}
-		
-		public function args()
-		{
-			return [
-				'profilePicture' => [
-					'name' => 'profilePicture',
-					'type' => new UploadType($this->attributes['name']),
-					'rules' => ['required', 'image', 'max:1500'],
-				],
-			];
-		}
-		
-		public function resolve($root, $args)
-		{
-			$file = $args['profilePicture'];
+    public function type()
+    {
+        return GraphQL::type('user');
+    }
 
-			// Do something with file here...
-		}
+    public function args()
+    {
+        return [
+            'profilePicture' => [
+                'name' => 'profilePicture',
+                'type' => new UploadType($this->attributes['name']),
+                'rules' => ['required', 'image', 'max:1500'],
+            ],
+        ];
+    }
 
-	}
+    public function resolve($root, $args)
+    {
+        $file = $args['profilePicture'];
+
+        // Do something with file here...
+    }
+}
 ```
 
 ### Advanced usage
@@ -544,3 +528,5 @@ any effect...
 - [Enums](docs/advanced.md#enums)
 - [Unions](docs/advanced.md#unions)
 - [Interfaces](docs/advanced.md#interfaces)
+- [Input Object](docs/advanced.md#input-object)
+- [JSON Columns](docs/advanced.md#json-columns)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -30,11 +30,11 @@ class UsersQuery extends Query
         return ! Auth::guest();
     }
     
-    ...
+    // ...
 }
 ```
 
-Or we can make use of arguments passed via the graph query:
+Or we can make use of arguments passed via the GraphQL query:
 
 ```php
 use Auth;
@@ -43,91 +43,92 @@ class UsersQuery extends Query
 {
     public function authorize(array $args)
     {
-        if(isset($args['id']))
-        {
+        if (isset($args['id'])) {
             return Auth::id() == $args['id'];
         }
         
         return true;
     }
     
-    ...
+    // ...
 }
 ```
 
 ### Privacy
 
-You can set custom privacy attributes for every Type's Field. If a field is not allowed, `null` will be returned. For example, if you want the user's email to only be accessible to themselves:
+You can set custom privacy attributes for every Type's Field. If a field is not
+allowed, `null` will be returned. For example, if you want the user's email to
+only be accessible to themselves:
 
 ```php
-class UserType extends GraphQLType {
-        
-        ...
-		
-        public function fields()
-        {
-            return [
-                'id' => [
-                    'type'          => Type::nonNull(Type::string()),
-                    'description'   => 'The id of the user'
-                ],
-                'email' => [
-                    'type'          => Type::string(),
-                    'description'   => 'The email of user',
-                    'privacy'       => function(array $args)
-                    {
-                        return $args['id'] == Auth::id();
-                    }
-                ]
-            ];
-        }
-            
-        ...
-        
+class UserType extends GraphQLType
+{        
+    // ...
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type'          => Type::nonNull(Type::string()),
+                'description'   => 'The id of the user'
+            ],
+            'email' => [
+                'type'          => Type::string(),
+                'description'   => 'The email of user',
+                'privacy'       => function(array $args)
+                {
+                    return $args['id'] == Auth::id();
+                }
+            ]
+        ];
     }
+
+    // ...
+
+}
 ```
 
 or you can create a class that extends the abstract GraphQL Privacy class:
 
 ```php
-use Rebing\GraphQL\Support\Privacy;
 use Auth;
+use Rebing\GraphQL\Support\Privacy;
 
-class MePrivacy extends Privacy {
-
+class MePrivacy extends Privacy
+{
     public function validate(array $args)
     {
         return $args['id'] == Auth::id();
     }
-
 }
 ```
 
 ```php
 use MePrivacy;
 
-class UserType extends GraphQLType {
-        
-        ...
-		
-        public function fields()
-        {
-            return [
-                'id' => [
-                    'type'          => Type::nonNull(Type::string()),
-                    'description'   => 'The id of the user'
-                ],
-                'email' => [
-                    'type'          => Type::string(),
-                    'description'   => 'The email of user',
-                    'privacy'       => MePrivacy::class,
-                ]
-            ];
-        }
-            
-        ...
-        
+class UserType extends GraphQLType
+{
+
+    // ...
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type'          => Type::nonNull(Type::string()),
+                'description'   => 'The id of the user'
+            ],
+            'email' => [
+                'type'          => Type::string(),
+                'description'   => 'The email of user',
+                'privacy'       => MePrivacy::class,
+            ]
+        ];
     }
+
+    // ...
+
+}
 ```
 
 ### Query Variables
@@ -135,13 +136,13 @@ class UserType extends GraphQLType {
 GraphQL offers you the possibility to use variables in your query so you don't need to "hardcode" value. This is done like that:
 
 ```
-    query FetchUserByID($id: String) 
-    {
-        user(id: $id) {
-            id
-            email
-        }
+query FetchUserByID($id: String) 
+{
+    user(id: $id) {
+        id
+        email
     }
+}
 ```
 
 When you query the GraphQL endpoint, you can pass a `params` (or whatever you define in the config) parameter.
@@ -150,155 +151,165 @@ When you query the GraphQL endpoint, you can pass a `params` (or whatever you de
 http://homestead.app/graphql?query=query+FetchUserByID($id:Int){user(id:$id){id,email}}&params={"id":123}
 ```
 
-Notice that your client side framework might use another parameter name than `params`. You can customize the parameter name to anything your client is using by adjusting the `params_key` in the `graphql.php` configuration file.
+Notice that your client side framework might use another parameter name than `params`.
+You can customize the parameter name to anything your client is using by adjusting
+the `params_key` in the `graphql.php` configuration file.
 
 ### Custom field
 
 You can also define a field as a class if you want to reuse it in multiple types.
 
 ```php
+<?php
 
 namespace App\GraphQL\Fields;
 	
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Field;
 
-class PictureField extends Field {
-        
-        protected $attributes = [
-            'description'   => 'A picture',
-        ];
-	
-	public function type()
-	{
-		return Type::string();
-	}
-		
-	public function args()
-	{
-		return [
-			'width' => [
-				'type' => Type::int(),
-				'description' => 'The width of the picture'
-			],
-			'height' => [
-				'type' => Type::int(),
-				'description' => 'The height of the picture'
-			]
-		];
-	}
-	
-	protected function resolve($root, $args)
-	{
-		$width = isset($args['width']) ? $args['width']:100;
-		$height = isset($args['height']) ? $args['height']:100;
-		return 'http://placehold.it/'.$width.'x'.$height;
-	}
-        
-}
+class PictureField extends Field
+{        
+    protected $attributes = [
+        'description'   => 'A picture',
+    ];
 
+    public function type()
+    {
+        return Type::string();
+    }
+
+    public function args()
+    {
+        return [
+            'width' => [
+                'type' => Type::int(),
+                'description' => 'The width of the picture'
+            ],
+            'height' => [
+                'type' => Type::int(),
+                'description' => 'The height of the picture'
+            ]
+        ];
+    }
+
+    protected function resolve($root, $args)
+    {
+        $width = isset($args['width']) ? $args['width']:100;
+        $height = isset($args['height']) ? $args['height']:100;
+        
+        return 'http://placehold.it/'.$width.'x'.$height;
+    }     
+}
 ```
 
 You can then use it in your type declaration
-
-```php
-
-namespace App\GraphQL\Type;
-
-use GraphQL\Type\Definition\Type;
-use Rebing\GraphQL\Support\Type as GraphQLType;
-
-use App\GraphQL\Fields\PictureField;
-
-class UserType extends GraphQLType {
-        
-        protected $attributes = [
-            'name'          => 'User',
-            'description'   => 'A user',
-            'model'         => UserModel::class,
-        ];
-	
-	public function fields()
-	{
-		return [
-			'id' => [
-				'type' => Type::nonNull(Type::string()),
-				'description' => 'The id of the user'
-			],
-			'email' => [
-				'type' => Type::string(),
-				'description' => 'The email of user'
-			],
-			//Instead of passing an array, you pass a class path to your custom field
-			'picture' => PictureField::class
-		];
-	}
-
-}
-
-```
-
-### Eager loading relationships
-
-The third argument passed to a query's resolve method is an instance of `Rebing\GraphQL\Support\SelectFields` which you can use to retrieve keys from the request. The following is an example of using this information to eager load related Eloquent models.
-This way only the required fields will be queried from the database.
-
-Your Query would look like
-
-```php
-	namespace App\GraphQL\Query;
-	
-	use GraphQL;
-	use GraphQL\Type\Definition\Type;
-	use GraphQL\Type\Definition\ResolveInfo;
-	use Rebing\GraphQL\Support\SelectFields;
-	use Rebing\GraphQL\Support\Query;
-	
-	use App\User;
-
-	class UsersQuery extends Query
-	{
-		protected $attributes = [
-			'name' => 'Users query'
-		];
-
-		public function type()
-		{
-			return Type::listOf(GraphQL::type('user'));
-		}
-
-		public function args()
-		{
-			return [
-				'id' => ['name' => 'id', 'type' => Type::string()],
-				'email' => ['name' => 'email', 'type' => Type::string()]
-			];
-		}
-        
-		public function resolve($root, $args, SelectFields $fields, ResolveInfo $info)
-		{
-		    // $info->getFieldSelection($depth = 3);
-		    
-			$select = $fields->getSelect();
-			$with = $fields->getRelations();
-			
-			$users = User::select($select)->with($with);
-			
-			return $users->get();
-		}
-	}
-```
-
-Your Type for User would look like. The `profile` and `posts` relations must also exist in the UserModel's relations.
-If some fields are required for the relation to load or validation etc, then you can define an `always` attribute that will add the given attributes to select.
 
 ```php
 <?php
 
 namespace App\GraphQL\Type;
 
-use Rebing\GraphQL\Support\Facades\GraphQL;
+use App\GraphQL\Fields\PictureField;
+use App\User;
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class UserType extends GraphQLType
+{
+    protected $attributes = [
+        'name'          => 'User',
+        'description'   => 'A user',
+        'model'         => User::class,
+    ];
+    
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The id of the user'
+            ],
+            'email' => [
+                'type' => Type::string(),
+                'description' => 'The email of user'
+            ],
+            //Instead of passing an array, you pass a class path to your custom field
+            'picture' => PictureField::class
+        ];
+    }
+}
+
+```
+
+### Eager loading relationships
+
+The third argument passed to a query's resolve method is an instance of
+`Rebing\GraphQL\Support\SelectFields` which you can use to retrieve keys
+from the request. The following is an example of using this information
+to eager load related Eloquent models.
+
+This way only the required fields will be queried from the database.
+
+Your Query would look like:
+
+```php
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\User;
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Support\Query;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Users query'
+    ];
+
+    public function type()
+    {
+        return Type::listOf(GraphQL::type('user'));
+    }
+
+    public function args()
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::string()],
+            'email' => ['name' => 'email', 'type' => Type::string()]
+        ];
+    }
+
+    public function resolve($root, $args, SelectFields $fields, ResolveInfo $info)
+    {
+        // $info->getFieldSelection($depth = 3);
+        
+        $select = $fields->getSelect();
+        $with = $fields->getRelations();
+        
+        $users = User::select($select)->with($with);
+        
+        return $users->get();
+    }
+}
+```
+
+Your Type for User might look like shown below. The `profile` and `posts`
+relations must also exist in the UserModel's relations. If some fields are
+required for the relation to load or validation etc, then you can define an
+`always` attribute that will add the given attributes to select.
+
+```php
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\User;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
 class UserType extends GraphQLType
@@ -309,7 +320,7 @@ class UserType extends GraphQLType
     protected $attributes = [
         'name'          => 'User',
         'description'   => 'A user',
-        'model'         => UserModel::class,
+        'model'         => User::class,
     ];
 
     /**
@@ -339,7 +350,6 @@ class UserType extends GraphQLType
         ];
     }
 }
-
 ```
 
 At this point we have a profile and a post type as expected for any model
@@ -395,16 +405,17 @@ class PostType extends GraphQLType
 You can also specify the `query` that will be included with a relationship via Eloquent's query builder:
 
 ```php
-class UserType extends GraphQLType {
+class UserType extends GraphQLType
+{
 
-    ...
-    
+    // ...
+
     public function fields()
     {
         return [
-            
-            ...
-            
+
+            // ...
+
             // Relation
             'posts' => [
                 'type'          => Type::listOf(GraphQL::type('post')),
@@ -416,25 +427,24 @@ class UserType extends GraphQLType {
             ]
         ];
     }
-
 }
 ```
 
 ### Pagination
 
-Pagination will be used, if a query or mutation returns a `PaginationType`. Note that you have to manually handle the 
-limit and page values:
+Pagination will be used, if a query or mutation returns a `PaginationType`.
+Note that you have to manually handle the limit and page values:
 
 ```php
-class PostsQuery extends Query {
-
+class PostsQuery extends Query
+{
     public function type()
     {
         return GraphQL::paginate('posts');
     }
-    
-    ...
-    
+
+    // ...
+
     public function resolve($root, $args, SelectFields $fields)
     {
         return Post::with($fields->getRelations())->select($fields->getSelect())
@@ -471,7 +481,7 @@ results.
 
 First, create a class that returns the custom fields you want to see:
 
-```
+```php
 use Illuminate\Pagination\LengthAwarePaginator;
 use GraphQL\Type\Definition\Type as GraphQLType;
 
@@ -505,7 +515,7 @@ class MyCustomPaginationFields
 
 Then add a config entry to map this class:
 
-```
+```php
 'custom_paginators' => [
     'post_pagination' => \Namespace\Of\The\MyCustomPaginationFields::class,
 ],
@@ -588,13 +598,14 @@ Read more about Enums [here](http://graphql.org/learn/schema/#enumeration-types)
 
 First create an Enum as an extension of the GraphQLType class:
 ```php
-// app/GraphQL/Enums/EpisodeEnum.php
+<?php
+
 namespace App\GraphQL\Enums;
 
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
-class EpisodeEnum extends GraphQLType {
-
+class EpisodeEnum extends GraphQLType
+{
     protected $enumObject = true;
 
     protected $attributes = [
@@ -606,14 +617,12 @@ class EpisodeEnum extends GraphQLType {
             'JEDI' => 'JEDI',
         ],
     ];
-    
 }
 
 ```
-Register the Enum in the 'types' array of the graphql.php config file:
+Register the Enum in the `types` array of the `graphql.php` config file:
 
 ```php
-// config/graphql.php
 'types' => [
     'EpisodeEnum' => EpisodeEnum::class
 ];
@@ -621,9 +630,14 @@ Register the Enum in the 'types' array of the graphql.php config file:
 
 Then use it like:
 ```php
-// app/GraphQL/Type/TestType.php
-class TestType extends GraphQLType {
+<?php
 
+namespace App\GraphQL\Type;
+
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class TestType extends GraphQLType
+{
    public function fields()
    {
         return [
@@ -632,7 +646,6 @@ class TestType extends GraphQLType {
             ]
         ]
    }
-   
 }
 ```
 
@@ -646,13 +659,16 @@ It's useful if you need to return unrelated types in the same Query. For example
 Example for defining a UnionType:
 
 ```php
-// app/GraphQL/Unions/SearchResultUnion.php
+<?php
+
 namespace App\GraphQL\Unions;
 
+use App\Post;
+use GraphQL;
 use Rebing\GraphQL\Support\UnionType;
 
-class SearchResultUnion extends UnionType {
-
+class SearchResultUnion extends UnionType
+{
     protected $attributes = [
         'name' => 'SearchResult',
     ];
@@ -660,23 +676,22 @@ class SearchResultUnion extends UnionType {
     public function types()
     {
         return [
-            \GraphQL::type('Post'),
-            \GraphQL::type('Episode'),
+            GraphQL::type('Post'),
+            GraphQL::type('Episode'),
         ];
     }
 
     public function resolveType($value)
     {
         if ($value instanceof Post) {
-            return \GraphQL::type('Post');
+            return GraphQL::type('Post');
         } elseif ($value instanceof Episode) {
-            return \GraphQL::type('Episode');
+            return GraphQL::type('Episode');
         }
     }
 }
 
 ```
-
 
 ### Interfaces
 
@@ -686,14 +701,15 @@ An implementation of an interface:
 
 ```php
 <?php
-// app/GraphQL/Interfaces/CharacterInterface.php
+
 namespace App\GraphQL\Interfaces;
 
 use GraphQL;
-use Rebing\GraphQL\Support\InterfaceType;
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\InterfaceType;
 
-class CharacterInterface extends InterfaceType {
+class CharacterInterface extends InterfaceType
+{
     protected $attributes = [
         'name' => 'Character',
         'description' => 'Character interface.',
@@ -720,7 +736,7 @@ class CharacterInterface extends InterfaceType {
         $type = $root['type'];
         if ($type === 'human') {
             return GraphQL::type('Human');
-        } else if  ($type === 'droid') {
+        } elseif  ($type === 'droid') {
             return GraphQL::type('Droid');
         }
     }
@@ -731,15 +747,15 @@ A Type that implements an interface:
 
 ```php
 <?php
-// app/GraphQL/Types/HumanType.php
+
 namespace App\GraphQL\Types;
 
 use GraphQL;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 use GraphQL\Type\Definition\Type;
 
-class HumanType extends GraphQLType {
-
+class HumanType extends GraphQLType
+{
     protected $attributes = [
         'name' => 'Human',
         'description' => 'A human.'
@@ -822,13 +838,15 @@ Read more about Input Object [here](https://graphql.org/learn/schema/#input-type
 
 First create an InputObjectType as an extension of the GraphQLType class:
 ```php
-// app/GraphQL/Enums/EpisodeEnum.php
+<?php
+
 namespace App\GraphQL\InputObject;
 
+use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
-class ReviewInput extends GraphQLType {
-
+class ReviewInput extends GraphQLType
+{
     protected $inputObject = true;
 
     protected $attributes = [
@@ -843,12 +861,12 @@ class ReviewInput extends GraphQLType {
                 'name' => 'comment',
                 'description' => 'A comment (250 max chars)',
                 'type' => Type::string(),
-		// You can define Laravel Validation here
+		        // You can define Laravel Validation here
                 'rules' => ['max:250']
             ],
             'score' => [
                 'name' => 'score',
-                'description' => 'A score (0 to 5)'
+                'description' => 'A score (0 to 5)',
                 'type' => Type::int(),
                 'rules' => ['min:0', 'max:5']
             ]
@@ -857,10 +875,9 @@ class ReviewInput extends GraphQLType {
 }
 
 ```
-Register the Input Object in the 'types' array of the graphql.php config file:
+Register the Input Object in the `types` array of the `graphql.php` config file:
 
 ```php
-// config/graphql.php
 'types' => [
     'ReviewInput' => ReviewInput::class
 ];
@@ -890,15 +907,16 @@ but rather a simple column with nested data. To get a nested object that's not a
 use the `non_relation_field` attribute in your Type:
 
 ```php
-class UserType extends GraphQLType {
+class UserType extends GraphQLType
+{
 
-    ...
-    
+    // ...
+
     public function fields()
     {
         return [
             
-            ...
+            // ...
             
             // JSON column containing all posts made by this user
             'posts' => [
@@ -911,6 +929,8 @@ class UserType extends GraphQLType {
             ]
         ];
     }
+
+    // ...
 
 }
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -618,8 +618,12 @@ class EpisodeEnum extends GraphQLType
         ],
     ];
 }
-
 ```
+
+> **Note:** within the `$attributes['values']` array the key is enum value the GraphQL client
+> will be able to choose from, while the value is what will your server receive (what will enum
+> be resolved to).
+
 Register the Enum in the `types` array of the `graphql.php` config file:
 
 ```php


### PR DESCRIPTION
Hopefully this pull request turned out not to be too long to review... I went through the docs line by line and tried to improve while paying the attention to the following:

- bringing internal consistency between examples in regard to how is `User` model namespaced, whether `::class` is used or not, their indendation level etc...
- changing code style to that used and promoted by Laravel (PSR-2)
- fixing formatting and minor errors (like invalid config file path) here and there

I also listed differiences between this and the original package (taken from #55), updated tables of contents for new aspects discussed within advanced docs and clarified on how enum type works internally (separate commit).

@rebing I'd be glad if you could find a time to review and eventually merge this changeset. I have a couple more small ideas on top of my head (like revamping package's generators provided in `make:graphql:*` and they would fit the best with more consistent docs promoting one particular style and convention.