### PR TITLE
Fix #161

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -133,6 +133,15 @@ return [
     // ]
     'error_formatter' => ['\Rebing\GraphQL\GraphQL', 'formatError'],
 
+    /**
+     * Custom Error Handling
+     *
+     * Expected handler signature is: function (array $errors, callable $formatter): array
+     *
+     * The default handler will pass exceptions to laravel Error Handling mechanism
+     */
+    'errors_handler' => ['\Rebing\GraphQL\GraphQL', 'handleErrors'],
+
     // You can set the key, which will be used to retrieve the dynamic variables
     'params_key'    => 'variables',
 

--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -96,15 +96,15 @@ class GraphQLQueryTest extends TestCase
     /**
      * Test query with error
      *
+     * If an error was encountered before execution begins, the data entry should not be present in the result.
+     *
      * @test
      */
     public function testQueryWithError()
     {
         $result = GraphQL::query($this->queries['examplesWithError']);
 
-        $this->assertArrayHasKey('data', $result);
         $this->assertArrayHasKey('errors', $result);
-        $this->assertNull($result['data']);
         $this->assertCount(1, $result['errors']);
         $this->assertArrayHasKey('message', $result['errors'][0]);
         $this->assertArrayHasKey('locations', $result['errors'][0]);

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -183,6 +183,7 @@ class GraphQLTest extends TestCase
         $this->assertArrayHasKey('locations', $error);
         $this->assertEquals($error, [
             'message' => 'Cannot query field "examplesQueryNotFound" on type "Query".',
+            'category' => 'graphql',
             'locations' => [
                 [
                     'line' => 3,


### PR DESCRIPTION
Actually this PR does two thing mentioned by #161 . One is using the default errorFormatter from graphql-php package with some customize (the `validation` field inside of `errors`).

Another is the error handling improvement, by set an error handler to catch errors then pass through laravel's error handling mechanism. Thus error could logged properly.
