### PR TITLE
[master] Comment undefined classes in config.php

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -100,10 +100,10 @@ return [
     'schemas' => [
         'default' => [
             'query' => [
-                'example_query' => ExampleQuery::class,
+                // 'example_query' => ExampleQuery::class,
             ],
             'mutation' => [
-                'example_mutation'  => ExampleMutation::class,
+                // 'example_mutation'  => ExampleMutation::class,
             ],
             'middleware' => [],
             'method' => ['get', 'post'],
@@ -120,8 +120,8 @@ return [
     // ]
     //
     'types' => [
-        'example'           => ExampleType::class,
-        'relation_example'  => ExampleRelationType::class,
+        // 'example'           => ExampleType::class,
+        // 'relation_example'  => ExampleRelationType::class,
     ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.


### PR DESCRIPTION
i think these undefined classes should be commented by default , so that undefined classes exception isn't thrown when following documentation example

![screenshot from 2019-01-27 20-07-23](https://user-images.githubusercontent.com/17250137/51805497-9ef74000-2276-11e9-93d4-5a9bd56e5d77.png)
