### PR TITLE
Fix PaginationType by passing $typeName properly to the method

### DIFF
--- a/src/Rebing/GraphQL/Support/PaginationType.php
+++ b/src/Rebing/GraphQL/Support/PaginationType.php
@@ -15,13 +15,13 @@ class PaginationType extends ObjectType {
 
         $config = [
             'name'  => $name,
-            'fields' => $this->getPaginationFields()
+            'fields' => $this->getPaginationFields($typeName)
         ];
 
         parent::__construct($config);
     }
 
-    protected function getPaginationFields()
+    protected function getPaginationFields($typeName)
     {
         return [
             'data' => [


### PR DESCRIPTION
The variable `$typeName` is referenced in `getPaginationFields` but not passed