### PR TITLE
Remove unused bootstrap.php

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This file was forgotten with the switch to Laravel 5.7/PHPunit 7 [1].
It was previously referenced in the phpunit.xml configuration file.

[1] https://github.com/rebing/graphql-laravel/pull/133