### PR TITLE
Fix for infinite recursion when InputTypeObject contains self reference fields

### DIFF
--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -135,6 +135,12 @@ class Field extends Fluent {
 
             // then recursively call the parent method to see if this is an
             // input object, passing in the new prefix
+            if($field->type instanceof InputObjectType) {
+                // in case the field is a self reference we must not do
+                // a recursive call as it will never stop
+                if($field->type->toString() == $input->toString())
+                    continue;
+            }
             $rules = array_merge($rules, $this->inferRulesFromType($field->type, $key, $resolutionArguments));
         }
 

--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -60,6 +60,31 @@ class GraphQLQueryTest extends TestCase
     }
 
     /**
+     * Test query with complex variables.
+     *
+     * @test
+     */
+    public function testQueryAndReturnResultWithFilterVariables()
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['examplesWithFilterVariables'], [
+            'filter' => [
+                'test' => 'Example 1'
+            ]
+        ]);
+
+        $this->assertObjectHasAttribute('data', $result);
+        // When XDebug is used with breaking on exceptions the real error will 
+        // be visible in case the recursion for getInputTypeRules runs away.
+        // GraphQL\Error\Error: Maximum function nesting level of '256' reached, aborting!
+        $this->assertCount(0, $result->errors);
+        $this->assertEquals($result->data, [
+            'examplesFiltered' => [
+                $this->data[0]
+            ]
+        ]);
+    }
+
+    /**
      * Test query with authorize
      *
      * @test

--- a/tests/Objects/ExampleFilterInputType.php
+++ b/tests/Objects/ExampleFilterInputType.php
@@ -1,0 +1,34 @@
+<?php
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class ExampleFilterInputType extends GraphQLType
+{
+    protected $inputObject = true;
+
+    protected $attributes = [
+        'name' => 'ExampleFilterInput',
+        'description' => 'A nested filter input with self reference'
+    ];
+
+    public function fields()
+    {
+        return [
+            'AND' => [
+                'type' => Type::listOf(Type::nonNull(GraphQL::type('ExampleFilterInput'))),
+                'description' => 'List of self references'
+            ],
+            'test' => [
+                'type' => Type::String(),
+                'description' => 'Test field filter'
+            ],
+            // This field can trigger an infinite recursion
+            // in case recursion in Field.getRules() is not handled correctly
+            'parent' => [
+                'type' => GraphQL::type('ExampleFilterInput'),
+                'description' => 'Self reference'
+            ]
+        ];
+    }
+}

--- a/tests/Objects/ExamplesFilteredQuery.php
+++ b/tests/Objects/ExamplesFilteredQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+
+class ExamplesFilteredQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Filtered examples'
+    ];
+
+    public function type()
+    {
+        return Type::listOf(GraphQL::type('Example'));
+    }
+
+    public function args()
+    {
+        return [
+            'filter' => [
+                'name' => 'filter', 
+                'type' => GraphQL::type('ExampleFilterInput')
+            ]
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $data = include(__DIR__.'/data.php');
+        $result = [];
+
+        if (isset($args['filter'])) {
+            if(isset($args['filter']['test'])) {
+                foreach($data as $item) {
+                    if($item['test'] == $args['filter']['test']) {
+                        $result[] = $item;
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Objects/ExamplesQuery.php
+++ b/tests/Objects/ExamplesQuery.php
@@ -17,7 +17,7 @@ class ExamplesQuery extends Query
     public function args()
     {
         return [
-            'index' => ['name' => 'index', 'type' => Type::int()]
+            'index' => ['name' => 'index', 'type' => Type::int()],
         ];
     }
 

--- a/tests/Objects/queries.php
+++ b/tests/Objects/queries.php
@@ -27,6 +27,14 @@ return [
         }
     ",
 
+    'examplesWithFilterVariables' => "
+        query QueryExamplesWithFilterVariables(\$filter: ExampleFilterInput) {
+            examplesFiltered(filter: \$filter) {
+                test
+            }
+        }
+    ",
+
     'shorthandExamplesWithVariables' =>  "
         query QueryShorthandExamplesVariables(\$message: String!) {
             echo(message: \$message)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,7 @@ class TestCase extends BaseTestCase
                 'examples' => ExamplesQuery::class,
                 'examplesAuthorize' => ExamplesAuthorizeQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
+                'examplesFiltered' => ExamplesFilteredQuery::class,
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class
@@ -41,7 +42,8 @@ class TestCase extends BaseTestCase
         ]);
 
         $app['config']->set('graphql.types', [
-            'Example' => ExampleType::class
+            'Example' => ExampleType::class,
+            'ExampleFilterInput' => ExampleFilterInputType::class,
         ]);
 
         $app['config']->set('app.debug', true);


### PR DESCRIPTION
A simple Input object with a self reference field causes the graphql library to end up in an uncontrolled recursive loop between `Field->inferRulesFromType` and `Field->getInputTypeRules` trying to generate the field rules.

```
...
class RepositoryFilterInput extends GraphQLType
{
    protected $inputObject = true;
    
    protected $attributes = [
        'name' => 'RepositoryFilter',
        'description' => 'A type RepositoryFilter',
    ];

    public function fields()
    {
        return [

            'parent' => [
                'type' => GraphQL::type('RepositoryFilter'),
                'description' => 'The parent of RepositoryFilter'
            ],
       ]
   }
...

```
An uncontrolled recursive call is extremely dangerous as it will bring down the php interpreter (and possibly more, depending on how much RAM and CPUs you have).

The proposed fix is to simply skip the recursive call for self referenced fields. I've tested it with my full implementation of filters and it works even with nested ones for parent without any issues.
