### PR TITLE
Use getter to retrieve types

### DIFF
--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -55,7 +55,7 @@ class GraphQL {
                 $types[] = $objectType;
             }
         } else {
-            foreach ($this->types as $name => $type) {
+            foreach ($this->getTypes() as $name => $type) {
                 $types[] = $this->type($name);
             }
         }

--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -32,7 +32,8 @@ class GraphQL {
         }
 
         $this->typesInstances = [];
-        foreach($this->types as $name => $type)
+
+        foreach($this->getTypes() as $name => $type)
         {
             $this->type($name);
         }


### PR DESCRIPTION
I want to override the `getTypes()` function to filter some of the types in retrospection queries for my own project.

Currently overwriting the `->getTypes()` function does nothing, because it is not used.