### PR TITLE
Replace array/str global helpers with class

### DIFF
--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -2,6 +2,7 @@
 
 use GraphQL\Error\Debug;
 use GraphQL\Error\Error;
+use Illuminate\Support\Arr;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
 use GraphQL\GraphQL as GraphQLBase;
@@ -40,10 +41,10 @@ class GraphQL {
 
         $schema = $this->getSchemaConfiguration($schema);
 
-        $schemaQuery = array_get($schema, 'query', []);
-        $schemaMutation = array_get($schema, 'mutation', []);
-        $schemaSubscription = array_get($schema, 'subscription', []);
-        $schemaTypes = array_get($schema, 'types', []);
+        $schemaQuery = Arr::get($schema, 'query', []);
+        $schemaMutation = Arr::get($schema, 'mutation', []);
+        $schemaSubscription = Arr::get($schema, 'subscription', []);
+        $schemaTypes = Arr::get($schema, 'types', []);
 
         //Get the types either from the schema, or the global types.
         $types = [];
@@ -94,9 +95,9 @@ class GraphQL {
 
     public function queryAndReturnResult($query, $params = [], $opts = [])
     {
-        $context = array_get($opts, 'context');
-        $schemaName = array_get($opts, 'schema');
-        $operationName = array_get($opts, 'operationName');
+        $context = Arr::get($opts, 'context');
+        $schemaName = Arr::get($opts, 'schema');
+        $operationName = Arr::get($opts, 'operationName');
 
         $schema = $this->schema($schemaName);
 

--- a/src/Rebing/GraphQL/GraphQLController.php
+++ b/src/Rebing/GraphQL/GraphQLController.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Arr;
 
 class GraphQLController extends Controller {
 
@@ -41,7 +42,7 @@ class GraphQLController extends Controller {
         foreach($batch as $batchItem)
         {
             $query = $batchItem['query'];
-            $params = array_get($batchItem, $paramsKey);
+            $params = Arr::get($batchItem, $paramsKey);
 
             if(is_string($params))
             {
@@ -49,7 +50,7 @@ class GraphQLController extends Controller {
             }
 
             $completedQueries[] = app('graphql')->query($query, $params, array_merge($opts, [
-                'operationName' => array_get($batchItem, 'operationName'),
+                'operationName' => Arr::get($batchItem, 'operationName'),
             ]));
         }
 

--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -2,6 +2,7 @@
 
 namespace Rebing\GraphQL\Support;
 
+use Illuminate\Support\Arr;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Validator;
 use Illuminate\Support\Fluent;
@@ -74,7 +75,7 @@ class Field extends Fluent {
             }
 
             if (isset($arg['type'])
-                && ($arg['type'] instanceof NonNull || isset(array_get($arguments, 0, [])[$name]))) {
+                && ($arg['type'] instanceof NonNull || isset(Arr::get($arguments, 0, [])[$name]))) {
                 $argsRules = array_merge($argsRules, $this->inferRulesFromType($arg['type'], $name, $arguments));
             }
         }
@@ -175,7 +176,7 @@ class Field extends Fluent {
             // Validate mutation arguments
             if(method_exists($this, 'getRules'))
             {
-                $args = array_get($arguments, 1, []);
+                $args = Arr::get($arguments, 1, []);
                 $rules = call_user_func_array([$this, 'getRules'], [$args]);
                 if(sizeof($rules))
                 {

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Arr;
 
 class SelectFields {
 
@@ -142,7 +143,7 @@ class SelectFields {
             if($canSelect === true)
             {
                 // Add a query, if it exists
-                $customQuery = array_get($fieldObject->config, 'query');
+                $customQuery = Arr::get($fieldObject->config, 'query');
 
                 // Check if the field is a relation that needs to be requested from the DB
                 $queryable = self::isQueryable($fieldObject->config);
@@ -313,7 +314,7 @@ class SelectFields {
      * @return bool
      */
     private static function isQueryable($fieldObject) {
-        return array_get($fieldObject, 'is_relation', true) === true;
+        return Arr::get($fieldObject, 'is_relation', true) === true;
     }
 
     /**

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -287,7 +287,7 @@ class SelectFields {
             // If Privacy class given
             elseif(is_string($privacyClass))
             {
-                if(array_has(self::$privacyValidations, $privacyClass))
+                if(Arr::has(self::$privacyValidations, $privacyClass))
                 {
                     $validated = self::$privacyValidations[$privacyClass];
                 }

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 
 class Type extends Fluent {
     
@@ -38,7 +39,7 @@ class Type extends Fluent {
             return $field['resolve'];
         }
 
-        $resolveMethod = 'resolve'.studly_case($name).'Field';
+        $resolveMethod = 'resolve'.Str::studly($name).'Field';
 
         if(method_exists($this, $resolveMethod))
         {

--- a/src/Rebing/GraphQL/routes.php
+++ b/src/Rebing/GraphQL/routes.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Arr;
+
 $router = app('router');
 
 $router->group(array_merge([
@@ -13,8 +15,8 @@ $router->group(array_merge([
     $mutationRoute = null;
     if(is_array($routes))
     {
-        $queryRoute = array_get($routes, 'query');
-        $mutationRoute = array_get($routes, 'mutation');
+        $queryRoute = Arr::get($routes, 'query');
+        $mutationRoute = Arr::get($routes, 'mutation');
     }
     else
     {
@@ -28,8 +30,8 @@ $router->group(array_merge([
     $mutationController = null;
     if(is_array($controllers))
     {
-        $queryController = array_get($controllers, 'query');
-        $mutationController = array_get($controllers, 'mutation');
+        $queryController = Arr::get($controllers, 'query');
+        $mutationController = Arr::get($controllers, 'mutation');
     }
     else
     {
@@ -59,12 +61,12 @@ $router->group(array_merge([
 
             foreach(config('graphql.schemas') as $name => $schema)
             {
-                foreach (array_get($schema, 'method', ['get', 'post']) as $method) {
+                foreach (Arr::get($schema, 'method', ['get', 'post']) as $method) {
                     $route = $router->{$method}(
                         Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, $queryRoute),
                         [
                             'uses'          => $queryController,
-                            'middleware'    => array_get($schema, 'middleware', []),
+                            'middleware'    => Arr::get($schema, 'middleware', []),
                         ]
                     );
 
@@ -101,12 +103,12 @@ $router->group(array_merge([
 
             foreach(config('graphql.schemas') as $name => $schema)
             {
-                foreach (array_get($schema, 'method', ['get', 'post']) as $method) {
+                foreach (Arr::get($schema, 'method', ['get', 'post']) as $method) {
                     $route = $router->{$method}(
                         Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, $mutationRoute),
                         [
                             'uses'          => $mutationController,
-                            'middleware'    => array_get($schema, 'middleware', []),
+                            'middleware'    => Arr::get($schema, 'middleware', []),
                         ]
                     );
 

--- a/src/example/Mutation/LoginMutation.php
+++ b/src/example/Mutation/LoginMutation.php
@@ -1,6 +1,7 @@
 <?php
 
 use GraphQL\GraphQL;
+use Illuminate\Support\Arr;
 use Rebing\GraphQL\Support\Mutation;
 use GraphQL\Type\Definition\Type;
 use Rebing\Services\Auth\UserLoginService; // not included in this project
@@ -41,7 +42,7 @@ class LoginMutation extends Mutation {
     public function resolve($root, $args)
     {
         $loginService = new UserLoginService();
-        $user = $loginService->doLogin($args['email'], $args['password'], array_get($args, 'remember_me'));
+        $user = $loginService->doLogin($args['email'], $args['password'], Arr::get($args, 'remember_me'));
 
         return $user;
     }

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Illuminate\Validation\Validator;
 
 class MutationTest extends FieldTest
@@ -39,17 +40,17 @@ class MutationTest extends FieldTest
         $this->assertEquals($rules['test_with_rules'], ['required']);
         $this->assertEquals($rules['test_with_rules_closure'], ['required']);
         $this->assertEquals($rules['test_with_rules_nullable_input_object'], ['nullable']);
-        $this->assertNull(array_get($rules, 'test_with_rules_nullable_input_object.val'));
-        $this->assertNull(array_get($rules, 'test_with_rules_nullable_input_object.nest'));
-        $this->assertNull(array_get($rules, 'test_with_rules_nullable_input_object.nest.email'));
-        $this->assertNull(array_get($rules, 'test_with_rules_nullable_input_object.list'));
-        $this->assertNull(array_get($rules, 'test_with_rules_nullable_input_object.list.*.email'));
+        $this->assertNull(Arr::get($rules, 'test_with_rules_nullable_input_object.val'));
+        $this->assertNull(Arr::get($rules, 'test_with_rules_nullable_input_object.nest'));
+        $this->assertNull(Arr::get($rules, 'test_with_rules_nullable_input_object.nest.email'));
+        $this->assertNull(Arr::get($rules, 'test_with_rules_nullable_input_object.list'));
+        $this->assertNull(Arr::get($rules, 'test_with_rules_nullable_input_object.list.*.email'));
         $this->assertEquals($rules['test_with_rules_non_nullable_input_object'], ['required']);
-        $this->assertEquals(array_get($rules, 'test_with_rules_non_nullable_input_object.val'), ['required']);
-        $this->assertEquals(array_get($rules, 'test_with_rules_non_nullable_input_object.nest'), ['required']);
-        $this->assertEquals(array_get($rules, 'test_with_rules_non_nullable_input_object.nest.email'), ['email']);
-        $this->assertEquals(array_get($rules, 'test_with_rules_non_nullable_input_object.list'), ['required']);
-        $this->assertEquals(array_get($rules, 'test_with_rules_non_nullable_input_object.list.*.email'), ['email']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.val'), ['required']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.nest'), ['required']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.nest.email'), ['email']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.list'), ['required']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.list.*.email'), ['email']);
     }
 
     /**

--- a/tests/Objects/UpdateExampleMutation.php
+++ b/tests/Objects/UpdateExampleMutation.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Mutation;
 use GraphQL\Type\Definition\Type;
@@ -50,7 +51,7 @@ class UpdateExampleMutation extends Mutation
     public function resolve($root, $args)
     {
         return [
-            'test' => array_get($args, 'test')
+            'test' => Arr::get($args, 'test')
         ];
     }
 }

--- a/tests/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Objects/UpdateExampleMutationWithInputType.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Mutation;
 use GraphQL\Type\Definition\Type;
@@ -61,7 +62,7 @@ class UpdateExampleMutationWithInputType extends Mutation
     public function resolve($root, $args)
     {
         return [
-            'test' => array_get($args, 'test'),
+            'test' => Arr::get($args, 'test'),
         ];
     }
 }


### PR DESCRIPTION
Some of the global helpers, including `array_*` and `str_*` are being deprecated in the future of Laravel.

They will always be available via a third party package for _Applications_, but libraries should not depend upon them.

See https://github.com/laravel/framework/pull/27504 and https://github.com/illuminate/support/commit/a41d7e12b39edea740d70a5591d3239284b6d16e#diff-37103b40d038920dbb5e8b957d21a0c8