### PR TITLE
Remove duplicate use statement 🚨

### DIFF
--- a/src/Rebing/GraphQL/GraphQLServiceProvider.php
+++ b/src/Rebing/GraphQL/GraphQLServiceProvider.php
@@ -6,7 +6,6 @@ use GraphQL\Validator\Rules\QueryDepth;
 use Illuminate\Support\ServiceProvider;
 use GraphQL\Validator\DocumentValidator;
 use Rebing\GraphQL\Console\TypeMakeCommand;
-use Rebing\GraphQL\Console\TypeMakeCommand;
 use GraphQL\Validator\Rules\QueryComplexity;
 use Rebing\GraphQL\Console\QueryMakeCommand;
 use Rebing\GraphQL\Console\MutationMakeCommand;


### PR DESCRIPTION
This is a critical source fix, otherwise nothing will work correctly:
```
php composer.phar update rebing/graphql-laravel --with-dependencies
Dependency "laravel/framework" is also a root requirement, but is not explicitly whitelisted. Ignoring.
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating rebing/graphql-laravel (v1.20.2 => v1.21.0): Downloading (100%)
Writing lock file
Generating autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi
PHP Fatal error:  Cannot use Rebing\GraphQL\Console\TypeMakeCommand as TypeMakeCommand because the name is already in use in /vendor/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLServiceProvider.php on line 9

In GraphQLServiceProvider.php line 9:

  Cannot use Rebing\GraphQL\Console\TypeMakeCommand as TypeMakeCommand becaus
  e the name is already in use


Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 255
```

TBH not sure how this exactly happened. Although StyleCI did re-order them, I don't see how it would potentially duplicate the line.

Maybe there was a merge conflict incorrectly resolved? 🤷‍♀️

Effectively, the [v1.21.0 release](https://github.com/rebing/graphql-laravel/releases/tag/v1.21.0) is broken.