### PR TITLE
[BREAKING CHANGE 🚨] Append SelectFields support class instead of overriding the context, make it deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/v1.23.0...master)
 ------------
 ## Breaking changes
-- The order and arguments for resolvers has changed:
-  - before: `resolve($root, $array, SelectFields $fields, ResolveInfo $info)`
-  - after: `resolve($root, $array, $context, ResolveInfo $info, SelectFields $fields)`
+- The order and arguments/types for resolvers has changed:
+  - before: `resolve($root, $array, SelectFields $selectFields, ResolveInfo $info)`
+  - after: `resolve($root, $array, $context, ResolveInfo $info, Closure $getSelectFields)`
 - Added PHP types / phpdoc to all methods / properties [\#331](https://github.com/rebing/graphql-laravel/pull/331)
   - Changes in method signatures will require small adaptions.
 - Validation errors are moved from error.validation to error.extensions.validation as per GraphQL spec recommendation [\#294](https://github.com/rebing/graphql-laravel/pull/294)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/v1.23.0...master)
 ------------
 ## Breaking changes
+- The order and arguments for resolvers has changed:
+  - before: `resolve($root, $array, SelectFields $fields, ResolveInfo $info)`
+  - after: `resolve($root, $array, $context, ResolveInfo $info, SelectFields $fields)`
 - Added PHP types / phpdoc to all methods / properties [\#331](https://github.com/rebing/graphql-laravel/pull/331)
   - Changes in method signatures will require small adaptions.
 - Validation errors are moved from error.validation to error.extensions.validation as per GraphQL spec recommendation [\#294](https://github.com/rebing/graphql-laravel/pull/294)

--- a/Readme.md
+++ b/Readme.md
@@ -797,8 +797,8 @@ return [
 
 ### Eager loading relationships
 
-The third argument passed to a query's resolve method is an instance of
-`Rebing\GraphQL\Support\SelectFields` which you can use to retrieve keys
+The fifth argument passed to a query's resolve method is a Closure which returns
+an instance of `Rebing\GraphQL\Support\SelectFields` which you can use to retrieve keys
 from the request. The following is an example of using this information
 to eager load related Eloquent models.
 
@@ -837,10 +837,11 @@ return [
 ];
 }
 
-public function resolve($root, $args, SelectFields $fields, ResolveInfo $info)
+public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
 {
 // $info->getFieldSelection($depth = 3);
 
+$fields = $getSelectFields();
 $select = $fields->getSelect();
 $with = $fields->getRelations();
 
@@ -999,8 +1000,9 @@ return GraphQL::paginate('posts');
 
 // ...
 
-public function resolve($root, $args, SelectFields $fields)
+public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
 {
+$fields = $getSelectFields();
 return Post::with($fields->getRelations())->select($fields->getSelect())
 ->paginate($args['limit'], ['*'], 'page', $args['page']);
 }

--- a/Readme.md
+++ b/Readme.md
@@ -252,7 +252,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         if (isset($args['id'])) {
             return User::where('id' , $args['id'])->get();
@@ -333,7 +333,7 @@ class UpdateUserPasswordMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $user = User::find($args['id']);
         if(!$user) {
@@ -424,7 +424,7 @@ class UpdateUserEmailMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $user = User::find($args['id']);
         if (!$user) {
@@ -557,7 +557,7 @@ class UserProfilePhotoMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $file = $args['profilePicture'];
 

--- a/Readme.md
+++ b/Readme.md
@@ -161,7 +161,9 @@ First you need to create a type. The Eloquent Model is only required, if specify
 namespace App\GraphQL\Type;
 
 use App\User;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
 class UserType extends GraphQLType
@@ -226,8 +228,10 @@ namespace App\GraphQL\Query;
 
 use App\User;
 use Rebing\GraphQL\Support\Facades\GraphQL;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
 
 class UsersQuery extends Query
 {
@@ -248,7 +252,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         if (isset($args['id'])) {
             return User::where('id' , $args['id'])->get();
@@ -306,7 +310,9 @@ namespace App\GraphQL\Mutation;
 use App\User;
 use GraphQL;
 use GraphQL\Type\Definition\Type;
-use Rebing\GraphQL\Support\Mutation;    
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Support\Mutation;
 
 class UpdateUserPasswordMutation extends Mutation
 {
@@ -327,7 +333,7 @@ class UpdateUserPasswordMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         $user = User::find($args['id']);
         if(!$user) {
@@ -386,7 +392,9 @@ namespace App\GraphQL\Mutation;
 
 use App\User;
 use GraphQL;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Mutation;
 
 class UpdateUserEmailMutation extends Mutation
@@ -416,7 +424,7 @@ class UpdateUserEmailMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         $user = User::find($args['id']);
         if (!$user) {
@@ -521,9 +529,11 @@ so you have to upload them as multipart form:
 <?php
 
 use GraphQL;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\UploadType;
 use Rebing\GraphQL\Support\Mutation;
+use Rebing\GraphQL\Support\SelectFields;
 
 class UserProfilePhotoMutation extends Mutation
 {
@@ -547,7 +557,7 @@ class UserProfilePhotoMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         $file = $args['profilePicture'];
 

--- a/example/Query/UserQuery.php
+++ b/example/Query/UserQuery.php
@@ -6,6 +6,7 @@ use Models\User;
 use GraphQL\GraphQL;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields; // not included in this project
 
 class UserQuery extends Query
@@ -31,7 +32,7 @@ class UserQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $fields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
     {
         $select = $fields->getSelect();
         $with = $fields->getRelations();

--- a/example/Query/UsersQuery.php
+++ b/example/Query/UsersQuery.php
@@ -8,6 +8,7 @@ use Models\User;
 use GraphQL\GraphQL;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields; // not included in this project
 
 class UsersQuery extends Query
@@ -31,7 +32,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $fields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
     {
         $select = $fields->getSelect();
         $with = $fields->getRelations();

--- a/src/Console/stubs/mutation.stub
+++ b/src/Console/stubs/mutation.stub
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DummyNamespace;
 
+use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;

--- a/src/Console/stubs/mutation.stub
+++ b/src/Console/stubs/mutation.stub
@@ -28,8 +28,9 @@ class DummyClass extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
+        $fields = $getSelectFields();
         $select = $fields->getSelect();
         $with = $fields->getRelations();
 

--- a/src/Console/stubs/mutation.stub
+++ b/src/Console/stubs/mutation.stub
@@ -28,7 +28,7 @@ class DummyClass extends Mutation
         ];
     }
 
-    public function resolve($root, $args, SelectFields $fields, ResolveInfo $info)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
     {
         $select = $fields->getSelect();
         $with = $fields->getRelations();

--- a/src/Console/stubs/query.stub
+++ b/src/Console/stubs/query.stub
@@ -28,7 +28,7 @@ class DummyClass extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $fields, ResolveInfo $info)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
     {
         $select = $fields->getSelect();
         $with = $fields->getRelations();

--- a/src/Console/stubs/query.stub
+++ b/src/Console/stubs/query.stub
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DummyNamespace;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;

--- a/src/Console/stubs/query.stub
+++ b/src/Console/stubs/query.stub
@@ -28,8 +28,9 @@ class DummyClass extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $fields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
+        $fields = $getSelectFields();
         $select = $fields->getSelect();
         $with = $fields->getRelations();
 

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -192,13 +192,9 @@ abstract class Field extends Fluent
                 }
             }
 
-            // Replace the context argument with 'selects and relations'
-            // $arguments[1] is direct args given with the query
-            // $arguments[2] is context (params given with the query)
-            // $arguments[3] is ResolveInfo
+            // Add the 'selects and relations' feature as 5th arg
             if (isset($arguments[3])) {
-                $fields = new SelectFields($arguments[3], $this->type(), $arguments[1]);
-                $arguments[2] = $fields;
+                $arguments[] = new SelectFields($arguments[3], $this->type(), $arguments[1]);
             }
 
             return call_user_func_array($resolver, $arguments);

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -194,7 +194,9 @@ abstract class Field extends Fluent
 
             // Add the 'selects and relations' feature as 5th arg
             if (isset($arguments[3])) {
-                $arguments[] = new SelectFields($arguments[3], $this->type(), $arguments[1]);
+                $arguments[] = function () use ($arguments): SelectFields {
+                    return new SelectFields($arguments[3], $this->type(), $arguments[1]);
+                };
             }
 
             return call_user_func_array($resolver, $arguments);

--- a/tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+++ b/tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Database\SelectFields\InterfaceTests;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -22,10 +22,10 @@ class ExampleInterfaceQuery extends Query
         return Type::listOf(GraphQL::type('ExampleInterface'));
     }
 
-    public function resolve($root, $args, $contxt, ResolveInfo $info, SelectFields $selectFields)
+    public function resolve($root, $args, $contxt, ResolveInfo $info, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->get();
     }
 }

--- a/tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+++ b/tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Database\SelectFields\InterfaceTests;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -21,7 +22,7 @@ class ExampleInterfaceQuery extends Query
         return Type::listOf(GraphQL::type('ExampleInterface'));
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $contxt, ResolveInfo $info, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\User;
@@ -33,9 +35,12 @@ class UsersQuery extends Query
         return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('User'))));
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $users = User::query();
+
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields();
 
         if (isset($args['select']) && $args['select']) {
             $users->select($selectFields->getSelect());

--- a/tests/Support/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Support/Objects/ExamplesAuthorizeQuery.php
@@ -6,6 +6,8 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesAuthorizeQuery extends Query
@@ -31,7 +33,7 @@ class ExamplesAuthorizeQuery extends Query
         ];
     }
 
-    public function resolve($root, $args)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         $data = include __DIR__.'/data.php';
 

--- a/tests/Support/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Support/Objects/ExamplesAuthorizeQuery.php
@@ -7,7 +7,6 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesAuthorizeQuery extends Query
@@ -33,7 +32,7 @@ class ExamplesAuthorizeQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $data = include __DIR__.'/data.php';
 

--- a/tests/Support/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Support/Objects/ExamplesAuthorizeQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;

--- a/tests/Support/Objects/ExamplesFilteredQuery.php
+++ b/tests/Support/Objects/ExamplesFilteredQuery.php
@@ -6,6 +6,8 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesFilteredQuery extends Query
@@ -29,7 +31,7 @@ class ExamplesFilteredQuery extends Query
         ];
     }
 
-    public function resolve($root, $args): array
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): array
     {
         $data = include __DIR__.'/data.php';
         $result = [];

--- a/tests/Support/Objects/ExamplesFilteredQuery.php
+++ b/tests/Support/Objects/ExamplesFilteredQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesFilteredQuery extends Query
@@ -31,7 +31,7 @@ class ExamplesFilteredQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): array
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
     {
         $data = include __DIR__.'/data.php';
         $result = [];

--- a/tests/Support/Objects/ExamplesPaginationQuery.php
+++ b/tests/Support/Objects/ExamplesPaginationQuery.php
@@ -6,6 +6,8 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Illuminate\Pagination\LengthAwarePaginator;
 
@@ -32,7 +34,7 @@ class ExamplesPaginationQuery extends Query
         ];
     }
 
-    public function resolve($root, $args): LengthAwarePaginator
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): LengthAwarePaginator
     {
         $data = include __DIR__.'/data.php';
 

--- a/tests/Support/Objects/ExamplesPaginationQuery.php
+++ b/tests/Support/Objects/ExamplesPaginationQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;

--- a/tests/Support/Objects/ExamplesPaginationQuery.php
+++ b/tests/Support/Objects/ExamplesPaginationQuery.php
@@ -7,7 +7,6 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Illuminate\Pagination\LengthAwarePaginator;
 
@@ -34,7 +33,7 @@ class ExamplesPaginationQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): LengthAwarePaginator
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): LengthAwarePaginator
     {
         $data = include __DIR__.'/data.php';
 

--- a/tests/Support/Objects/UpdateExampleMutation.php
+++ b/tests/Support/Objects/UpdateExampleMutation.php
@@ -7,6 +7,8 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class UpdateExampleMutation extends Mutation
@@ -51,7 +53,7 @@ class UpdateExampleMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args): array
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): array
     {
         return [
             'test' => Arr::get($args, 'test'),

--- a/tests/Support/Objects/UpdateExampleMutation.php
+++ b/tests/Support/Objects/UpdateExampleMutation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
+use Closure;
 use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;

--- a/tests/Support/Objects/UpdateExampleMutation.php
+++ b/tests/Support/Objects/UpdateExampleMutation.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class UpdateExampleMutation extends Mutation
@@ -53,7 +52,7 @@ class UpdateExampleMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields): array
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
     {
         return [
             'test' => Arr::get($args, 'test'),

--- a/tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -30,7 +31,7 @@ class PostNonNullWithSelectFieldsAndModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -31,10 +31,10 @@ class PostNonNullWithSelectFieldsAndModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->findOrFail($args['id']);
     }
 }

--- a/tests/Support/Queries/PostQuery.php
+++ b/tests/Support/Queries/PostQuery.php
@@ -6,7 +6,6 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -30,7 +29,7 @@ class PostQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args)
     {
         return Post::findOrFail($args['id']);
     }

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -31,10 +31,10 @@ class PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->findOrFail($args['id']);
     }
 }

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -30,7 +31,7 @@ class PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -31,10 +31,10 @@ class PostWithSelectFieldsAndModelAndAliasQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->findOrFail($args['id']);
     }
 }

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -30,7 +31,7 @@ class PostWithSelectFieldsAndModelAndAliasQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -30,7 +31,7 @@ class PostWithSelectFieldsAndModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -31,10 +31,10 @@ class PostWithSelectFieldsAndModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->findOrFail($args['id']);
     }
 }

--- a/tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -31,10 +31,10 @@ class PostWithSelectFieldsNoModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->findOrFail($args['id']);
     }
 }

--- a/tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+++ b/tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -30,7 +31,7 @@ class PostWithSelectFieldsNoModelQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -21,7 +22,7 @@ class PostsListOfWithSelectFieldsAndModelQuery extends Query
         return Type::listOf(GraphQL::type('PostWithModel'));
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -22,10 +22,10 @@ class PostsListOfWithSelectFieldsAndModelQuery extends Query
         return Type::listOf(GraphQL::type('PostWithModel'));
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->get();
     }
 }

--- a/tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -22,10 +22,10 @@ class PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery extends Query
         return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('PostWithModel'))));
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->get();
     }
 }

--- a/tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -21,7 +22,7 @@ class PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery extends Query
         return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('PostWithModel'))));
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())

--- a/tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Queries;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
 use GraphQL\Type\Definition\ResolveInfo;
-use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
@@ -22,10 +22,10 @@ class PostsNonNullAndListOfWithSelectFieldsAndModelQuery extends Query
         return Type::nonNull(Type::listOf(GraphQL::type('PostWithModel')));
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         return Post
-            ::select($selectFields->getSelect())
+            ::select($getSelectFields()->getSelect())
             ->get();
     }
 }

--- a/tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+++ b/tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Support\Queries;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\SelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Models\Post;
@@ -21,7 +22,7 @@ class PostsNonNullAndListOfWithSelectFieldsAndModelQuery extends Query
         return Type::nonNull(Type::listOf(GraphQL::type('PostWithModel')));
     }
 
-    public function resolve($root, $args, SelectFields $selectFields)
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, SelectFields $selectFields)
     {
         return Post
             ::select($selectFields->getSelect())


### PR DESCRIPTION
# This is a hard breaking change
This PR is to start a discussion / viability / willingness for this change.

### Background
Most GraphQL server implementations follow the following pattern when calling query/mutation resolvers: root, args, context, info

This library opted to overwrite context with the useful "SelectFields" class.

However, overwriting means the context isn't available anymore at all. Which is quite a surprise as there are useful application making use of the context.

Whilst not the most useful thing, the default context for example is the authenticated user, if any is present. This is even implemented by this library in `\Rebing\GraphQL\GraphQLController::queryContext`:
```php
    protected function queryContext()
    {
        try {
            return app('auth')->user();
        } catch (\Exception $e) {
            return;
        }
    }
```
Given the design of the library, `queryContext` can be overridden by specifying a custom `GraphQLController` in the configuration. However this is moot as the context is never passed to any query/mutation.

Other library examples:
- Apollo graphql-tools https://www.apollographql.com/docs/graphql-tools/resolvers
  > `author(obj, args, context, info) {`
- The definition in the underlying webonxy PHP library http://webonyx.github.io/graphql-php/executing-queries/
  > Any value that holds information shared between all field resolvers. Most often they use it to pass currently logged in user, locale details, etc.
  >
  > It will be available as the 3rd argument in all field resolvers. (see section on Field Definitions for reference) graphql-php never modifies this value and passes it as is to all underlying resolvers.

## Further change
Besides re-ordering the arguments I've also changed `SelectFields $selectFields` to a `Closure $getSelectField`.

The reason is that the use of `SelectFields` is entirely optional, yet as now to provide this parameter, it has to traverse the GraphQL AST to extract the necessary information.

In cases where this is not used, it's waste of resources.

That's why the Closure was added which lazy creates SelectFields only when requested.

## Impact
### Migration
Every query/mutation typing more than the first two arguments to `resolve` needs to adapt them (types are **not** affected):
```php
public function resolve($root, $args, SelectFields $fields, ResolveInfo $resolveInfo)
```
to
```php
public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields) {
  $selectFields = $getSelectFields();
}
```
### Compatibility
This change is inherently not backwards compatible. Although unclear if this library follows [SemVer](https://semver.org/), such a change should lead to a new major version bump (i.e. `v2.*` as it currently stands).

### TODO
- [x] There's currently no test making actual use of the `SelectFields` utility => one should be added
  => Fixed after https://github.com/rebing/graphql-laravel/pull/289 landed which added some
- [ ] ~Add dedicated entry to the Readme to inform users~
  Decided against it, the `CHANGELOG.md` will have the details
- [x] If https://github.com/rebing/graphql-laravel/pull/273 gets merged, also add a clear entry about it

### Links
- Fixes https://github.com/rebing/graphql-laravel/issues/258