### PR TITLE
[BREAKING CHANGES] A Type always has it's Interface fields

### DIFF
--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -213,7 +213,7 @@ class SelectFields
             }
         }
 
-        // If parent type is an or union we select all fields
+        // If parent type is an union we select all fields
         // because we don't know which other fields are required
         if (is_a($parentType, UnionType::class)) {
             $select = ['*'];

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -8,7 +8,6 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Type\Definition\InterfaceType;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -214,9 +213,8 @@ class SelectFields
             }
         }
 
-        // If parent type is an interface or union we select all fields
+        // If parent type is an or union we select all fields
         // because we don't know which other fields are required
-        // from types which implement this interface
         if (is_a($parentType, UnionType::class)) {
             $select = ['*'];
         }

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -217,7 +217,7 @@ class SelectFields
         // If parent type is an interface or union we select all fields
         // because we don't know which other fields are required
         // from types which implement this interface
-        if (is_a($parentType, InterfaceType::class) || is_a($parentType, UnionType::class)) {
+        if (is_a($parentType, UnionType::class)) {
             $select = ['*'];
         }
     }


### PR DESCRIPTION
### Background

Query's type defined as an interface leads to a problem: the `SelectFields::getSelect` returns: `['*']`.

The code responsible of this is stating the following:

```php
/* SelectFields.php > handleFields */

// If parent type is an interface or union we select all fields
// because we don't know which other fields are required
// from types which implement this interface
```

The reason why this code was implemented seems to be a specific case. If other fields are required, they probably should be added to the current selected fields by the developer in it's `Query` component.

GraphQL.org is stating that
> Like many type systems, GraphQL supports interfaces. An Interface is an abstract type that includes a certain set of fields that a type must include to implement the interface.
[https://graphql.org/learn/schema/#interfaces](https://graphql.org/learn/schema/#interfaces)

Since we know what fields are required, we can safely select the fields of the `Interface`.

This behavior leads to "1.5" issues:
* The `alias` is not used to retrieve fields, so it can lead to unexpected issues.
* When using `group by`, MySQL with `sql_mode=ONLY_FULL_GROUP_BY` will throw an error since all fields aren't in the group by. (Since it is related to a specific configuration of a specific database system, this can be ignored)

### Impact

The `Interface`s will need to explicitly define their available fields, or be selected by the developer in their `Query` component.

### Compatibility

This change will only impact the `Queries` that requires more fields than the actual `Interface` provides. Since it's a "rollback", it's not backward compatible as it could cause bugs in currently deployed codes.

### TODO

- [ ] Write a test suite

### Links

* Fixes #272 