### PR TITLE
[TRAVIS] Add PHP 7.3 but let it fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - '7.2'
   - '7.3'
 
+matrix:
+  allow_failures:
+    - php: '7.3'
+
 before_script:
   - composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 matrix:
   allow_failures:
     - php: '7.3'
+  fast_finish: true
 
 before_script:
   - composer install


### PR DESCRIPTION
It seems the underlying webonxy library is needed in a newer version:
```
There was 1 error:

1) ConfigTest::testRouteQuery
ErrorException: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

/home/travis/build/rebing/graphql-laravel/vendor/webonyx/graphql-php/src/Validator/Rules/OverlappingFieldsCanBeMerged.php:355
/home/travis/build/rebing/graphql-laravel/vendor/webonyx/graphql-php/src/Validator/DocumentValidator.php:148
/home/travis/build/rebing/graphql-laravel/vendor/webonyx/graphql-php/src/Validator/DocumentValidator.php:114
/home/travis/build/rebing/graphql-laravel/vendor/webonyx/graphql-php/src/Validator/DocumentValidator.php:187
/home/travis/build/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLServiceProvider.php:102
/home/travis/build/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLServiceProvider.php:138
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:749
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:631
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:586
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:732
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:1195
/home/travis/build/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLServiceProvider.php:74
/home/travis/build/rebing/graphql-laravel/src/Rebing/GraphQL/GraphQLServiceProvider.php:24
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:87
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:31
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:549
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:792
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:775
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:776
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/BootProviders.php:17
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/Concerns/CreatesApplication.php:310
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/Concerns/CreatesApplication.php:202
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/TestCase.php:71
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/Concerns/Testing.php:59
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/TestCase.php:41
/home/travis/build/rebing/graphql-laravel/tests/TestCase.php:15
```

We'll keep the `allow_failure` in the matrix until this is fixed.