### PR TITLE
Auto-resolve unresolved aliased fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 Next release
 ------------
 - This project has a changelog `\o/`
+- Auto-resolve aliased fields [\#283](https://github.com/rebing/graphql-laravel/pull/283)
 
 2019-03-07, v1.21.2
 -------------------

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -49,6 +49,15 @@ class Type extends Fluent
                 return call_user_func_array($resolver, $args);
             };
         }
+        
+        if (isset($field['alias'])) {
+            $alias = $field['alias'];
+
+            return function ($type) use ($alias)
+            {
+                return $type->{$alias}; 
+            };
+        }
     }
 
     public function getFields()

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -49,13 +49,12 @@ class Type extends Fluent
                 return call_user_func_array($resolver, $args);
             };
         }
-        
+
         if (isset($field['alias'])) {
             $alias = $field['alias'];
 
-            return function ($type) use ($alias)
-            {
-                return $type->{$alias}; 
+            return function ($type) use ($alias) {
+                return $type->{$alias};
             };
         }
     }

--- a/tests/Objects/ExampleType.php
+++ b/tests/Objects/ExampleType.php
@@ -18,6 +18,10 @@ class ExampleType extends GraphQLType
                 'description' => 'A test field',
             ],
             'test_validation' => ExampleValidationField::class,
+            'test_with_alias' => [
+                'type'        => Type::string(),
+                'alias'       => 'testWithAlias',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Adds simple default resolver to aliased fields when no resolver is present. 

**I'm not sure how to test this properly ( please comment )**

#280 