### PR TITLE
[TESTS] Move into PSR-4 compliant namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,9 @@
         }
     },
     "autoload-dev": {
-        "classmap": [
-            "tests/"
-        ]
+        "psr-4": {
+            "Rebing\\GraphQL\\Tests\\": "tests/"
+        }
     },
     "extra": {
         "laravel": {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -2,8 +2,16 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\DocumentValidator;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Objects\ExamplesQuery;
+use Rebing\GraphQL\Tests\Objects\ErrorFormatter;
+use Rebing\GraphQL\Tests\Objects\CustomExampleType;
+use Rebing\GraphQL\Tests\Objects\UpdateExampleMutation;
 
 class ConfigTest extends TestCase
 {

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
 class EndpointTest extends TestCase
 {
     /**

--- a/tests/EnumTypeTest.php
+++ b/tests/EnumTypeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
 use GraphQL\Type\Definition\EnumType;
+use Rebing\GraphQL\Tests\Objects\ExampleEnumType;
 
 class EnumTypeTest extends TestCase
 {

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Closure;
+use Rebing\GraphQL\Tests\Objects\ExampleField;
+
 class FieldTest extends TestCase
 {
     protected function getFieldClass()

--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Objects\ExamplesQuery;
+
 class GraphQLQueryTest extends TestCase
 {
     /**

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -2,11 +2,19 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Validator;
 use GraphQL\Error\Error;
 use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\ObjectType;
 use Rebing\GraphQL\Error\ValidationError;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Objects\ExamplesQuery;
+use Rebing\GraphQL\Tests\Objects\CustomExampleType;
+use Rebing\GraphQL\Tests\Objects\UpdateExampleMutation;
 
 class GraphQLTest extends TestCase
 {
@@ -260,7 +268,7 @@ class GraphQLTest extends TestCase
         $this->assertArrayHasKey('Example', $types);
 
         $type = app($types['Example']);
-        $this->assertInstanceOf(\ExampleType::class, $type);
+        $this->assertInstanceOf(ExampleType::class, $type);
     }
 
     /**

--- a/tests/InputTypeTest.php
+++ b/tests/InputTypeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
 use GraphQL\Type\Definition\InputObjectType;
+use Rebing\GraphQL\Tests\Objects\ExampleInputType;
 
 class InputTypeTest extends TestCase
 {

--- a/tests/InterfaceTypeTest.php
+++ b/tests/InterfaceTypeTest.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Closure;
 use GraphQL\Type\Definition\InterfaceType;
+use Rebing\GraphQL\Tests\Objects\ExampleInterfaceType;
 
 class InterfaceTypeTest extends TestCase
 {

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -2,8 +2,14 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Validator;
+use Rebing\GraphQL\Tests\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Objects\ExampleValidationInputObject;
+use Rebing\GraphQL\Tests\Objects\ExampleNestedValidationInputObject;
+use Rebing\GraphQL\Tests\Objects\UpdateExampleMutationWithInputType;
 
 class MutationTest extends FieldTest
 {

--- a/tests/Objects/CustomExampleType.php
+++ b/tests/Objects/CustomExampleType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 

--- a/tests/Objects/ErrorFormatter.php
+++ b/tests/Objects/ErrorFormatter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Error\Error;
 use Rebing\GraphQL\Error\ValidationError;
 

--- a/tests/Objects/ExampleEnumType.php
+++ b/tests/Objects/ExampleEnumType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 

--- a/tests/Objects/ExampleField.php
+++ b/tests/Objects/ExampleField.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Field;
 

--- a/tests/Objects/ExampleFilterInputType.php
+++ b/tests/Objects/ExampleFilterInputType.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
 class ExampleFilterInputType extends GraphQLType

--- a/tests/Objects/ExampleInputType.php
+++ b/tests/Objects/ExampleInputType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 

--- a/tests/Objects/ExampleInterfaceType.php
+++ b/tests/Objects/ExampleInterfaceType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\InterfaceType;
 

--- a/tests/Objects/ExampleNestedValidationInputObject.php
+++ b/tests/Objects/ExampleNestedValidationInputObject.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as BaseType;
 

--- a/tests/Objects/ExampleType.php
+++ b/tests/Objects/ExampleType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 

--- a/tests/Objects/ExampleUnionType.php
+++ b/tests/Objects/ExampleUnionType.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\UnionType as BaseUnionType;
 
 class ExampleUnionType extends BaseUnionType

--- a/tests/Objects/ExampleValidationField.php
+++ b/tests/Objects/ExampleValidationField.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Field;
 

--- a/tests/Objects/ExampleValidationInputObject.php
+++ b/tests/Objects/ExampleValidationInputObject.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Type as BaseType;
 
 class ExampleValidationInputObject extends BaseType

--- a/tests/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Objects/ExamplesAuthorizeQuery.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesAuthorizeQuery extends Query
 {

--- a/tests/Objects/ExamplesFilteredQuery.php
+++ b/tests/Objects/ExamplesFilteredQuery.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesFilteredQuery extends Query
 {

--- a/tests/Objects/ExamplesPaginationQuery.php
+++ b/tests/Objects/ExamplesPaginationQuery.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 class ExamplesPaginationQuery extends Query

--- a/tests/Objects/ExamplesQuery.php
+++ b/tests/Objects/ExamplesQuery.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class ExamplesQuery extends Query
 {

--- a/tests/Objects/UpdateExampleMutation.php
+++ b/tests/Objects/UpdateExampleMutation.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;

--- a/tests/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Objects/UpdateExampleMutationWithInputType.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests\Objects;
+
 use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Rebing\GraphQL\Tests\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Objects\ExamplesQuery;
+
 class QueryTest extends FieldTest
 {
     protected function getFieldClass()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,16 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Rebing\GraphQL\Tests\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Objects\ExamplesQuery;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Rebing\GraphQL\Tests\Objects\ExamplesFilteredQuery;
+use Rebing\GraphQL\Tests\Objects\UpdateExampleMutation;
+use Rebing\GraphQL\Tests\Objects\ExampleFilterInputType;
+use Rebing\GraphQL\Tests\Objects\ExamplesAuthorizeQuery;
+use Rebing\GraphQL\Tests\Objects\ExamplesPaginationQuery;
 
 class TestCase extends BaseTestCase
 {

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 
+namespace Rebing\GraphQL\Tests;
+
+use Closure;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\ObjectType;
+use Rebing\GraphQL\Tests\Objects\ExampleType;
 
 class TypeTest extends TestCase
 {


### PR DESCRIPTION
A flat space for all classes doesn't lend itself of for a start for more tests without a way to organize them.

- Introduce the `Rebing\GraphQL\Tests` namespace
- adapted all tests to add the namespace and imports were necessary

Existing checkouts will likely not work after a git update, `composer dump-autoload` should fix this.