### PR TITLE
[SELECTFIELDS] Unwrap type before introspecting for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Next release
 ### Changed
 - Replace global helper `is_lumen` with static class call `\Rebing\GraphQL\Helpers::isLumen`
 
+### Fixed
+- SelectFields now works with wrapped types (nonNull, listOf)
+
 2019-03-07, v1.21.2
 -------------------
 

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -10,6 +10,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\WrappingType;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -37,6 +38,10 @@ class SelectFields
      */
     public function __construct(ResolveInfo $info, $parentType, array $args)
     {
+        if ($parentType instanceof WrappingType) {
+            $parentType = $parentType->getWrappedType(true);
+        }
+
         if (! is_null($info->fieldNodes[0]->selectionSet)) {
             self::$args = $args;
 

--- a/src/Rebing/GraphQL/Support/SelectFields.php
+++ b/src/Rebing/GraphQL/Support/SelectFields.php
@@ -8,7 +8,6 @@ use Closure;
 use Illuminate\Support\Arr;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\UnionType;
-use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\WrappingType;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -65,8 +64,8 @@ class SelectFields
         $select = [];
         $with = [];
 
-        if (is_a($parentType, ListOfType::class)) {
-            $parentType = $parentType->getWrappedType();
+        if ($parentType instanceof WrappingType) {
+            $parentType = $parentType->getWrappedType(true);
         }
         $parentTable = self::getTableNameFromParentType($parentType);
         $primaryKey = self::getPrimaryKeyFromParentType($parentType);

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
@@ -197,7 +197,104 @@ GRAQPHQL;
 
         $result = GraphQL::query($graphql);
 
-        $this->assertSame('SQLSTATE[HY000]: General error: 1 near "from": syntax error (SQL: select  from "users" order by "users"."id" asc)', $result['errors'][0]['debugMessage']);
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
     }
 
     public function testQueryWith(): void
@@ -243,12 +340,8 @@ GRAQPHQL;
 
         $this->assertSqlQueries(<<<'SQL'
 select * from "users" order by "users"."id" asc;
-select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
-select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
-select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
-select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
-select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
-select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
 SQL
         );
 
@@ -382,7 +475,100 @@ GRAQPHQL;
 
         $result = GraphQL::query($graphql);
 
-        $this->assertSame('SQLSTATE[HY000]: General error: 1 near "from": syntax error (SQL: select  from "users" order by "users"."id" asc)', $result['errors'][0]['debugMessage']);
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -124,10 +124,17 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries('');
+        $expectedResult = [
+            'data' => [
+                'postNonNullWithSelectFieldsAndModel' => [
+                    'id' => "$post->id",
+                    'title' => 'Title of the post',
+                ],
+            ],
+        ];
 
         $this->assertEquals($response->getStatusCode(), 200);
-        $this->assertRegExp('/SQLSTATE\[HY000\]: General error: 1 near "from": syntax error \(SQL: select  from "posts" where "posts"."id" = . limit 1\)/', $response->json()['errors'][0]['debugMessage']);
+        $this->assertEquals($expectedResult, $response->json());
     }
 
     public function testWithListOfSelectFieldsAndModel(): void
@@ -170,7 +177,7 @@ GRAQPHQL;
 
     public function testWithNonNullAndListOfSelectFieldsAndModel(): void
     {
-        factory(Post::class)->create([
+        $post = factory(Post::class)->create([
             'title' => 'Title of the post',
         ]);
 
@@ -189,15 +196,24 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries('');
+        $expectedResult = [
+            'data' => [
+                'postsNonNullAndListOfWithSelectFieldsAndModel' => [
+                    [
+                        'id' => "$post->id",
+                        'title' => 'Title of the post',
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($response->getStatusCode(), 200);
-        $this->assertRegExp('/SQLSTATE\[HY000\]: General error: 1 near "from": syntax error \(SQL: select  from "posts"\)/', $response->json()['errors'][0]['debugMessage']);
+        $this->assertEquals($expectedResult, $response->json());
     }
 
     public function testWithNonNullAndListOfAndNonNullSelectFieldsAndModel(): void
     {
-        factory(Post::class)->create([
+        $post = factory(Post::class)->create([
             'title' => 'Title of the post',
         ]);
 
@@ -216,10 +232,19 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries('');
+        $expectedResult = [
+            'data' => [
+                'postsNonNullAndListAndNonNullOfWithSelectFieldsAndModel' => [
+                    [
+                        'id' => "$post->id",
+                        'title' => 'Title of the post',
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($response->getStatusCode(), 200);
-        $this->assertRegExp('/SQLSTATE\[HY000\]: General error: 1 near "from": syntax error \(SQL: select  from "posts"\)/', $response->json()['errors'][0]['debugMessage']);
+        $this->assertEquals($expectedResult, $response->json());
     }
 
     public function testWithSelectFieldsAndModelAndAlias(): void


### PR DESCRIPTION
## Summary
Makes queries work where they type is wrapped in nonNull for example.

By using the recursive version of `getWrappedType($recursive=true)` we also make cases work where the types are nested like this: `Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type(…))));`

Fixes https://github.com/rebing/graphql-laravel/issues/290