### PR TITLE
[BREAKING CHANGE 🚨] Move error.validation to error.extensions.validation per GraphQL spec recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 Next release
 ------------
+## Breaking changes
+- Validation errors are moved from error.validation to error.extensions.validation as per GraphQL spec recommendation [\#294](https://github.com/rebing/graphql-laravel/pull/294)
+
 ### Added
 - Auto-resolve aliased fields [\#283](https://github.com/rebing/graphql-laravel/pull/283)
 - Added declare(strict_types=1) directive to all files

--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -297,7 +297,7 @@ class GraphQL
 
         $previous = $e->getPrevious();
         if ($previous && $previous instanceof ValidationError) {
-            $error['validation'] = $previous->getValidatorMessages();
+            $error['extensions']['validation'] = $previous->getValidatorMessages();
         }
 
         return $error;

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -132,8 +132,9 @@ class GraphQLQueryTest extends TestCase
 
         $this->assertArrayHasKey('data', $result);
         $this->assertArrayHasKey('errors', $result);
-        $this->assertArrayHasKey('validation', $result['errors'][0]);
-        $this->assertTrue($result['errors'][0]['validation']->has('index'));
+        $this->assertArrayHasKey('extensions', $result['errors'][0]);
+        $this->assertArrayHasKey('validation', $result['errors'][0]['extensions']);
+        $this->assertTrue($result['errors'][0]['extensions']['validation']->has('index'));
     }
 
     /**

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -202,8 +202,9 @@ class GraphQLTest extends TestCase
         $error = GraphQL::formatError($error);
 
         $this->assertIsArray($error);
-        $this->assertArrayHasKey('validation', $error);
-        $this->assertTrue($error['validation']->has('test'));
+        $this->assertArrayHasKey('extensions', $error);
+        $this->assertArrayHasKey('validation', $error['extensions']);
+        $this->assertTrue($error['extensions']['validation']->has('test'));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/rebing/graphql-laravel/issues/291

Will only target the v2 release