### PR TITLE
[TESTS] Add support for code coverage via codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - php: '7.3'
       env: LARAVEL='5.7.*'
     - php: '7.3'
-      env: LARAVEL='5.8.*'
+      env: LARAVEL='5.8.*' CODE_COVERAGE=1
 
 before_script:
   - phpenv config-rm xdebug.ini || true
@@ -38,4 +38,9 @@ install:
   - composer require "illuminate/support:${LARAVEL}" --no-interaction --no-update
   - composer install --prefer-dist --no-interaction --no-suggest
 
-script: vendor/bin/phpunit --colors=always --verbose
+script:
+  - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
+  - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
+
+after_success:
+ - if [[ $CODE_COVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
 # Laravel GraphQL
 
 [![Latest Stable Version](https://poser.pugx.org/rebing/graphql-laravel/v/stable)](https://packagist.org/packages/rebing/graphql-laravel)
+[![codecov](https://codecov.io/gh/rebing/graphql-laravel/branch/master/graph/badge.svg)](https://codecov.io/gh/rebing/graphql-laravel)
 [![Build Status](https://travis-ci.org/rebing/graphql-laravel.svg?branch=master)](https://travis-ci.org/rebing/graphql-laravel)
 [![Style CI](https://styleci.io/repos/68595316/shield)](https://styleci.io/repos/68595316)
 [![License](https://poser.pugx.org/rebing/graphql-laravel/license)](https://packagist.org/packages/rebing/graphql-laravel)


### PR DESCRIPTION
See https://codecov.io/gh/rebing/graphql-laravel/

(actually not much to see until it's merged into `master` because this is the default branch)

Since running tests for coverage slows them down, only the latest combination in the matrix uses conditional coverage via env variable.

The badge added only will work once merged into master I believe.

Using codecov is free for open source projects.