### PR TITLE
Fix for "composer: remove and ignore composer.lock"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.5.*|3.6.*|3.7.*",
+        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*",
         "phpunit/phpunit": "^5.5|~6.0|~7.0"
     },
     "autoload": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,7 +27,7 @@ class TestCase extends BaseTestCase
     /**
      * Setup the test environment.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCaseDatabase.php
+++ b/tests/TestCaseDatabase.php
@@ -8,7 +8,7 @@ use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
 
 abstract class TestCaseDatabase extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
When I tried to merge https://github.com/rebing/graphql-laravel/pull/302 I accidentally merged a local, outdated, branch and brushed off the not-merged status of the PR as some other error 💥 => lesson learned 👨‍🏫

Two commits were missing from the merge in master, which are now re-applied here.