### PR TITLE
[VALIDATIONERROR] Improve handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Next release
   - Test suite has been refactored and now features Database (SQLite) tests too
 
 ### Changed
+- `ValidatorError`: remove setter and make it a constructor arg, add getter and rely on contracts
 - Replace global helper `is_lumen` with static class call `\Rebing\GraphQL\Helpers::isLumen`
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "type": "project",
     "require": {
         "php": ">= 7.1",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "webonyx/graphql-php": "^0.13",
         "ext-json": "*"

--- a/src/Rebing/GraphQL/Error/ValidationError.php
+++ b/src/Rebing/GraphQL/Error/ValidationError.php
@@ -5,20 +5,28 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Error;
 
 use GraphQL\Error\Error;
+use Illuminate\Contracts\Support\MessageBag;
+use Illuminate\Contracts\Validation\Validator;
 
 class ValidationError extends Error
 {
-    public $validator;
+    /** @var Validator */
+    private $validator;
 
-    public function setValidator($validator)
+    public function __construct(string $message, Validator $validator)
     {
-        $this->validator = $validator;
+        parent::__construct($message);
 
-        return $this;
+        $this->validator = $validator;
     }
 
-    public function getValidatorMessages()
+    public function getValidatorMessages(): MessageBag
     {
-        return $this->validator ? $this->validator->messages() : [];
+        return $this->validator->errors();
+    }
+
+    public function getValidator(): Validator
+    {
+        return $this->validator;
     }
 }

--- a/src/Rebing/GraphQL/Support/Field.php
+++ b/src/Rebing/GraphQL/Support/Field.php
@@ -179,7 +179,7 @@ class Field extends Fluent
 
                     $validator = Validator::make($args, $rules, $messages);
                     if ($validator->fails()) {
-                        throw with(new ValidationError('validation'))->setValidator($validator);
+                        throw with(new ValidationError('validation', $validator));
                     }
                 }
             }

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -197,7 +197,7 @@ class GraphQLTest extends TestCase
             'test' => 'required',
         ]);
         $validator->fails();
-        $validationError = with(new ValidationError('validation'))->setValidator($validator);
+        $validationError = with(new ValidationError('validation', $validator));
         $error = new Error('error', null, null, null, null, $validationError);
         $error = GraphQL::formatError($error);
 

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -121,8 +121,7 @@ class MutationTest extends FieldTest
         try {
             $attributes['resolve'](null, [], [], null);
         } catch (ValidationError $e) {
-            // FIXME Replace with getValidator()
-            $validator = $e->validator;
+            $validator = $e->getValidator();
 
             $this->assertInstanceOf(Validator::class, $validator);
 


### PR DESCRIPTION
## Summary
- Add explicit dependency on illuminate/contracts in composer
- rely on contracts on boundaries to define the interface
- removes ambiguity on when getValidatorMessages returns a MessseBag or
  an array => it now always returns a MessageBag
- introduce getter and make internal field private