### PR TITLE
Add PHP types to console commands were possible

### DIFF
--- a/src/Rebing/GraphQL/Console/MutationMakeCommand.php
+++ b/src/Rebing/GraphQL/Console/MutationMakeCommand.php
@@ -69,9 +69,9 @@ class MutationMakeCommand extends GeneratorCommand
      * @param string $stub
      * @param string $name
      *
-     * @return $this
+     * @return string
      */
-    protected function replaceType($stub, $name)
+    protected function replaceType(string $stub, string $name): string
     {
         preg_match('/([^\\\]+)$/', $name, $matches);
         $stub = str_replace(

--- a/src/Rebing/GraphQL/Console/PublishCommand.php
+++ b/src/Rebing/GraphQL/Console/PublishCommand.php
@@ -49,12 +49,7 @@ class PublishCommand extends Command
         ];
     }
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle()
+    public function handle(): void
     {
         foreach ($this->fileMap as $from => $to) {
             if ($this->files->exists($to) && ! $this->option('force')) {
@@ -73,7 +68,7 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    protected function createParentDirectory($directory)
+    protected function createParentDirectory(string $directory): void
     {
         if (! $this->files->isDirectory($directory)) {
             $this->files->makeDirectory($directory, 0755, true);
@@ -88,7 +83,7 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    protected function status($from, $to)
+    protected function status(string $from, string $to): void
     {
         $from = str_replace(base_path(), '', realpath($from));
         $to = str_replace(base_path(), '', realpath($to));

--- a/src/Rebing/GraphQL/Console/QueryMakeCommand.php
+++ b/src/Rebing/GraphQL/Console/QueryMakeCommand.php
@@ -69,9 +69,9 @@ class QueryMakeCommand extends GeneratorCommand
      * @param string $stub
      * @param string $name
      *
-     * @return $this
+     * @return string
      */
-    protected function replaceType($stub, $name)
+    protected function replaceType(string $stub, string $name): string
     {
         preg_match('/([^\\\]+)$/', $name, $matches);
         $stub = str_replace(

--- a/src/Rebing/GraphQL/Console/TypeMakeCommand.php
+++ b/src/Rebing/GraphQL/Console/TypeMakeCommand.php
@@ -69,9 +69,9 @@ class TypeMakeCommand extends GeneratorCommand
      * @param string $stub
      * @param string $name
      *
-     * @return $this
+     * @return string
      */
-    protected function replaceType($stub, $name)
+    protected function replaceType(string $stub, string $name): string
     {
         preg_match('/([^\\\]+)$/', $name, $matches);
         $stub = str_replace(


### PR DESCRIPTION
Only touch non-inherited methods for now