### PR TITLE
Backport: "Port over Folklore config headers and json_encoding_options"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
+Next release
+----------------
+### Added
+- New config options `headers` to send custom HTTP headers and `json_encoding_options` for encoding the JSON response [\#293](https://github.com/rebing/graphql-laravel/pull/293)
+
 2019-05-31, v1.22.0
 ------------
 ### Added
-- New config options `headers` to send custom HTTP headers and `json_encoding_options` for encoding the JSON response [\#293](https://github.com/rebing/graphql-laravel/pull/293)
 - Auto-resolve aliased fields [\#283](https://github.com/rebing/graphql-laravel/pull/283)
 - This project has a changelog `\o/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2019-05-31, v1.22.0
 ------------
 ### Added
+- New config options `headers` to send custom HTTP headers and `json_encoding_options` for encoding the JSON response [\#293](https://github.com/rebing/graphql-laravel/pull/293)
 - Auto-resolve aliased fields [\#283](https://github.com/rebing/graphql-laravel/pull/283)
 - This project has a changelog `\o/`
 

--- a/src/Rebing/GraphQL/GraphQLController.php
+++ b/src/Rebing/GraphQL/GraphQLController.php
@@ -52,7 +52,12 @@ class GraphQLController extends Controller
             ]));
         }
 
-        return $isBatch ? $completedQueries : $completedQueries[0];
+        $data = $isBatch ? $completedQueries : $completedQueries[0];
+
+        $headers = config('graphql.headers', []);
+        $jsonOptions = config('graphql.json_encoding_options', 0);
+
+        return response()->json($data, 200, $headers, $jsonOptions);
     }
 
     protected function queryContext()

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -189,4 +189,15 @@ return [
      * ```
      */
     'defaultFieldResolver' => null,
+
+    /*
+     * Any headers that will be added to the response returned by the default controller
+     */
+    'headers' => [],
+
+    /*
+     * Any JSON encoding options when returning a response from the default controller
+     * See http://php.net/manual/function.json-encode.php for the full list of options
+     */
+    'json_encoding_options' => 0,
 ];


### PR DESCRIPTION
Backport of https://github.com/rebing/graphql-laravel/pull/293 but for the v1 release branch.

Includes only the code change and not the test, because the infrastructure for them changed too much already.

Part of https://github.com/rebing/graphql-laravel/issues/287