### PR TITLE
Add test showing the behaviour of fetching nested relations

### DIFF
--- a/tests/Database/SelectFields/NestedRelationLoadingTests/CommentType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/CommentType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+
+class CommentType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Comment',
+        'model' => Comment::class,
+    ];
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+
+class NestedRelationLoadingTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testQueryNoSelectFields(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select * from "users" order by "users"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testQuerySelect(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql);
+
+        $this->assertSame('SQLSTATE[HY000]: General error: 1 near "from": syntax error (SQL: select  from "users" order by "users"."id" asc)', $result['errors'][0]['debugMessage']);
+    }
+
+    public function testQueryWith(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(with: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select * from "users" order by "users"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testQuerySelectAndWith(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql);
+
+        $this->assertSame('SQLSTATE[HY000]: General error: 1 near "from": syntax error (SQL: select  from "users" order by "users"."id" asc)', $result['errors'][0]['debugMessage']);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                UsersQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.schemas.custom', null);
+
+        $app['config']->set('graphql.types', [
+            CommentType::class,
+            PostType::class,
+            UserType::class,
+        ]);
+    }
+}

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class PostType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Post',
+        'model' => Post::class,
+    ];
+
+    public function fields()
+    {
+        return [
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'comments' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class UserType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'User',
+        'model' => User::class,
+    ];
+
+    public function fields()
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'name' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+            'posts' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'users',
+    ];
+
+    public function args()
+    {
+        return [
+            'select' => [
+                'type' => Type::boolean(),
+            ],
+            'with' => [
+                'type' => Type::boolean(),
+            ],
+        ];
+    }
+
+    public function type()
+    {
+        return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('User'))));
+    }
+
+    public function resolve($root, $args, SelectFields $selectFields)
+    {
+        $users = User::query();
+
+        if (isset($args['select']) && $args['select']) {
+            $users->select($selectFields->getSelect());
+        }
+
+        if (isset($args['with']) && $args['with']) {
+            $users->with($selectFields->getRelations());
+        }
+
+        return $users->orderBy('users.id')->get();
+    }
+}

--- a/tests/Support/Models/Comment.php
+++ b/tests/Support/Models/Comment.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+}

--- a/tests/Support/Models/User.php
+++ b/tests/Support/Models/User.php
@@ -7,10 +7,10 @@ namespace Rebing\GraphQL\Tests\Support\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class Post extends Model
+class User extends Model
 {
-    public function comments(): HasMany
+    public function posts(): HasMany
     {
-        return $this->hasMany(Comment::class)->orderBy('comments.id');
+        return $this->hasMany(Post::class)->orderBy('posts.id');
     }
 }

--- a/tests/Support/database/factories/CommentFactory.php
+++ b/tests/Support/database/factories/CommentFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+
+/* @var Factory $factory */
+$factory->define(Comment::class, function (Faker $faker) {
+    return [
+        'title' => $faker->title,
+        'body' => $faker->sentence,
+    ];
+});

--- a/tests/Support/database/factories/UserFactory.php
+++ b/tests/Support/database/factories/UserFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+/* @var Factory $factory */
+$factory->define(User::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+    ];
+});

--- a/tests/Support/database/migrations/____comments_table.php
+++ b/tests/Support/database/migrations/____comments_table.php
@@ -6,15 +6,15 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class PostsTable extends Migration
+class CommentsTable extends Migration
 {
     public function up(): void
     {
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('comments', function (Blueprint $table) {
             $table->increments('id');
+            $table->integer('post_id');
             $table->string('title');
             $table->string('body')->nullable();
-            $table->integer('user_id')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Support/database/migrations/____posts_table.php
+++ b/tests/Support/database/migrations/____posts_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateTestbenchPostsTable extends Migration
+class PostsTable extends Migration
 {
     /**
      * Run the migrations.

--- a/tests/Support/database/migrations/____users_table.php
+++ b/tests/Support/database/migrations/____users_table.php
@@ -6,15 +6,13 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class PostsTable extends Migration
+class UsersTable extends Migration
 {
     public function up(): void
     {
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('title');
-            $table->string('body')->nullable();
-            $table->integer('user_id')->nullable();
+            $table->string('name');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Inspired by https://github.com/rebing/graphql-laravel/issues/310 , it uses a more realistic query with multiple nested models.

The tests also include a version which doesn't make use of SelectFields, showing the n+1 issue.

Some tests in `\Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests\NestedRelationLoadingTest` are testing for errors; this is known until https://github.com/rebing/graphql-laravel/pull/292 is merged.

This adds a couple of migrations/models/factories:
- Comment
- User
- (Post => already existed)