### PR TITLE
[TESTS] Show that arguments on sub fields are currently ignored by SelectFields

### DIFF
--- a/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
@@ -571,6 +571,159 @@ SQL
         $this->assertEquals($expectedResult, $result);
     }
 
+    /**
+     * The test is expected to break and needs adaption once the referenced
+     * issue is fixed:
+     * - SQL queries
+     * - actual posts returned (only 1 post per user).
+     *
+     * @see https://github.com/rebing/graphql-laravel/issues/314
+     */
+    public function testQuerySelectAndWithAndSubArgs(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                $post = factory(Post::class)
+                    ->create([
+                        'flag' => true,
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class, 2)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+
+                $post = factory(Post::class)
+                    ->create([
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class, 2)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    posts(flag: true) {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Database\SelectFields\NestedRelationLoadingTests;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\Post;
 use Rebing\GraphQL\Tests\Support\Models\User;
 use Rebing\GraphQL\Support\Type as GraphQLType;
 
@@ -27,6 +28,11 @@ class UserType extends GraphQLType
             ],
             'posts' => [
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
+                'args' => [
+                    'flag' => [
+                        Type::boolean(),
+                    ],
+                ],
             ],
         ];
     }

--- a/tests/Support/database/migrations/____posts_table.php
+++ b/tests/Support/database/migrations/____posts_table.php
@@ -15,6 +15,7 @@ class PostsTable extends Migration
             $table->string('title');
             $table->string('body')->nullable();
             $table->integer('user_id')->nullable();
+            $table->boolean('flag')->default('false');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Provide a starting point test for https://github.com/rebing/graphql-laravel/issues/314 by coming up with a query which should filter on a sub-type:
```graphql
{
  users(select: true, with: true) {
    id
    name
    posts(flag: true) {
      body
      id
      title
      comments {
        body
        id
        title
      }
    }
  }
}
```
But currently it doesn't filter with using purely `$selectFields->getRelations()` thus it returns all posts of all users when it should only return one post per user.