### PR TITLE
[TESTS] Show that custom rules (closure, RuleObject) work

### DIFF
--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\MutationValidationUniqueWithCustomRulesTests;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Illuminate\Contracts\Support\MessageBag;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+
+class MutationValidationUniqueWithCustomRulesTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testUniquePassRulePass(): void
+    {
+        /* @var User $user */
+        factory(User::class)
+            ->create([
+                'name' => 'name_unique',
+            ]);
+
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_unique_rule_pass: String) {
+  mutationWithCustomRuleWithRuleObject(arg_unique_rule_pass: $arg_unique_rule_pass)
+}
+GRAPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql, [
+            'arg_unique_rule_pass' => 'another_name',
+        ]);
+
+        $this->assertSqlQueries(<<<'SQL'
+select count(*) as aggregate from "users" where "name" = ?;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testUniqueFailRulePass(): void
+    {
+        /* @var User $user */
+        factory(User::class)
+            ->create([
+                'name' => 'name_unique',
+            ]);
+
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_unique_rule_pass: String) {
+  mutationWithCustomRuleWithRuleObject(arg_unique_rule_pass: $arg_unique_rule_pass)
+}
+GRAPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql, [
+            'arg_unique_rule_pass' => 'name_unique',
+        ]);
+
+        $this->assertSqlQueries(<<<'SQL'
+select count(*) as aggregate from "users" where "name" = ?;
+SQL
+        );
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'The arg unique rule pass has already been taken.',
+        ];
+        $this->assertSame($expectedMessages, $messageBag->all());
+    }
+
+    public function testUniquePassRuleFail(): void
+    {
+        /* @var User $user */
+        factory(User::class)
+            ->create([
+                'name' => 'name_unique',
+            ]);
+
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_unique_rule_fail: String) {
+  mutationWithCustomRuleWithRuleObject(arg_unique_rule_fail: $arg_unique_rule_fail)
+}
+GRAPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql, [
+            'arg_unique_rule_pass' => 'another_name',
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testUniqueFailRuleFail(): void
+    {
+        /* @var User $user */
+        factory(User::class)
+            ->create([
+                'name' => 'name_unique',
+            ]);
+
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_unique_rule_fail: String) {
+  mutationWithCustomRuleWithRuleObject(arg_unique_rule_fail: $arg_unique_rule_fail)
+}
+GRAPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = GraphQL::query($graphql, [
+            'arg_unique_rule_fail' => 'name_unique',
+        ]);
+
+        $this->assertSqlQueries(<<<'SQL'
+select count(*) as aggregate from "users" where "name" = ?;
+SQL
+        );
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'The arg unique rule fail has already been taken.',
+            'rule object validation fails',
+        ];
+        $this->assertSame($expectedMessages, $messageBag->all());
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                MutationWithCustomRuleWithRuleObject::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\MutationValidationUniqueWithCustomRulesTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class MutationWithCustomRuleWithRuleObject extends Mutation
+{
+    protected $attributes = [
+        'name' => 'mutationWithCustomRuleWithRuleObject',
+    ];
+
+    public function type()
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function rules(array $args = [])
+    {
+        return [
+            'arg_unique_rule_pass' => [
+                'unique:users,name',
+                new RuleObjectPass(),
+            ],
+            'arg_unique_rule_fail' => [
+                'unique:users,name',
+                new RuleObjectFail(),
+            ],
+        ];
+    }
+
+    public function args()
+    {
+        return [
+            'arg_unique_rule_pass' => [
+                'type' => Type::string(),
+            ],
+            'arg_unique_rule_fail' => [
+                'type' => Type::string(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): string
+    {
+        return 'mutation result';
+    }
+}

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectFail.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectFail.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\MutationValidationUniqueWithCustomRulesTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectFail implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'rule object validation fails';
+    }
+}

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectPass.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectPass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\MutationValidationUniqueWithCustomRulesTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectPass implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return true;
+    }
+
+    public function message()
+    {
+        return 'this message is not expected to be triggered';
+    }
+}

--- a/tests/Unit/LaravelValidatorTests/LaravelValidatorTest.php
+++ b/tests/Unit/LaravelValidatorTests/LaravelValidatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\LaravelValidatorTests;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Illuminate\Validation\Validator;
+
+class LaravelValidatorTest extends TestCase
+{
+    public function testInPassRulePass(): void
+    {
+        $rules = [
+            'arg' => [
+                'in:valid_name',
+                new RuleObjectPass(),
+            ],
+        ];
+
+        $data = [
+            'arg' => 'valid_name',
+        ];
+
+        /** @var Validator $validator */
+        $validator = \Validator::make($data, $rules);
+
+        $this->assertSame([], $validator->errors()->all());
+    }
+
+    public function testInPassRuleFail(): void
+    {
+        $rules = [
+            'arg' => [
+                'in:valid_name',
+                new RuleObjectFail(),
+            ],
+        ];
+
+        $data = [
+            'arg' => 'valid_name',
+        ];
+
+        /** @var Validator $validator */
+        $validator = \Validator::make($data, $rules);
+
+        $expectedMessages = [
+            'rule object validation fails',
+        ];
+        $this->assertSame($expectedMessages, $validator->errors()->all());
+    }
+
+    public function testInFailRulePass(): void
+    {
+        $rules = [
+            'arg' => [
+                'in:valid_name',
+                new RuleObjectPass(),
+            ],
+        ];
+
+        $data = [
+            'arg' => 'invalid_name',
+        ];
+
+        /** @var Validator $validator */
+        $validator = \Validator::make($data, $rules);
+
+        $expectedMessages = [
+            'The selected arg is invalid.',
+        ];
+        $this->assertSame($expectedMessages, $validator->errors()->all());
+    }
+
+    public function testInFailRuleFail(): void
+    {
+        $rules = [
+            'arg' => [
+                'in:valid_name',
+                new RuleObjectFail(),
+            ],
+        ];
+
+        $data = [
+            'The selected arg is invalid.',
+            'rule object validation fails',
+        ];
+
+        /** @var Validator $validator */
+        $validator = \Validator::make($data, $rules);
+
+        $this->assertSame([], $validator->errors()->all());
+    }
+}

--- a/tests/Unit/LaravelValidatorTests/RuleObjectFail.php
+++ b/tests/Unit/LaravelValidatorTests/RuleObjectFail.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\LaravelValidatorTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectFail implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'rule object validation fails';
+    }
+}

--- a/tests/Unit/LaravelValidatorTests/RuleObjectPass.php
+++ b/tests/Unit/LaravelValidatorTests/RuleObjectPass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\LaravelValidatorTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectPass implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return true;
+    }
+
+    public function message()
+    {
+        return 'this message is not expected to be triggered';
+    }
+}

--- a/tests/Unit/MutationCustomRulesTests/MutationCustomRulesTest.php
+++ b/tests/Unit/MutationCustomRulesTests/MutationCustomRulesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationCustomRulesTests;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Illuminate\Contracts\Support\MessageBag;
+
+class MutationCustomRulesTest extends TestCase
+{
+    public function testMutationWithCustomRuleWithClosure(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg1: String) {
+  mutationWithCustomRuleWithClosure(arg1: $arg1)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg1' => 'Test argument 1',
+        ]);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $this->assertSame(['arg1 is invalid'], $messageBag->all());
+    }
+
+    public function testMutationWithCustomRuleWithRuleObject(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg1: String) {
+  mutationWithCustomRuleWithRuleObject(arg1: $arg1)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg1' => 'Test argument 1',
+        ]);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $this->assertSame(['arg1 is invalid'], $messageBag->all());
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                MutationWithCustomRuleWithClosure::class,
+                MutationWithCustomRuleWithRuleObject::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+++ b/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationCustomRulesTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class MutationWithCustomRuleWithClosure extends Mutation
+{
+    protected $attributes = [
+        'name' => 'mutationWithCustomRuleWithClosure',
+    ];
+
+    public function type()
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function rules(array $args = [])
+    {
+        return [
+            'arg1' => [
+                'required',
+                function (string $attribute, $value, $fail) {
+                    $fail($attribute.' is invalid');
+                },
+            ],
+        ];
+    }
+
+    public function args()
+    {
+        return [
+            'arg1' => [
+                'type' => Type::string(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): string
+    {
+        return 'mutation result';
+    }
+}

--- a/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationCustomRulesTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class MutationWithCustomRuleWithRuleObject extends Mutation
+{
+    protected $attributes = [
+        'name' => 'mutationWithCustomRuleWithRuleObject',
+    ];
+
+    public function type()
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function rules(array $args = [])
+    {
+        return [
+            'arg1' => [
+                'required',
+                new RuleObject(),
+            ],
+        ];
+    }
+
+    public function args()
+    {
+        return [
+            'arg1' => [
+                'type' => Type::string(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): string
+    {
+        return 'mutation result';
+    }
+}

--- a/tests/Unit/MutationCustomRulesTests/RuleObject.php
+++ b/tests/Unit/MutationCustomRulesTests/RuleObject.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationCustomRulesTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObject implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'arg1 is invalid';
+    }
+}

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/MutationValidationInWithCustomRulesTest.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/MutationValidationInWithCustomRulesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationValidationInWithCustomRulesTests;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Illuminate\Contracts\Support\MessageBag;
+
+class MutationValidationInWithCustomRulesTest extends TestCase
+{
+    public function testInPassRulePass(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_in_rule_pass: String) {
+  mutationWithCustomRuleWithRuleObject(arg_in_rule_pass: $arg_in_rule_pass)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg_in_rule_pass' => 'valid_name',
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testInPassRuleFail(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_in_rule_fail: String) {
+  mutationWithCustomRuleWithRuleObject(arg_in_rule_fail: $arg_in_rule_fail)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg_in_rule_pass' => 'valid_name',
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testInFailRulePass(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_in_rule_pass: String) {
+  mutationWithCustomRuleWithRuleObject(arg_in_rule_pass: $arg_in_rule_pass)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg_in_rule_pass' => 'invalid_name',
+        ]);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'The selected arg in rule pass is invalid.',
+        ];
+        $this->assertSame($expectedMessages, $messageBag->all());
+    }
+
+    public function testInFailRuleFail(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_in_rule_fail: String) {
+  mutationWithCustomRuleWithRuleObject(arg_in_rule_fail: $arg_in_rule_fail)
+}
+GRAPHQL;
+
+        $result = GraphQL::query($graphql, [
+            'arg_in_rule_fail' => 'invalid_name',
+        ]);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'The selected arg in rule fail is invalid.',
+            'rule object validation fails',
+        ];
+        $this->assertSame($expectedMessages, $messageBag->all());
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                MutationWithCustomRuleWithRuleObject::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationValidationInWithCustomRulesTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class MutationWithCustomRuleWithRuleObject extends Mutation
+{
+    protected $attributes = [
+        'name' => 'mutationWithCustomRuleWithRuleObject',
+    ];
+
+    public function type()
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function rules(array $args = [])
+    {
+        return [
+            'arg_in_rule_pass' => [
+                'in:valid_name',
+                new RuleObjectPass(),
+            ],
+            'arg_in_rule_fail' => [
+                'in:valid_name',
+                new RuleObjectFail(),
+            ],
+        ];
+    }
+
+    public function args()
+    {
+        return [
+            'arg_in_rule_pass' => [
+                'type' => Type::string(),
+            ],
+            'arg_in_rule_fail' => [
+                'type' => Type::string(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): string
+    {
+        return 'mutation result';
+    }
+}

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectFail.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectFail.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationValidationInWithCustomRulesTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectFail implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'rule object validation fails';
+    }
+}

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectPass.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectPass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\MutationValidationInWithCustomRulesTests;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class RuleObjectPass implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return true;
+    }
+
+    public function message()
+    {
+        return 'this message is not expected to be triggered';
+    }
+}


### PR DESCRIPTION
Cover scenario described in https://github.com/rebing/graphql-laravel/issues/321

There two tests which are not producing the desired result:
- `\Rebing\GraphQL\Tests\Database\MutationValidationUniqueWithCustomRulesTests\MutationValidationUniqueWithCustomRulesTest::testUniquePassRuleFail`
- `\Rebing\GraphQL\Tests\Unit\MutationValidationInWithCustomRulesTests\MutationValidationInWithCustomRulesTest::testInPassRuleFail`

Both tests return the GraphQL mutation result when the shouldn't: just because the first rule passes doesn't mean the second shall be ignored => in these cases the 2nd is supposed to fail the validation.

For clarity, I made a simple Laravel-only test in `\Rebing\GraphQL\Tests\Unit\LaravelValidatorTests\LaravelValidatorTest::testInPassRuleFail` which shows the expected validation failure:
```php
        $rules = [
            'arg' => [
                'in:valid_name',
                new RuleObjectFail(),
            ],
        ];

        $data = [
            'arg' => 'valid_name',
        ];

        /** @var Validator $validator */
        $validator = \Validator::make($data, $rules);

        $expectedMessages = [
            'rule object validation fails',
        ];
        $this->assertSame($expectedMessages, $validator->errors()->all());
```