### PR TITLE
[TRAVIS] Fix actually running unit tests for all matrix combinations ('cept 5.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ install:
   - composer install --prefer-dist --no-interaction --no-suggest
 
 script:
-  - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
+  - if [[ $LARAVEL = '5.5.*' && $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose --testsuite=Unit; fi
+  - if [[ $LARAVEL != '5.5.*' && $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
   - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
   directories:
   - $HOME/.composer/cache/files
 
+env:
+  global:
+    - CODE_COVERAGE=0
+
 matrix:
   include:
     - php: '7.1'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,10 +10,10 @@
          stopOnFailure="false"
 >
     <testsuites>
-        <testsuite name="Unit tests">
+        <testsuite name="Unit">
             <directory suffix=".php">./tests/Unit</directory>
         </testsuite>
-        <testsuite name="Database tests">
+        <testsuite name="Database">
             <directory suffix=".php">./tests/Database</directory>
         </testsuite>
     </testsuites>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests;
 
+use Error;
 use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
+use PHPUnit\Framework\Constraint\IsType;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -111,5 +113,25 @@ class TestCase extends BaseTestCase
         return [
             'GraphQL' => GraphQL::class,
         ];
+    }
+
+    /**
+     * Implement for Laravel 5.5 testing with PHPUnit 6.5 which doesn't have
+     * `assertIsArray`.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if ($name !== 'assertIsArray') {
+            throw new Error('Call to undefined method '.static::class.'::$name via __call()');
+        }
+
+        static::assertThat(
+            $arguments[0],
+            new IsType(IsType::TYPE_ARRAY),
+            $arguments[1] ?? ''
+        );
     }
 }


### PR DESCRIPTION
# TL;DR
phpunit is finally really executed for all travis matrix combinations; previously only for the last one with code coverage 💥

### Details
The existing `.travis.yml` with its existing test matrix was all nice and well thought but had a subtle bug: it would try to run all combinations as jobs but out of the 12 job only a **single** one (the one with the code coverage) was actually executed. Oh my 😅

The reason for this was an oversight with the environment setup. This line was supposed to run the tests when not doing coverage:
`  - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi`

But an environment variable doesn't automagically equal `0` unless it's explicitly defined that way => which was missing and this PR added it.

After that it became evident that Laravel 5.5.* tests didn't work for two reasons:
1. test method `assertIsArray` was used but not present in PHPUnit 6.5 requires for this older Laravel installation => fixed with a shim
2. database tests didn't work

#### Problem with 5.5 and database tests
The issue with 2) was not really solved; I decided to simply skip the `Database` tests on this version of Laravel.

For a start, orchestra complained the package `orchestra/database` was not installed (newer version don't need this).

After fixing this, another error came up: [the migration for the tests contains this code](https://github.com/orchestral/testbench-core/blob/09a57dc446a24fd19a75ff57b679b86094251f8e/src/Concerns/WithLoadMigrationsFrom.php):
```php
        $options = is_array($realpath) ? $realpath : ['--realpath' => $realpath];

        $this->artisan('migrate', $options);
```
However the Laravel artisan command the complains that:
```
Symfony\Component\Console\Exception\InvalidOptionException : The "--realpath" option does not exist.
 /graphql-laravel/vendor/symfony/console/Input/ArrayInput.php:172
 /graphql-laravel/vendor/symfony/console/Input/ArrayInput.php:134
 /graphql-laravel/vendor/symfony/console/Input/Input.php:55
 /graphql-laravel/vendor/symfony/console/Command/Command.php:214
 /graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Command.php:167
 /graphql-laravel/vendor/symfony/console/Application.php:969
 /graphql-laravel/vendor/symfony/console/Application.php:255
 /graphql-laravel/vendor/symfony/console/Application.php:148
 /graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:82
 /graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:171
 /graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:258
 /graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php:18
 /graphql-laravel/vendor/orchestra/testbench-core/src/Concerns/WithLoadMigrationsFrom.php:26
 /graphql-laravel/tests/TestCaseDatabase.php:15
```
I'll see to follow-up with orchestra here.