### PR TITLE
[TRAVIS] Add upcoming PHP 7.4 to test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 /phpunit.xml
 /composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
       env: LARAVEL='5.7.*'
     - php: '7.3'
       env: LARAVEL='5.8.*' CODE_COVERAGE=1
+    - php: '7.4snapshot'
+      env: LARAVEL='5.8.*'
 
 before_script:
   - phpenv config-rm xdebug.ini || true

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*",
-        "phpunit/phpunit": "^5.5|~6.0|~7.0"
+        "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
PHP 7.4 only works with PHPUnit 8, but PHPUnit 8 is only compatible with Laravel 5.8 and not below.

Thus this is the only combination added to the matrix right now.

These are the errors when using an PHPUnit < 8:
```
Runtime:       PHP 7.4.0-dev
Configuration: /home/travis/build/rebing/graphql-laravel/phpunit.xml.dist
.........E........E................................E..E.......... 65 / 84 ( 77%)
...................                                               84 / 84 (100%)
Time: 671 ms, Memory: 28.00 MB
There were 4 errors:
1) Rebing\GraphQL\Tests\Unit\ConfigTest::testErrorFormatter
ErrorException: Function ReflectionType::__toString() is deprecated
/home/travis/build/rebing/graphql-laravel/tests/Unit/ConfigTest.php:156
2) Rebing\GraphQL\Tests\Unit\FieldTest::testResolve
ErrorException: Function ReflectionType::__toString() is deprecated
/home/travis/build/rebing/graphql-laravel/tests/Unit/FieldTest.php:44
3) Rebing\GraphQL\Tests\Unit\InterfaceTypeTest::testGetAttributesResolveType
ErrorException: Function ReflectionType::__toString() is deprecated
/home/travis/build/rebing/graphql-laravel/tests/Unit/InterfaceTypeTest.php:33
4) Rebing\GraphQL\Tests\Unit\MutationTest::testResolve
ErrorException: Function ReflectionType::__toString() is deprecated
/home/travis/build/rebing/graphql-laravel/tests/Unit/MutationTest.php:71
```