### PR TITLE
 [TRAVIS] Enable database tests for Laravel 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ before_script:
 install:
   - composer require "illuminate/support:${LARAVEL}" --no-interaction --no-update
   - composer install --prefer-dist --no-interaction --no-suggest
+  - if [[ $LARAVEL = '5.5.*' ]]; then composer require --dev orchestra/database:3.5 --prefer-dist --no-interaction --no-suggest; fi
 
 script:
-  - if [[ $LARAVEL = '5.5.*' && $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose --testsuite=Unit; fi
-  - if [[ $LARAVEL != '5.5.*' && $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
+  - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
   - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
 
 after_success:

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Constraint\IsType;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use GraphQL\Type\Definition\FieldDefinition;
+use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleType;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
@@ -103,9 +104,16 @@ class TestCase extends BaseTestCase
 
     protected function getPackageProviders($app): array
     {
-        return [
+        $providers = [
             GraphQLServiceProvider::class,
         ];
+
+        // Support for Laravel 5.5 testing
+        if (class_exists(ConsoleServiceProvider::class)) {
+            $providers[] = ConsoleServiceProvider::class;
+        }
+
+        return $providers;
     }
 
     protected function getPackageAliases($app): array


### PR DESCRIPTION
Currently all database related tests fail because of this:
```
Symfony\Component\Console\Exception\InvalidOptionException: The "--realpath" option does not exist.
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Input/ArrayInput.php:172
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Input/ArrayInput.php:134
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Input/Input.php:55
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Command/Command.php:214
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Command.php:170
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Application.php:969
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Application.php:255
/home/travis/build/rebing/graphql-laravel/vendor/symfony/console/Application.php:148
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:88
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:177
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:249
/home/travis/build/rebing/graphql-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php:18
/home/travis/build/rebing/graphql-laravel/vendor/orchestra/testbench-core/src/Concerns/WithLoadMigrationsFrom.php:26
/home/travis/build/rebing/graphql-laravel/tests/TestCaseDatabase.php:15
```

### Edit
Fixed by adjusting `getPackageProviders` 🎉 