### PR TITLE
[TESTS] Follow-up fix to tests for custom rules

### DIFF
--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
@@ -99,15 +99,17 @@ GRAPHQL;
         $this->sqlCounterReset();
 
         $result = GraphQL::query($graphql, [
-            'arg_unique_rule_pass' => 'another_name',
+            'arg_unique_rule_fail' => 'another_name',
         ]);
 
-        $expectedResult = [
-            'data' => [
-                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
-            ],
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'rule object validation fails',
         ];
-        $this->assertSame($expectedResult, $result);
+        $this->assertSame($expectedMessages, $messageBag->all());
     }
 
     public function testUniqueFailRuleFail(): void

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/MutationValidationInWithCustomRulesTest.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/MutationValidationInWithCustomRulesTest.php
@@ -39,15 +39,17 @@ mutation Mutate($arg_in_rule_fail: String) {
 GRAPHQL;
 
         $result = GraphQL::query($graphql, [
-            'arg_in_rule_pass' => 'valid_name',
+            'arg_in_rule_fail' => 'valid_name',
         ]);
 
-        $expectedResult = [
-            'data' => [
-                'mutationWithCustomRuleWithRuleObject' => 'mutation result',
-            ],
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('validation', $result['errors'][0]['message']);
+        /** @var MessageBag $messageBag */
+        $messageBag = $result['errors'][0]['extensions']['validation'];
+        $expectedMessages = [
+            'rule object validation fails',
         ];
-        $this->assertSame($expectedResult, $result);
+        $this->assertSame($expectedMessages, $messageBag->all());
     }
 
     public function testInFailRulePass(): void


### PR DESCRIPTION
## Summary
Fixes small but important copypaste mistakes made in
https://github.com/rebing/graphql-laravel/pull/322

Turns out: feature works correctly.

Actually those two tests mentioned in https://github.com/rebing/graphql-laravel/pull/322 had a bug (🤦‍♂️) and the validation works correctly and the same way as the native Laravel validation.

Seems it's too 🔥 outside these days to write proper tests.