### PR TITLE
[CLEANUP] Remove unused fields on \Rebing\GraphQL\Support\Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Next release
 ### Fixed
 - SelectFields now works with wrapped types (nonNull, listOf)
 
+### Removed
+- Unused static field `\Rebing\GraphQL\Support\Type::$instances`
+- Unused field `\Rebing\GraphQL\Support\Type::$unionType`
+
 2019-03-07, v1.21.2
 -------------------
 

--- a/src/Rebing/GraphQL/Support/Type.php
+++ b/src/Rebing/GraphQL/Support/Type.php
@@ -13,11 +13,8 @@ use GraphQL\Type\Definition\InputObjectType;
 
 class Type extends Fluent
 {
-    protected static $instances = [];
-
     protected $inputObject = false;
     protected $enumObject = false;
-    protected $unionType = false;
 
     public function attributes()
     {


### PR DESCRIPTION
Neither field is currently in use.

- `instances`: was added with the very first commit to this repo but even then wasn't "in use"
- `unionType`: was added [in the PR which added unions](https://github.com/rebing/graphql-laravel/pull/91) but even that PR didn't make use of the field