### PR TITLE
[CLEANUP] Remove \Rebing\GraphQL\GraphQL::getTypeName

### DIFF
--- a/src/Rebing/GraphQL/GraphQL.php
+++ b/src/Rebing/GraphQL/GraphQL.php
@@ -268,17 +268,6 @@ class GraphQL
         $this->typesInstances = [];
     }
 
-    protected function getTypeName($class, $name = null)
-    {
-        if ($name) {
-            return $name;
-        }
-
-        $type = is_object($class) ? $class : $this->app->make($class);
-
-        return $type->name;
-    }
-
     public function paginate($typeName, $customName = null)
     {
         $name = $customName ?: $typeName.'_pagination';


### PR DESCRIPTION
The method isn't used anywhere.

The exact same code is found in `\Rebing\GraphQL\GraphQL::addType`:
```php
    public function addType($class, $name = null)
    {
        if (! $name) {
            $type = is_object($class) ? $class : app($class);
            $name = $type->name;
        }

        $this->types[$name] = $class;
    }
```
But since this is the only place I see no use in keeping the method.