### PR TITLE
Handle x-csrf-token changes via response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Next release
   - Although this could be consider a bug fix, it changes what columns are selected and if your code as a side-effect dependent on all columns being selected, it will break
 
 ### Added
+- GraphiQL: use regenerated CSRF from server if present [\#332](https://github.com/rebing/graphql-laravel/pull/332)
 - New config options `headers` to send custom HTTP headers and `json_encoding_options` for encoding the JSON response [\#293](https://github.com/rebing/graphql-laravel/pull/293)
 - Auto-resolve aliased fields [\#283](https://github.com/rebing/graphql-laravel/pull/283)
 - Added declare(strict_types=1) directive to all files

--- a/src/resources/views/graphiql.php
+++ b/src/resources/views/graphiql.php
@@ -79,6 +79,8 @@
                 history.replaceState(null, null, newSearch);
             }
 
+            var xcrsfToken = null;
+
             // Defines a GraphQL fetcher using the fetch API.
             function graphQLFetcher(graphQLParams) {
                 return fetch('<?php echo $graphqlPath; ?>', {
@@ -86,11 +88,13 @@
                     headers: {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': '<?php echo csrf_token(); ?>'
+                        'X-CSRF-TOKEN': xcrsfToken || '<?php echo csrf_token(); ?>'
                     },
                     body: JSON.stringify(graphQLParams),
                     credentials: 'include',
                 }).then(function (response) {
+                    xcrsfToken = response.headers.get('x-csrf-token');
+
                     return response.text();
                 }).then(function (responseBody) {
                     try {

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -148,6 +148,6 @@ class EndpointTest extends TestCase
         $response->assertSee('This GraphiQL example illustrates how to use some of GraphiQL\'s props');
         // The argument to fetch is extracted from the configuration
         $response->assertSee('return fetch(\'/graphql\', {');
-        $response->assertSee("'X-CSRF-TOKEN': ''");
+        $response->assertSee("'X-CSRF-TOKEN': xcrsfToken || ''");
     }
 }


### PR DESCRIPTION
Re-PR from https://github.com/rebing/graphql-laravel/pull/332 , not sure why the tests didn't run there (travis setup issue?)