### PR TITLE
composer: switch from PSR-0 to PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "phpstan/phpstan": "^0.11.8"
     },
     "autoload": {
-        "psr-0": {
-            "Rebing\\GraphQL\\": "src/"
+        "psr-4": {
+            "Rebing\\GraphQL\\": "src/Rebing/GraphQL/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Already tested with a test installation, class resolution works.

A few days ago I tried to use https://github.com/nunomaduro/larastan but it didn't work because it expected a psr-4 key.