### PR TITLE
[GRAPHIQL] Update to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Next release
   - Test suite has been refactored and now features Database (SQLite) tests too
 
 ### Changed
+- Updated GraphiQL to 0.13.0 (\#335)[https://github.com/rebing/graphql-laravel/pull/335]
+  - If you're using CSP, be sure to allow `cdn.jsdelivr.net` and `cdnjs.cloudflare.com`
 - `ValidatorError`: remove setter and make it a constructor arg, add getter and rely on contracts
 - Replace global helper `is_lumen` with static class call `\Rebing\GraphQL\Helpers::isLumen`
 

--- a/resources/views/README.md
+++ b/resources/views/README.md
@@ -1,0 +1,16 @@
+# GraphiQL integration
+
+See https://github.com/graphql/graphiql for the home of GraphiQL
+
+The file `graphiql.php` is an integration of the example provided by GraphiQL. It's a slightly modified version from the official repository so it can be integrated.
+
+The modifications are documented here in detail as to replicate them on future updates:
+
+- copy example from packages/graphiql/example/index.html
+- adjust CDN URLs from https://cdnjs.com/libraries/graphiql
+- graphQLFetcher: replace the hardcoded path with the library configured path:
+  `return fetch('/graphql', {` => `return fetch('<?php echo $graphqlPath; ?>', {`
+- csrf integration
+  - right before `function graphQLFetcher` add: `var xcsrfToken = null;`
+  - in the actual `fetch` call, add this header: `'x-csrf-token': xcsrfToken || '<?php echo csrf_token(); ?>'`
+  - in the first `then` after the `fetch` call: `xcsrfToken = response.headers.get('x-csrf-token');`

--- a/resources/views/graphiql.php
+++ b/resources/views/graphiql.php
@@ -37,8 +37,8 @@
       copy them directly into your environment, or perhaps include them in your
       favored resource bundler.
      -->
-    <link rel="stylesheet" href="./node_modules/graphiql/graphiql.css" />
-    <script src="./node_modules/graphiql/graphiql.js" charset="utf-8"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.min.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.min.js" charset="utf-8"></script>
 
   </head>
   <body>

--- a/resources/views/graphiql.php
+++ b/resources/views/graphiql.php
@@ -103,6 +103,8 @@
         history.replaceState(null, null, newSearch);
       }
 
+      var xcsrfToken = null;
+
       // Defines a GraphQL fetcher using the fetch API. You're not required to
       // use fetch, and could instead implement graphQLFetcher however you like,
       // as long as it returns a Promise or Observable.
@@ -114,10 +116,12 @@
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+            'x-csrf-token': xcsrfToken || '<?php echo csrf_token(); ?>'
           },
           body: JSON.stringify(graphQLParams),
           credentials: 'include',
         }).then(function (response) {
+          xcsrfToken = response.headers.get('x-csrf-token');
           return response.text();
         }).then(function (responseBody) {
           try {

--- a/resources/views/graphiql.php
+++ b/resources/views/graphiql.php
@@ -109,7 +109,7 @@
       function graphQLFetcher(graphQLParams) {
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
-        return fetch('/graphql', {
+        return fetch('<?php echo $graphqlPath; ?>', {
           method: 'post',
           headers: {
             'Accept': 'application/json',

--- a/resources/views/graphiql.php
+++ b/resources/views/graphiql.php
@@ -1,123 +1,149 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
 <!DOCTYPE html>
 <html>
-    <head>
-        <style>
-            html, body {
-                height: 100%;
-                margin: 0;
-                padding: 0;
-                width: 100%;
-                overflow: hidden;
-            }
-            #graphiql {
-                height: 100vh;
-            }
-        </style>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.min.css" />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
-    </head>
-    <body>
-        <div id="graphiql">Loading...</div>
-        <script>
-            /**
-            * This GraphiQL example illustrates how to use some of GraphiQL's props
-            * in order to enable reading and updating the URL parameters, making
-            * link sharing of queries a little bit easier.
-            *
-            * This is only one example of this kind of feature, GraphiQL exposes
-            * various React params to enable interesting integrations.
-            */
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
 
-            // Parse the search string to get url parameters.
-            var search = window.location.search;
-            var parameters = {};
-            search.substr(1).split('&').forEach(function (entry) {
-                var eq = entry.indexOf('=');
-                if (eq >= 0) {
-                    parameters[decodeURIComponent(entry.slice(0, eq))] =
-                    decodeURIComponent(entry.slice(eq + 1));
-                }
-            });
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
 
-            // if variables was provided, try to format it.
-            if (parameters.variables) {
-                try {
-                    parameters.variables =
-                    JSON.stringify(JSON.parse(parameters.variables), null, 2);
-                } catch (e) {
-                    // Do nothing, we want to display the invalid JSON as a string, rather
-                    // than present an error.
-                }
-            }
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="./node_modules/graphiql/graphiql.css" />
+    <script src="./node_modules/graphiql/graphiql.js" charset="utf-8"></script>
 
-            // When the query and variables string is edited, update the URL bar so
-            // that it can be easily shared
-            function onEditQuery(newQuery) {
-                parameters.query = newQuery;
-                updateURL();
-            }
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script>
 
-            function onEditVariables(newVariables) {
-                parameters.variables = newVariables;
-                updateURL();
-            }
+      /**
+       * This GraphiQL example illustrates how to use some of GraphiQL's props
+       * in order to enable reading and updating the URL parameters, making
+       * link sharing of queries a little bit easier.
+       *
+       * This is only one example of this kind of feature, GraphiQL exposes
+       * various React params to enable interesting integrations.
+       */
 
-            function onEditOperationName(newOperationName) {
-                parameters.operationName = newOperationName;
-                updateURL();
-            }
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
 
-            function updateURL() {
-                var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-                    return Boolean(parameters[key]);
-                }).map(function (key) {
-                    return encodeURIComponent(key) + '=' + encodeURIComponent(parameters[key]);
-                }).join('&');
-                history.replaceState(null, null, newSearch);
-            }
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
+      }
 
-            var xcrsfToken = null;
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+      }
 
-            // Defines a GraphQL fetcher using the fetch API.
-            function graphQLFetcher(graphQLParams) {
-                return fetch('<?php echo $graphqlPath; ?>', {
-                    method: 'post',
-                    headers: {
-                        'Accept': 'application/json',
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': xcrsfToken || '<?php echo csrf_token(); ?>'
-                    },
-                    body: JSON.stringify(graphQLParams),
-                    credentials: 'include',
-                }).then(function (response) {
-                    xcrsfToken = response.headers.get('x-csrf-token');
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
 
-                    return response.text();
-                }).then(function (responseBody) {
-                    try {
-                        return JSON.parse(responseBody);
-                    } catch (error) {
-                        return responseBody;
-                    }
-                });
-            }
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
 
-            // Render <GraphiQL /> into the body.
-            ReactDOM.render(
-                React.createElement(GraphiQL, {
-                    fetcher: graphQLFetcher,
-                    query: parameters.query,
-                    variables: parameters.variables,
-                    operationName: parameters.operationName,
-                    onEditQuery: onEditQuery,
-                    onEditVariables: onEditVariables,
-                    onEditOperationName: onEditOperationName
-                }),
-                document.getElementById('graphiql')
-            );
-        </script>
-    </body>
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
+
+      // Defines a GraphQL fetcher using the fetch API. You're not required to
+      // use fetch, and could instead implement graphQLFetcher however you like,
+      // as long as it returns a Promise or Observable.
+      function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        return fetch('/graphql', {
+          method: 'post',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(graphQLParams),
+          credentials: 'include',
+        }).then(function (response) {
+          return response.text();
+        }).then(function (responseBody) {
+          try {
+            return JSON.parse(responseBody);
+          } catch (error) {
+            return responseBody;
+          }
+        });
+      }
+
+      // Render <GraphiQL /> into the body.
+      // See the README in the top level of this module to learn more about
+      // how you can customize GraphiQL by providing different values or
+      // additional child elements.
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+      );
+    </script>
+  </body>
 </html>

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -148,6 +148,6 @@ class EndpointTest extends TestCase
         $response->assertSee('This GraphiQL example illustrates how to use some of GraphiQL\'s props');
         // The argument to fetch is extracted from the configuration
         $response->assertSee('return fetch(\'/graphql\', {');
-        $response->assertSee("'X-CSRF-TOKEN': xcrsfToken || ''");
+        $response->assertSee("'x-csrf-token': xcsrfToken || ''");
     }
 }


### PR DESCRIPTION
This upgrades from 0.10.1 to [0.13.0](https://github.com/graphql/graphiql/releases/tag/v0.13.0)

There's a 0.13.1 release but those release files were not published on the CDN (yet?).

Upgrading is a manual process currently. I've kept the existing modifications:
- configurable fetch path
- CSRF integration (including the [recent PR with the additional header](https://github.com/rebing/graphql-laravel/pull/332))

I've also tried to **not** change the formatting of the HTML part as to make future updates easier to reason.

I've tested this by copypasting the template into an existing project and it worked 👍 


Here's the paste from the README.md:

----
# GraphiQL integration

See https://github.com/graphql/graphiql for the home of GraphiQL

The file `graphiql.php` is an integration of the example provided by GraphiQL. It's a slightly modified version from the official repository so it can be integrated.

The modifications are documented here in detail as to replicate them on future updates:

- copy example from packages/graphiql/example/index.html
- adjust CDN URLs from https://cdnjs.com/libraries/graphiql
- graphQLFetcher: replace the hardcoded path with the library configured path:
  `return fetch('/graphql', {` => `return fetch('<?php echo $graphqlPath; ?>', {`
- csrf integration
  - right before `function graphQLFetcher` add: `var xcsrfToken = null;`
  - in the actual `fetch` call, add this header: `'x-csrf-token': xcsrfToken || '<?php echo csrf_token(); ?>'`
  - in the first `then` after the `fetch` call: `xcsrfToken = response.headers.get('x-csrf-token');`

----