### PR TITLE
[SELECTFIELDS] Remove support for composite primary keys

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,7 +27,6 @@ parameters:
         - '/Parameter #1 \$haystack of function mb_stripos expects string, \(array\)\|string given/'
         - '/Strict comparison using === between null and array will always evaluate to false/'
         - '/Cannot access offset . on array\|Closure/'
-        - '/Call to function is_array\(\) with string will always evaluate to false/' # TODO: fix \Rebing\GraphQL\Support\SelectFields::getSelectableFieldsAndRelations
         # \Rebing\GraphQL\Support\SelectFields::handleFields
         - '/Parameter #1 \$function of function call_user_func expects callable\(\): mixed, array\(mixed, mixed\) given/'
         - '/Binary operation "." between string and array\|string\|null results in an error/'

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -84,16 +84,10 @@ class SelectFields
         self::handleFields($queryArgs, $requestedFields, $parentType, $select, $with);
 
         // If a primary key is given, but not in the selects, add it
-        if (! is_null($primaryKey)) {
-            if (is_array($primaryKey)) {
-                foreach ($primaryKey as $key) {
-                    $select[] = $parentTable ? ($parentTable.'.'.$key) : $key;
-                }
-            } else {
-                $primaryKey = $parentTable ? ($parentTable.'.'.$primaryKey) : $primaryKey;
-                if (! in_array($primaryKey, $select)) {
-                    $select[] = $primaryKey;
-                }
+        if (null !== $primaryKey) {
+            $primaryKey = $parentTable ? ($parentTable.'.'.$primaryKey) : $primaryKey;
+            if (! in_array($primaryKey, $select)) {
+                $select[] = $primaryKey;
             }
         }
 


### PR DESCRIPTION
## Summary
phpstan reported this:
Call to function is_array() with string will always evaluate to false

After adding types to `getPrimaryKeyFromParentType()`, it's not possible
to return an array here.

All the information I could find on such composite keys is that Laravel
does not support them (e.g. https://github.com/laravel/framework/issues/5355 ).

I also read a bit through the 5.8 sources and everywhere where
`getKeyName()` is called within Laravel you can see that it's expected
to be a string and doesn't seem like it would truly work with an array.

### More information
This feature was added via https://github.com/rebing/graphql-laravel/pull/216 to resolve https://github.com/rebing/graphql-laravel/issues/215 .

But it doens't go into much detail how this is really achieved and we've no tests for this.

@yasergh can you shed some light on your use cases? How to you make your Laravel version work with composite keys when it doesn't seem to be officially supported? Are you using a library like https://github.com/coenjacobs/eloquent-composite-primary-keys ?
