### PR TITLE
[LUMEN] Fix path to config/view after project structure change

### DIFF
--- a/src/GraphQLLumenServiceProvider.php
+++ b/src/GraphQLLumenServiceProvider.php
@@ -10,11 +10,11 @@ class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 {
     protected function bootPublishes(): void
     {
-        $configPath = __DIR__.'/../../config';
+        $configPath = __DIR__.'/../config';
 
         $this->mergeConfigFrom($configPath.'/config.php', 'graphql');
 
-        $viewsPath = __DIR__.'/../../resources/views';
+        $viewsPath = __DIR__.'/../resources/views';
         $this->loadViewsFrom($viewsPath, 'graphql');
     }
 


### PR DESCRIPTION
We've no tests for this so it wasn't noticed until I tried to get
Larastan working, which seems to boot the Lumen service provider.

Really need some basic test here.