### PR TITLE
Remove {graphql_schema?} from graphqil.prefix and thus making it compatible with Lumen

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -167,7 +167,7 @@ return [
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */
     'graphiql' => [
-        'prefix'     => '/graphiql/{graphql_schema?}',
+        'prefix'     => '/graphiql',
         'controller' => \Rebing\GraphQL\GraphQLController::class.'@graphiql',
         'middleware' => [],
         'view'       => 'graphql::graphiql',


### PR DESCRIPTION
I installed this under Lumen 5.8 and `/graphql` endpoint itself worked but `/graphiql` didn't.

After some forth and back I figured it's this part in the `graphql.graphiql.prefix`. Once I removed it, graphiql worked; also with explicit schema names, e.g. `/graphiql/default`.

This seems to be fine (ignored?) in Laravel (also tried to remove it in a Laravel installation and it broken nothing).

Anyone using Lumen can test/verify this?