### PR TITLE
Add actual Laravel/Lumen integration with a basic test (and fix Lumen)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
   - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
   - if [[ $INSTALL_LARAVEL = 1 ]]; then export -f travis_retry ; tests/integration-larvavel.sh; fi
+  - if [[ $INSTALL_LUMEN = 1 ]]; then export -f travis_retry ; tests/integration-lumen.sh; fi
 
 after_success:
  - if [[ $CODE_COVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
 env:
   global:
     - CODE_COVERAGE=0
+    - INSTALL_LARAVEL=0
+    - INSTALL_LUMEN=0
     - STATIC_ANALYSER=0
 
 matrix:
@@ -36,7 +38,7 @@ matrix:
     - php: '7.3'
       env: LARAVEL='5.7.*'
     - php: '7.3'
-      env: LARAVEL='5.8.*' CODE_COVERAGE=1 STATIC_ANALYSER=1
+      env: LARAVEL='5.8.*' CODE_COVERAGE=1 STATIC_ANALYSER=1 INSTALL_LARAVEL=1 INSTALL_LUMEN=1
     - php: '7.4snapshot'
       env: LARAVEL='5.8.*'
 
@@ -53,6 +55,7 @@ script:
   - if [[ $STATIC_ANALYSER = 1 ]]; then composer phpstan; fi
   - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
   - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
+  - if [[ $INSTALL_LARAVEL = 1 ]]; then export -f travis_retry ; tests/integration-larvavel.sh; fi
 
 after_success:
  - if [[ $CODE_COVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,13 @@ $app->register(Rebing\GraphQL\GraphQLLumenServiceProvider::class);
 config/graphql.php
 ```
 
+The default GraphiQL view makes use of the global `csrf_token()` helper function.
+Out of the box, this function is not available in Lumen.
+
+To work this around:
+- Point to your local GraphiQL view: change `graphql.view` to `'vendor/graphql/graphiql'`
+- Modify your file `resources/views/vendor/graphql/graphiql.php` and remove the call
+
 ## Usage
 
 - [Schemas](#schemas)

--- a/src/Console/stubs/query.stub
+++ b/src/Console/stubs/query.stub
@@ -33,6 +33,8 @@ class DummyClass extends Query
         $select = $fields->getSelect();
         $with = $fields->getRelations();
 
-        return [];
+        return [
+            'The DummyQuery works',
+        ];
     }
 }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -19,12 +19,12 @@ use Rebing\GraphQL\Error\ValidationError;
 use Rebing\GraphQL\Support\PaginationType;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Exception\SchemaNotFound;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Contracts\Foundation\Application;
 
 class GraphQL
 {
-    /** @var Application */
+    /** @var Container */
     protected $app;
 
     protected $schemas = [];
@@ -37,7 +37,7 @@ class GraphQL
     /** @var Type[] */
     protected $typesInstances = [];
 
-    public function __construct(Application $app)
+    public function __construct(Container $app)
     {
         $this->app = $app;
     }

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -10,8 +10,8 @@ use GraphQL\Validator\DocumentValidator;
 use Rebing\GraphQL\Console\TypeMakeCommand;
 use GraphQL\Validator\Rules\QueryComplexity;
 use Rebing\GraphQL\Console\QueryMakeCommand;
+use Illuminate\Contracts\Container\Container;
 use Rebing\GraphQL\Console\MutationMakeCommand;
-use Illuminate\Contracts\Foundation\Application;
 use GraphQL\Validator\Rules\DisableIntrospection;
 
 class GraphQLServiceProvider extends ServiceProvider
@@ -132,7 +132,7 @@ class GraphQLServiceProvider extends ServiceProvider
 
     public function registerGraphQL(): void
     {
-        $this->app->singleton('graphql', function (Application $app): GraphQL {
+        $this->app->singleton('graphql', function (Container $app): GraphQL {
             $graphql = new GraphQL($app);
 
             $this->applySecurityRules();

--- a/src/routes.php
+++ b/src/routes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Arr;
 use Rebing\GraphQL\Helpers;
-use Illuminate\Routing\Router;
 use Rebing\GraphQL\GraphQLController;
 
 $router = app('router');
@@ -12,7 +11,8 @@ $router = app('router');
 $router->group(array_merge([
     'prefix'        => config('graphql.prefix'),
     'middleware'    => config('graphql.middleware', []),
-], config('graphql.route_group_attributes', [])), function (Router $router): void {
+], config('graphql.route_group_attributes', [])), function ($router): void {
+    /** @var \Illuminate\Routing\Router|\Laravel\Lumen\Routing\Router $router */
     // Routes
     $routes = config('graphql.routes');
     $queryRoute = null;
@@ -150,7 +150,8 @@ if (config('graphql.graphiql.display', true)) {
     $router->group([
         'prefix'        => config('graphql.graphiql.prefix', 'graphiql'),
         'middleware'    => config('graphql.graphiql.middleware', []),
-    ], function (Router $router): void {
+    ], function ($router): void {
+        /** @var \Illuminate\Routing\Router|\Laravel\Lumen\Routing\Router $router */
         $graphiqlController = config('graphql.graphiql.controller', GraphQLController::class.'@graphiql');
         $schemaParameterPattern = '/\{\s*graphql\_schema\s*\?\s*\}/';
         $graphiqlAction = ['uses' => $graphiqlController];

--- a/tests/integration-larvavel.sh
+++ b/tests/integration-larvavel.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Inspired by https://github.com/nunomaduro/larastan/blob/669b489e10558bd45fafc2429068fd4a73843802/tests/laravel-test.sh
+#
+# Create a fresh Laravel installation, install our package in it and run some
+# basic tests to ensure everything works.
+#
+# This script is meant to be run on Travis CI
+
+echo "Prevent shallow repository error"
+git fetch --unshallow
+
+echo "Install Laravel"
+travis_retry composer create-project --quiet --prefer-dist "laravel/laravel" laravel
+cd laravel
+
+echo "Add package from source"
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "vcs", "url": "../" } ],|' -i composer.json
+travis_retry composer require --dev "rebing/graphql-laravel:dev-master#${TRAVIS_COMMIT}"
+
+echo "Publish vendor files"
+php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider"
+
+echo "Make GraphQL ExampleQuery"
+php artisan make:graphql:query ExampleQuery
+
+echo "Add ExampleQuery to config"
+sed -e "s|// 'example_query' => ExampleQuery::class,|\\\App\\\GraphQL\\\Query\\\ExampleQuery::class,|" -i config/graphql.php
+
+echo "Start Webserver"
+php -S 127.0.0.1:8001 -t public >/dev/null 2>&1 &
+sleep 2
+
+echo "Send GraphQL HTTP request to fetch ExampleQuery"
+curl 'http://127.0.0.1:8001/graphql?query=%7BExampleQuery%7D' -sSfLv | grep 'The ExampleQuery works'
+
+if [[ $? = 0 ]]; then
+  echo "Example GraphQL query works 👍"
+else
+  echo "Example GraphQL query DID NOT work 👎"
+  curl 'http://127.0.0.1:8001/graphql?query=%7BExampleQuery%7D' -sSfLv
+  cat storage/logs/*
+  exit 1
+fi
+
+echo "Test accessing GraphiQL"
+curl 'http://127.0.0.1:8001/graphiql' -sSfLv | grep '<div id="graphiql">Loading...</div>'
+
+if [[ $? = 0 ]]; then
+  echo "Can access GraphiQL 👍"
+else
+  echo "Cannot access GraphiQL 👎"
+  curl 'http://127.0.0.1:8001/graphiql' -sSfLv
+  cat storage/logs/*
+  exit 1
+fi

--- a/tests/integration-lumen.sh
+++ b/tests/integration-lumen.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Inspired by https://github.com/nunomaduro/larastan/blob/669b489e10558bd45fafc2429068fd4a73843802/tests/laravel-test.sh
+#
+# Create a fresh Kumen installation, install our package in it and run some
+# basic tests to ensure everything works.
+#
+# This script is meant to be run on Travis CI
+
+echo "Prevent shallow repository error"
+git fetch --unshallow
+
+echo "Install Lumen"
+travis_retry composer create-project --quiet --prefer-dist "laravel/lumen" lumen
+cd lumen
+
+echo "Add package from source"
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "vcs", "url": "../" } ],|' -i composer.json
+travis_retry composer require --dev "rebing/graphql-laravel:dev-master#${TRAVIS_COMMIT}"
+
+echo "Install library"
+
+echo "Register library"
+sed -e 's|// \$app->register(App\\\Providers\\\EventServiceProvider::class);|&\n$app->register(Rebing\\\GraphQL\\\GraphQLLumenServiceProvider::class);|' -i bootstrap/app.php
+echo "Publish vendor files"
+php artisan graphql:publish
+echo "Initialize configuration"
+sed -e 's|\$app->register(Rebing\\\GraphQL\\\GraphQLLumenServiceProvider::class);|$app->configure("graphql");\n&\n|' -i bootstrap/app.php
+
+
+echo "Make GraphQL ExampleQuery"
+php artisan make:graphql:query ExampleQuery
+
+echo "Add ExampleQuery to config"
+sed -e "s|// 'example_query' => ExampleQuery::class,|\\\App\\\GraphQL\\\Query\\\ExampleQuery::class,|" -i config/graphql.php
+
+echo "Use local copy of GraphiQL view"
+sed -e "s|'view'       => 'graphql::graphiql'|'view'       => 'vendor/graphql/graphiql'|" -i config/graphql.php
+
+echo "Removing non-existent csrf_token() call"
+sed -e "s|.*csrf_token.*||" -i resources/views/vendor/graphql/graphiql.php
+
+echo "Start Webserver"
+php -S 127.0.0.1:8002 -t public >/dev/null 2>&1 &
+sleep 2
+
+echo "Send GraphQL HTTP request to fetch ExampleQuery"
+curl 'http://127.0.0.1:8002/graphql?query=%7BExampleQuery%7D' -sSfLv | grep 'The ExampleQuery works'
+
+if [[ $? = 0 ]]; then
+  echo "Example GraphQL query works 👍"
+else
+  echo "Example GraphQL query DID NOT work 👎"
+  curl 'http://127.0.0.1:8002/graphql?query=%7BExampleQuery%7D' -sSfLv
+  cat storage/logs/*
+  exit 1
+fi
+
+echo "Test accessing GraphiQL"
+curl 'http://127.0.0.1:8002/graphiql' -sSfLv | grep '<div id="graphiql">Loading...</div>'
+
+if [[ $? = 0 ]]; then
+  echo "Can access GraphiQL 👍"
+else
+  echo "Cannot access GraphiQL 👎"
+  curl 'http://127.0.0.1:8002/graphiql' -sSfLv
+  cat storage/logs/*
+  exit 1
+fi


### PR DESCRIPTION
## Summary
I wanted to have a and very small test whether the integration into Laravel/Lumen works on the most basic level. After I found out about how [Larastan does it](https://github.com/nunomaduro/larastan/blob/master/tests/laravel-test.sh), I decided to give it a go.

Similar to static analysis which is performed for a single matrix combination (PHP 7.3, Laravel 5.8), for this entry we now perform an actual integration test for Laravel and Lumen.

Both work the same way (but need different approaches):
- Install Framework
- Install graphql-laravel from the commit under test in Travis
- configure installation
- test basic query execution works
- test GraphiQL loads

Along the way I found out that Lumen in `master` was broken due to the [recent addition of type declarations](https://github.com/rebing/graphql-laravel/pull/331), therefore some small code adaptions were also necessary.

I also learned that GraphiQL didn't work for Lumen because it calls `csfr_token()` function which isn't available to Lumen by default => a small entry into the README Lumen installation part has been added (and the integration test also performs this workaround steps).