### PR TITLE
[LUMEN] Fix path multi-level support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
 - Replace global helper `is_lumen` with static class call `\Rebing\GraphQL\Helpers::isLumen`
 
 ### Fixed
+- Path multi-level support for Schemas works again [\#358](https://github.com/rebing/graphql-laravel/pull/358)
 - SelectFields correctly passes field arguments to the custom query [\#327](https://github.com/rebing/graphql-laravel/pull/327)
   - This also applies to privacy checks on fields, the callback now receives the field arguments too
   - Previously the initial query arguments would be used everywhere

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -21,8 +21,11 @@ class GraphQLController extends Controller
         // If there are multiple route params we can expect that there
         // will be a schema name that has to be built
 
-        if (Helpers::isLumen() && $request->request->count() > 1) {
-            $schema = implode('/', $request->request->all());
+        if (Helpers::isLumen()) {
+            $route = $request->route();
+            if (isset($route[2]) && count($route[2]) > 1) {
+                $schema = implode('/', $route[2]);
+            }
         } elseif (! Helpers::isLumen() && $request->route()->parameters && count($request->route()->parameters) > 1) {
             $schema = implode('/', $request->route()->parameters);
         }

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -20,14 +20,9 @@ class GraphQLController extends Controller
 
         // If there are multiple route params we can expect that there
         // will be a schema name that has to be built
-
-        if (Helpers::isLumen()) {
-            $route = $request->route();
-            if (isset($route[2]) && count($route[2]) > 1) {
-                $schema = implode('/', $route[2]);
-            }
-        } elseif (! Helpers::isLumen() && $request->route()->parameters && count($request->route()->parameters) > 1) {
-            $schema = implode('/', $request->route()->parameters);
+        $routeParameters = $this->getRouteParameters($request);
+        if (count($routeParameters) > 1) {
+            $schema = implode('/', $routeParameters);
         }
 
         if (! $schema) {
@@ -90,5 +85,20 @@ class GraphQLController extends Controller
             'graphql_schema' => 'graphql_schema',
             'graphqlPath'    => $graphqlPath,
         ]);
+    }
+
+    /**
+     * @param  Request  $request
+     * @return array<string,string>
+     */
+    protected function getRouteParameters(Request $request): array
+    {
+        if (Helpers::isLumen()) {
+            $route = $request->route();
+
+            return $route[2] ?? [];
+        }
+
+        return $request->route()->parameters;
     }
 }

--- a/tests/Unit/SchemaMultiLevelPathTest.php
+++ b/tests/Unit/SchemaMultiLevelPathTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
+
+class SchemaMultiLevelPathTest extends TestCase
+{
+    public function testMultiLevelPath(): void
+    {
+        $graphql = <<<'GRAPHQL'
+{
+    examples {
+        test
+    }
+}
+GRAPHQL;
+
+        $response = $this->call('GET', '/graphql/multi/level', [
+            'query' => $graphql,
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'examples' => [
+                    [
+                        'test' => 'Example 1',
+                    ],
+                    [
+                        'test' => 'Example 2',
+                    ],
+                    [
+                        'test' => 'Example 3',
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $response->json());
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.multi/level', [
+            'query' => [
+                'examples' => ExamplesQuery::class,
+            ],
+        ]);
+    }
+}

--- a/tests/integration-larvavel.sh
+++ b/tests/integration-larvavel.sh
@@ -7,16 +7,13 @@
 #
 # This script is meant to be run on Travis CI
 
-echo "Prevent shallow repository error"
-git fetch --unshallow
-
 echo "Install Laravel"
-travis_retry composer create-project --quiet --prefer-dist "laravel/laravel" laravel
-cd laravel
+travis_retry composer create-project --quiet --prefer-dist "laravel/laravel" ../laravel
+cd ../laravel
 
 echo "Add package from source"
-sed -e 's|"type": "project",|&\n"repositories": [ { "type": "vcs", "url": "../" } ],|' -i composer.json
-travis_retry composer require --dev "rebing/graphql-laravel:dev-master#${TRAVIS_COMMIT}"
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../graphql-laravel" } ],|' -i composer.json
+travis_retry composer require --dev "rebing/graphql-laravel:*"
 
 echo "Publish vendor files"
 php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider"

--- a/tests/integration-larvavel.sh
+++ b/tests/integration-larvavel.sh
@@ -37,7 +37,7 @@ curl 'http://127.0.0.1:8001/graphql?query=%7BExampleQuery%7D' -sSfLv | grep 'The
 if [[ $? = 0 ]]; then
   echo "Example GraphQL query works 👍"
 else
-  echo "Example GraphQL query DID NOT work 👎"
+  echo "Example GraphQL query DID NOT work 🚨"
   curl 'http://127.0.0.1:8001/graphql?query=%7BExampleQuery%7D' -sSfLv
   cat storage/logs/*
   exit 1
@@ -49,7 +49,7 @@ curl 'http://127.0.0.1:8001/graphiql' -sSfLv | grep '<div id="graphiql">Loading.
 if [[ $? = 0 ]]; then
   echo "Can access GraphiQL 👍"
 else
-  echo "Cannot access GraphiQL 👎"
+  echo "Cannot access GraphiQL 🚨"
   curl 'http://127.0.0.1:8001/graphiql' -sSfLv
   cat storage/logs/*
   exit 1

--- a/tests/integration-lumen.sh
+++ b/tests/integration-lumen.sh
@@ -28,11 +28,15 @@ echo "Initialize configuration"
 sed -e 's|\$app->register(Rebing\\\GraphQL\\\GraphQLLumenServiceProvider::class);|$app->configure("graphql");\n&\n|' -i bootstrap/app.php
 
 
-echo "Make GraphQL ExampleQuery"
+echo "Make GraphQL queries"
 php artisan make:graphql:query ExampleQuery
+php artisan make:graphql:query ExampleMultiLevelQuery
 
 echo "Add ExampleQuery to config"
 sed -e "s|// 'example_query' => ExampleQuery::class,|\\\App\\\GraphQL\\\Query\\\ExampleQuery::class,|" -i config/graphql.php
+
+echo "Add ExampleMultiLevelQuery in a multi path level schema to the config"
+sed -e "s|^        'default' => \[|'multi/level' => ['query' => [ \\\App\\\GraphQL\\\Query\\\ExampleMultiLevelQuery::class]],\n&|" -i config/graphql.php
 
 echo "Use local copy of GraphiQL view"
 sed -e "s|'view'       => 'graphql::graphiql'|'view'       => 'vendor/graphql/graphiql'|" -i config/graphql.php
@@ -48,13 +52,14 @@ echo "Send GraphQL HTTP request to fetch ExampleQuery"
 curl 'http://127.0.0.1:8002/graphql?query=%7BExampleQuery%7D' -sSfLv | grep 'The ExampleQuery works'
 
 if [[ $? = 0 ]]; then
-  echo "Example GraphQL query works 👍"
+  echo "GraphQL ExampleQuery works 👍"
 else
-  echo "Example GraphQL query DID NOT work 👎"
+  echo "GraphQL ExampleQuery DID NOT work 🚨"
   curl 'http://127.0.0.1:8002/graphql?query=%7BExampleQuery%7D' -sSfLv
   cat storage/logs/*
   exit 1
 fi
+
 
 echo "Test accessing GraphiQL"
 curl 'http://127.0.0.1:8002/graphiql' -sSfLv | grep '<div id="graphiql">Loading...</div>'
@@ -62,8 +67,22 @@ curl 'http://127.0.0.1:8002/graphiql' -sSfLv | grep '<div id="graphiql">Loading.
 if [[ $? = 0 ]]; then
   echo "Can access GraphiQL 👍"
 else
-  echo "Cannot access GraphiQL 👎"
+  echo "Cannot access GraphiQL 🚨"
   curl 'http://127.0.0.1:8002/graphiql' -sSfLv
   cat storage/logs/*
   exit 1
 fi
+
+
+echo "Send GraphQL HTTP request to fetch ExampleMultiLevelQuery"
+curl 'http://127.0.0.1:8002/graphql/multi/level?query=%7BExampleMultiLevelQuery%7D' -sSfLv | grep 'The ExampleMultiLevelQuery works'
+
+if [[ $? = 0 ]]; then
+  echo "GraphQL ExampleMultiLevelQuery works 👍"
+else
+  echo "GraphQL ExampleMultiLevelQuery DID NOT work 🚨"
+  curl 'http://127.0.0.1:8002/graphql/multi/level?query=%7BExampleMultiLevelQuery%7D' -sSfLv
+  cat storage/logs/*
+  exit 1
+fi
+

--- a/tests/integration-lumen.sh
+++ b/tests/integration-lumen.sh
@@ -7,16 +7,13 @@
 #
 # This script is meant to be run on Travis CI
 
-echo "Prevent shallow repository error"
-git fetch --unshallow
-
 echo "Install Lumen"
-travis_retry composer create-project --quiet --prefer-dist "laravel/lumen" lumen
-cd lumen
+travis_retry composer create-project --quiet --prefer-dist "laravel/lumen" ../lumen
+cd ../lumen
 
 echo "Add package from source"
-sed -e 's|"type": "project",|&\n"repositories": [ { "type": "vcs", "url": "../" } ],|' -i composer.json
-travis_retry composer require --dev "rebing/graphql-laravel:dev-master#${TRAVIS_COMMIT}"
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../graphql-laravel" } ],|' -i composer.json
+travis_retry composer require --dev "rebing/graphql-laravel:*"
 
 echo "Install library"
 


### PR DESCRIPTION
## Summary
The existing code didn't work when accessing `/graphql/some/schema`,
only for `/graphql/some`.

With the current routing setup, the parameters to the route describe
the schema to use.

The existing code did check `request->count()` which is something else,
it contains e.g. query or JSON parameters and didn't return a correct
schema.

Route parameters are actually available in `$route[2]` which the code
now checks for.

This also means GraphiQL now finally fully works. The reason is that
GraphiQL sent multiple json parameters (operationName, query, variables)
which the code due to `request->all()` used to build the schema name
which never worked correctly.

It's not possible to write a test for this as orchestra/testbench
does not support Lumen currently.

Interestingly https://github.com/rebing/graphql-laravel/issues/236#issuecomment-486116951 was almost the solution though not entirely (the `->count()` check was still not correct).

### Links
- Fixes https://github.com/rebing/graphql-laravel/issues/204
- Fixes https://github.com/rebing/graphql-laravel/issues/236