### PR TITLE
[V1][ROUTES] Prefix named graphiql routes with `graphql`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/v1.23.0...v1)
 ------------
+### Changed
+- Prefix named GraphiQL routes with `graphql.` for compatibility with Folklore [\#360](https://github.com/rebing/graphql-laravel/pull/360)
 
 2019-06-10, v1.23.0
 -------------------

--- a/src/Rebing/GraphQL/routes.php
+++ b/src/Rebing/GraphQL/routes.php
@@ -153,7 +153,7 @@ if (config('graphql.graphiql.display', true)) {
         foreach (config('graphql.schemas') as $name => $schema) {
             $route = $router->get(
                 Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, '{graphql_schema?}'),
-                $graphiqlAction + ['as' => "graphiql.$name"]
+                $graphiqlAction + ['as' => "graphql.graphiql.$name"]
             );
             if (! is_lumen()) {
                 $route->where($name, $name);
@@ -161,14 +161,14 @@ if (config('graphql.graphiql.display', true)) {
 
             $route = $router->post(
                 Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, '{graphql_schema?}'),
-                $graphiqlAction + ['as' => "graphiql.$name.post"]
+                $graphiqlAction + ['as' => "graphql.graphiql.$name.post"]
             );
             if (! is_lumen()) {
                 $route->where($name, $name);
             }
         }
 
-        $router->get('/', $graphiqlAction + ['as' => 'graphiql']);
-        $router->post('/', $graphiqlAction + ['as' => 'graphiql.post']);
+        $router->get('/', $graphiqlAction + ['as' => 'graphql.graphiql']);
+        $router->post('/', $graphiqlAction + ['as' => 'graphql.graphiql.post']);
     });
 }


### PR DESCRIPTION
Compatibility with Folklore

Technically a breaking change but [named routes were only recently added](https://github.com/rebing/graphql-laravel/pull/264) and I don't think anyone jumped already onto them.