### PR TITLE
Remove abstract on `Type::fields` and provide default implementation

### DIFF
--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -36,7 +36,10 @@ abstract class Type extends Fluent
     /**
      * @return array<string,array|string|FieldDefinition>
      */
-    abstract public function fields(): array;
+    public function fields(): array
+    {
+        return [];
+    }
 
     public function interfaces(): array
     {


### PR DESCRIPTION
Turns out in reality some types don't require a custom fields() method,
e.g. Unions.

Follow-up adjustments for https://github.com/rebing/graphql-laravel/pull/357