### PR TITLE
Introduce TypeConvertible interface and supporting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ CHANGELOG
   - Although this could be consider a bug fix, it changes what columns are selected and if your code as a side-effect dependent on all columns being selected, it will break
 
 ### Added
+- `TypeConvertible` interface requiring to implement `toType(): \GraphQL\Type\Definition\Type`
+  Existing types are not affected because they already made use of the same method/signature, but custom Scalar GraphQL types work differently and benefit from the interface
 - `alias` is now also supported for relationships [\#367](https://github.com/rebing/graphql-laravel/pull/367)
 - `InputType` support class which eventually replace `$inputObject=true` [\#363](https://github.com/rebing/graphql-laravel/pull/363)
 - Support `DB::raw()` in `alias` fields

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,6 +46,8 @@ parameters:
         - '/Parameter #1 \$abstract of function app expects string\|null, mixed given/'
         # \Rebing\GraphQL\Support\ResolveInfoFieldsAndArguments::getValue
         - '/Access to an undefined property GraphQL\\Language\\AST\\ValueNode::\$value/'
+        # tests/Unit/GraphQLTest.php
+        - '/Call to an undefined method GraphQL\\Type\\Definition\\Type::getFields\(\)/'
         ### Larastan ; manually disable the ones reported
         #- '#Result of function abort \(void\) is used#'
         #- '#Call to an undefined method Illuminate\\Support\\HigherOrder#'

--- a/src/Exception/TypeNotFound.php
+++ b/src/Exception/TypeNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Exception;
+
+use RuntimeException;
+
+class TypeNotFound extends RuntimeException
+{
+}

--- a/src/Support/Contracts/TypeConvertible.php
+++ b/src/Support/Contracts/TypeConvertible.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support\Contracts;
+
+use GraphQL\Type\Definition\Type;
+
+interface TypeConvertible
+{
+    public function toType(): Type;
+}

--- a/src/Support/Facades/GraphQL.php
+++ b/src/Support/Facades/GraphQL.php
@@ -21,7 +21,7 @@ use GraphQL\Type\Definition\ObjectType;
  * @method static array getSchemas()
  * @method static void addSchema(string $name, Schema|array $schema)
  * @method static void addType(object|string $class, string $name = null)
- * @method static ObjectType objectType(ObjectType|array|string $type, array $opts = [])
+ * @method static Type objectType(ObjectType|array|string $type, array $opts = [])
  * @method static array formatError(Error $e)
  */
 class GraphQL extends Facade

--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -11,11 +11,12 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type as GraphqlType;
+use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 
 /**
  * @property string $name
  */
-abstract class Type extends Fluent
+abstract class Type extends Fluent implements TypeConvertible
 {
     /**
      * Set to `true` in your type when it should reflect an InputObject.

--- a/tests/Support/Types/MyCustomScalarString.php
+++ b/tests/Support/Types/MyCustomScalarString.php
@@ -7,11 +7,13 @@ namespace Rebing\GraphQL\Tests\Support\Types;
 use Exception;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\Node;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Language\AST\StringValueNode;
+use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 
-class MyCustomScalarString extends ScalarType
+class MyCustomScalarString extends ScalarType implements TypeConvertible
 {
     /**
      * Serializes an internal value to include in a response.
@@ -28,7 +30,7 @@ class MyCustomScalarString extends ScalarType
     }
 
     /**
-     * Parses an externally provided value (query variable) to use as an input
+     * Parses an externally provided value (query variable) to use as an input.
      *
      * In the case of an invalid value this method must throw an Exception
      *
@@ -44,7 +46,7 @@ class MyCustomScalarString extends ScalarType
     }
 
     /**
-     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input
+     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input.
      *
      * In the case of an invalid node or value this method must throw an Exception
      *
@@ -57,10 +59,15 @@ class MyCustomScalarString extends ScalarType
      */
     public function parseLiteral($valueNode, ?array $variables = null)
     {
-        if (!$valueNode instanceof StringValueNode) {
-            throw new InvariantViolation('Expected node of type ' . StringValueNode::class . ' , got ' . get_class($valueNode));
+        if (! $valueNode instanceof StringValueNode) {
+            throw new InvariantViolation('Expected node of type '.StringValueNode::class.' , got '.get_class($valueNode));
         }
 
         return $valueNode->value;
+    }
+
+    public function toType(): Type
+    {
+        return new static();
     }
 }

--- a/tests/Unit/ScalarTypeTest.php
+++ b/tests/Unit/ScalarTypeTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Unit;
 
-use Error;
 use Rebing\GraphQL\Tests\TestCase;
 use Rebing\GraphQL\Tests\Support\Queries\ReturnScalarQuery;
 use Rebing\GraphQL\Tests\Support\Types\MyCustomScalarString;
 
 class ScalarTypeTest extends TestCase
 {
-
     public function testScalarType(): void
     {
         $query = <<<'GRAPHQL'
@@ -20,11 +18,14 @@ class ScalarTypeTest extends TestCase
 }
 GRAPHQL;
 
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Call to undefined method Rebing\GraphQL\Tests\Support\Types\MyCustomScalarString::toType()');
+        $result = $this->graphql($query);
 
-        $this->graphql($query);
-
+        $expectedResult = [
+            'data' => [
+                'returnScalar' => 'just a string',
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
- Clarifies use of the defined types and necessary for `Scalar` types
- Increases compatibility with Folklore lib (should be a simple namespace replace and done)