### PR TITLE
Make support for scalar types more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
   - Although this could be consider a bug fix, it changes what columns are selected and if your code as a side-effect dependent on all columns being selected, it will break
 
 ### Added
+- New `make:graphql:scalar` command and add more information regarding scalars to the readme
 - `TypeConvertible` interface requiring to implement `toType(): \GraphQL\Type\Definition\Type`
   Existing types are not affected because they already made use of the same method/signature, but custom Scalar GraphQL types work differently and benefit from the interface
 - `alias` is now also supported for relationships [\#367](https://github.com/rebing/graphql-laravel/pull/367)

--- a/Readme.md
+++ b/Readme.md
@@ -112,6 +112,7 @@ To work this around:
 - [Type relationship query](#type-relationship-query)
 - [Pagination](#pagination)
 - [Batching](#batching)
+- [Scalar Types](#scalar-types)
 - [Enums](#enums)
 - [Unions](#unions)
 - [Interfaces](#interfaces)
@@ -1070,6 +1071,25 @@ within a certain interval of time.
 
 There are tools that help with this and can handle the batching for you, e.g [Apollo](http://www.apollodata.com/)
 
+### Scalar Types
+
+GraphQL comes with built-in scalar types for string, int, boolean, etc. It's possible to create custom scalar types to special purpose fields.
+
+An example could be a link: instead of using `Type::string()` you could create a scalar type `Link` and reference it with `GraphQL::type('Link')`.
+
+The benefits would be:
+
+- a dedicated description so you can give more meaning/purpose to a field than just call it a string type
+- explicit conversion logic for the followig steps:
+  - converting from the internal logic to the serialized GraphQL output (`serialize`)
+  - query/field input argument conversion (`parseLiteral`)
+  - when passed as variables to your query (`parseValue`)
+
+This also means validation logic can be added within these methods to _ensure_ that the value delivered/received is e.g. a true link.
+
+A scalar type has to implement all the methods; you can quick start this with `artisan make:graphql:scalar <typename>`. Then just add the scalar to your existing types in the schema.
+
+For more advanced use, please [refer to the official documentation regarding scalar types](https://webonyx.github.io/graphql-php/type-system/scalar-types).
 
 ### Enums
 

--- a/src/Console/ScalarMakeCommand.php
+++ b/src/Console/ScalarMakeCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ScalarMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:graphql:scalar {name}';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new GraphQL scalar type class';
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Scalar';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/scalar.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\GraphQL\Scalars';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        return $this->replaceType($stub, $name);
+    }
+
+    /**
+     * Replace the namespace for the given stub.
+     *
+     * @param string $stub
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function replaceType(string $stub, string $name): string
+    {
+        preg_match('/([^\\\]+)$/', $name, $matches);
+        $stub = str_replace(
+            'DummyType',
+            $matches[1],
+            $stub
+        );
+
+        return $stub;
+    }
+}

--- a/src/Console/stubs/scalar.stub
+++ b/src/Console/stubs/scalar.stub
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DummyNamespace;
+
+use Exception;
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\Node;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\ScalarType;
+use Rebing\GraphQL\Support\Contracts\TypeConvertible;
+
+class DummyClass extends ScalarType implements TypeConvertible
+{
+    /**
+     * @var string
+     */
+    public $name = 'DummyType';
+
+    /**
+     * @var string
+     */
+    public $description = '';
+
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     *
+     * @throws Error
+     */
+    public function serialize($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Parses an externally provided value (query variable) to use as an input.
+     *
+     * In the case of an invalid value this method must throw an Exception
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     *
+     * @throws Error
+     */
+    public function parseValue($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input.
+     *
+     * In the case of an invalid node or value this method must throw an Exception
+     *
+     * @param Node $valueNode
+     * @param mixed[]|null $variables
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     */
+    public function parseLiteral($valueNode, ?array $variables = null)
+    {
+        return null;
+    }
+
+    public function toType(): Type
+    {
+        return new static();
+    }
+}

--- a/tests/Unit/Console/ScalarMakeCommandTest.php
+++ b/tests/Unit/Console/ScalarMakeCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\Console;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Rebing\GraphQL\Console\ScalarMakeCommand;
+
+class ScalarMakeCommandTest extends TestCase
+{
+    public function testCommand(): void
+    {
+        $filesystemMock = $this
+            ->getMockBuilder(Filesystem::class)
+            ->setMethods([
+                'isDirectory',
+                'makeDirectory',
+                'put',
+            ])
+            ->getMock();
+        $filesystemMock
+            ->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->callback(function (string $path): bool {
+                    $this->assertRegExp('|laravel/app/GraphQL/Scalars/ExampleScalar.php|', $path);
+
+                    return true;
+                }),
+                $this->callback(function (string $contents): bool {
+                    $this->assertRegExp('/class ExampleScalar extends ScalarType implements TypeConvertible/', $contents);
+                    $this->assertRegExp("/public \\\$name = 'ExampleScalar';/", $contents);
+
+                    return true;
+                })
+            );
+        $this->instance(Filesystem::class, $filesystemMock);
+
+        $command = $this->app->make(ScalarMakeCommand::class);
+
+        $tester = $this->runCommand($command, [
+            'name' => 'ExampleScalar',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertRegExp('/Scalar created successfully/', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
It was always supported but so far there were not much examples or
guides how to do it:

- add make command generator `make:graphql:scalar` + stub with the methods
- quick intro in the readme