### PR TITLE
Remove Fluent dependency on core `Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ CHANGELOG
   - Previously the initial query arguments would be used everywhere
 
 ### Removed
+- Removed `\Fluent` dependency on `\Rebing\GraphQL\Support\Type`
 - Unused static field `\Rebing\GraphQL\Support\Type::$instances`
 - Unused field `\Rebing\GraphQL\Support\Type::$unionType`
 

--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Support;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Fluent;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -16,8 +15,9 @@ use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 /**
  * @property string $name
  */
-abstract class Type extends Fluent implements TypeConvertible
+abstract class Type implements TypeConvertible
 {
+    protected $attributes = [];
     /**
      * Set to `true` in your type when it should reflect an InputObject.
      * @var bool
@@ -174,5 +174,10 @@ abstract class Type extends Fluent implements TypeConvertible
         $attributes = $this->getAttributes();
 
         return isset($attributes[$key]);
+    }
+
+    public function __set(string $key, $value): void
+    {
+        $this->attributes[$key] = $value;
     }
 }


### PR DESCRIPTION
This is an experiment, because it seems the dependency on Fluent doesn't
bring much to the table.

At least according to the test suite, the only missing piece was a
property __get shim.