### PR TITLE
 Fix batch request combined with file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ CHANGELOG
 - Replace global helper `is_lumen` with static class call `\Rebing\GraphQL\Helpers::isLumen`
 
 ### Fixed
+- File uploads now correctly work with batched requests [\#397](https://github.com/rebing/graphql-laravel/pull/397)
 - Path multi-level support for Schemas works again [\#358](https://github.com/rebing/graphql-laravel/pull/358)
 - SelectFields correctly passes field arguments to the custom query [\#327](https://github.com/rebing/graphql-laravel/pull/327)
   - This also applies to privacy checks on fields, the callback now receives the field arguments too

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,7 +49,9 @@ parameters:
         - '/Call to an undefined method Mockery\\/'
         - '/Parameter #2 \$replace of function str_replace expects array\|string, string\|null given/'
         # tests/Unit/UploadTests/UploadMultipleFilesMutation.php
-        - '/Anonymous function should return string but returns bool\|string/'
+        - '/Anonymous function should return string but returns string\|false/'
+        # tests/Unit/UploadTests/UploadSingleFileMutation.php
+        - '/Method Rebing\\GraphQL\\Tests\\Unit\\UploadTests\\UploadSingleFileMutation::resolve\(\) should return string but returns string\|false/'
         ### Larastan ; manually disable the ones reported
         #- '#Result of function abort \(void\) is used#'
         #- '#Call to an undefined method Illuminate\\Support\\HigherOrder#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,6 +48,8 @@ parameters:
         - '/Call to an undefined method GraphQL\\Type\\Definition\\Type::getFields\(\)/'
         - '/Call to an undefined method Mockery\\/'
         - '/Parameter #2 \$replace of function str_replace expects array\|string, string\|null given/'
+        # tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+        - '/Anonymous function should return string but returns bool\|string/'
         ### Larastan ; manually disable the ones reported
         #- '#Result of function abort \(void\) is used#'
         #- '#Call to an undefined method Illuminate\\Support\\HigherOrder#'

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -40,7 +40,7 @@ class GraphQLController extends Controller
 
         // If a singular query was not found, it means the queries are in batch
         $isBatch = ! $request->has('query');
-        $inputs = $isBatch ? $request->all() : [$request->all()];
+        $inputs = $isBatch ? $request->input() : [$request->input()];
 
         $completedQueries = [];
 

--- a/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+++ b/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\UploadTests;
+
+use GraphQL\Type\Definition\Type;
+use Illuminate\Http\Testing\File;
+use Rebing\GraphQL\Support\Mutation;
+use Rebing\GraphQL\Support\UploadType;
+
+class UploadMultipleFilesMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'uploadMultipleFiles',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::listOf(Type::nonNull(Type::string())));
+    }
+
+    public function args(): array
+    {
+        return [
+            'files' => [
+                'type' => Type::listOf(UploadType::getInstance()),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): array
+    {
+        return array_map(
+            function (File $file): string {
+                return $file->get();
+            },
+            $args['files']
+        );
+    }
+}

--- a/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+++ b/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
@@ -33,7 +33,7 @@ class UploadMultipleFilesMutation extends Mutation
     {
         return array_map(
             function (File $file): string {
-                return $file->get();
+                return file_get_contents($file->getPathname());
             },
             $args['files']
         );

--- a/tests/Unit/UploadTests/UploadSingleFileMutation.php
+++ b/tests/Unit/UploadTests/UploadSingleFileMutation.php
@@ -30,6 +30,6 @@ class UploadSingleFileMutation extends Mutation
 
     public function resolve($root, $args): string
     {
-        return $args['file']->get();
+        return file_get_contents($args['file']->getPathname());
     }
 }

--- a/tests/Unit/UploadTests/UploadSingleFileMutation.php
+++ b/tests/Unit/UploadTests/UploadSingleFileMutation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\UploadTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+use Rebing\GraphQL\Support\UploadType;
+
+class UploadSingleFileMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'uploadSingleFile',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'file' => [
+                'type' => UploadType::getInstance(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args): string
+    {
+        return $args['file']->get();
+    }
+}

--- a/tests/Unit/UploadTests/UploadTest.php
+++ b/tests/Unit/UploadTests/UploadTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\UploadTests;
+
+use Illuminate\Http\UploadedFile;
+use Rebing\GraphQL\Tests\TestCase;
+
+class UploadTest extends TestCase
+{
+    public function testSingleFile(): void
+    {
+        $fileToUpload = UploadedFile::fake()->create('file.txt');
+        fwrite($fileToUpload->tempFile, "This is the\nuploaded\ndata");
+
+        $result = $this
+            ->call(
+                'POST',
+                '/graphql',
+                // $parameters
+                [
+                    'operations' => json_encode([
+                        'query' => 'mutation($file: Upload!) { uploadSingleFile(file: $file) }',
+                        'variables' => [
+                            'file' => null,
+                        ],
+                    ]),
+                    'map' => json_encode([
+                        '0' => ['variables.file'],
+                    ]),
+                ],
+                // $cookies
+                [],
+                // $files
+                [
+                    '0' => $fileToUpload,
+
+                ],
+                // $server
+                [
+                    'CONTENT_TYPE' => 'multipart/form-data',
+                ]
+            )
+            ->json();
+
+        $expectedResult = [
+            'data' => [
+                'uploadSingleFile' => "This is the\nuploaded\ndata",
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testMultipleFiles(): void
+    {
+        $file1ToUpload = UploadedFile::fake()->create('file1.txt');
+        fwrite($file1ToUpload->tempFile, 'File 1 to upload');
+
+        $file2ToUpload = UploadedFile::fake()->create('file2.txt');
+        fwrite($file2ToUpload->tempFile, 'File 2 to upload');
+
+        $result = $this
+            ->call(
+                'POST',
+                '/graphql',
+                // $parameters
+                [
+                    'operations' => json_encode([
+                        'query' => 'mutation($files: [Upload!]!) { uploadMultipleFiles(files: $files) }',
+                        'variables' => [
+                            'files' => [null, null],
+                        ],
+                    ]),
+                    'map' => json_encode([
+                        '0' => ['variables.files.0'],
+                        '1' => ['variables.files.1'],
+                    ]),
+                ],
+                // $cookies
+                [],
+                // $files
+                [
+                    '0' => $file1ToUpload,
+                    '1' => $file2ToUpload,
+
+                ],
+                // $server
+                [
+                    'CONTENT_TYPE' => 'multipart/form-data',
+                ]
+            )
+            ->json();
+
+        $expectedResult = [
+            'data' => [
+                'uploadMultipleFiles' => [
+                    'File 1 to upload',
+                    'File 2 to upload',
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testBatchUploads(): void
+    {
+        $file1ToUpload = UploadedFile::fake()->create('file1.txt');
+        fwrite($file1ToUpload->tempFile, 'File 1 to upload');
+
+        $file2ToUpload = UploadedFile::fake()->create('file2.txt');
+        fwrite($file2ToUpload->tempFile, 'File 2 to upload');
+
+        $file3ToUpload = UploadedFile::fake()->create('file3.txt');
+        fwrite($file3ToUpload->tempFile, 'File 3 to upload');
+
+        $result = $this
+            ->call(
+                'POST',
+                '/graphql',
+                // $parameters
+                [
+                    'operations' => json_encode([
+                        [
+                            'query' => 'mutation($file: Upload!) { uploadSingleFile(file: $file) }',
+                            'variables' => [
+                                'file' => null,
+                            ],
+                        ],
+                        [
+                            'query' => 'mutation($files: [Upload!]!) { uploadMultipleFiles(files: $files) }',
+                            'variables' => [
+                                'files' => [null, null],
+                            ],
+                        ],
+                    ]),
+                    'map' => json_encode([
+                        '0' => ['0.variables.file'],
+                        '1' => ['1.variables.files.0'],
+                        '2' => ['1.variables.files.1'],
+                    ]),
+                ],
+                // $cookies
+                [],
+                // $files
+                [
+                    '0' => $file1ToUpload,
+                    '1' => $file2ToUpload,
+                    '2' => $file3ToUpload,
+
+                ],
+                // $server
+                [
+                    'CONTENT_TYPE' => 'multipart/form-data',
+                ]
+            )
+            ->json();
+
+        $expectedResult = [
+            [
+                'data' => [
+                    'uploadSingleFile' => 'File 1 to upload',
+                ],
+            ],
+            [
+                'data' => [
+                    'uploadMultipleFiles' => [
+                            'File 2 to upload',
+                            'File 3 to upload',
+                        ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                UploadMultipleFilesMutation::class,
+                UploadSingleFileMutation::class,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
`->all()` returns the input _as well_ as the files in single array.

A non-batch request has the input keys `query` and optional
`operationName` and `variables`.

Even when `->all()` is used with non-batch and file uploads, the files
are inter-mixed with the resulting arrays using array offsets 0, 1, …

So a resulting input would look like:
```
[
  'query' => …,
  'variables' => …,
  '0' => uploaded file,
]
```

This is actually undesired but had no-side effects for non-batch
requests, as no one was looking at/accessing the 0 offset for example.

(Uploaded files are transplanted _within_ the `variables` anyway).

Now with batch requests, a conflict arises because the input itself is
an array (of queries / operations) _as well_ as the files:
```
[
  '0' => [
    'query' => …,
    'variables' => …,
  ],
  '0' => uploaded file,
```

The end result being that the files overwrite the batch operations and
thus completely breaking "batch queries plus file uploads".

The solution is to _just_ process the `->input()` for GraphQL; the
files are never needed directly here as the middleware transplants
them always within the `variables` within each batched request.

### Bonus points
Added file upload tests covering all variations per the spec at https://github.com/jaydenseric/graphql-multipart-request-spec