### PR TITLE
Treat UploadType like any regular type which has to be registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/v1.24.0...master)
 ------------
 ## Breaking changes
+- The `UploadType` now has to be added manually to the `types` in your schema if you want to use it
+  - The `::getInstance()` method is gone
 - The order and arguments/types for resolvers has changed:
   - before: `resolve($root, $array, SelectFields $selectFields, ResolveInfo $info)`
   - after: `resolve($root, $array, $context, ResolveInfo $info, Closure $getSelectFields)`

--- a/Readme.md
+++ b/Readme.md
@@ -518,9 +518,11 @@ public function validationErrorMessages(array $args = []): array
 
 #### File uploads
 
-For uploading new files just use `UploadType`. This support of uploading files is
-based on https://github.com/jaydenseric/graphql-multipart-request-spec
-so you have to upload them as multipart form:
+This library provides a middleware compliant with the spec at https://github.com/jaydenseric/graphql-multipart-request-spec .
+
+You have to add the `\Rebing\GraphQL\Support\UploadType` first to your `config/graphql` schema types definition.
+
+It is relevant that you send the request as `multipart/form-data`:
 
 > **WARNING:** when you are uploading files, Laravel will use FormRequest - it means
 > that middlewares which are changing request, will not have any effect.
@@ -534,7 +536,6 @@ use Closure;
 use GraphQL;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
-use Rebing\GraphQL\Support\UploadType;
 use Rebing\GraphQL\Support\Mutation;
 
 class UserProfilePhotoMutation extends Mutation
@@ -553,7 +554,7 @@ class UserProfilePhotoMutation extends Mutation
         return [
             'profilePicture' => [
                 'name' => 'profilePicture',
-                'type' => UploadType::getInstance(),
+                'type' => GraphQL::type('Upload'),
                 'rules' => ['required', 'image', 'max:1500'],
             ],
         ];

--- a/src/Support/UploadType.php
+++ b/src/Support/UploadType.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Support;
 
 use GraphQL\Error\Error;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ScalarType;
+use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 
-class UploadType extends ScalarType
+class UploadType extends ScalarType implements TypeConvertible
 {
     /**
      * @var string
@@ -52,13 +54,8 @@ class UploadType extends ScalarType
         throw new Error('`Upload` cannot be hardcoded in query, be sure to conform to GraphQL multipart request specification. Instead got: '.$valueNode->kind, [$valueNode]);
     }
 
-    public static function getInstance()
+    public function toType(): Type
     {
-        static $inst = null;
-        if ($inst === null) {
-            $inst = new self();
-        }
-
-        return $inst;
+        return new static();
     }
 }

--- a/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+++ b/tests/Unit/UploadTests/UploadMultipleFilesMutation.php
@@ -7,7 +7,7 @@ namespace Rebing\GraphQL\Tests\Unit\UploadTests;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Http\Testing\File;
 use Rebing\GraphQL\Support\Mutation;
-use Rebing\GraphQL\Support\UploadType;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class UploadMultipleFilesMutation extends Mutation
 {
@@ -24,7 +24,7 @@ class UploadMultipleFilesMutation extends Mutation
     {
         return [
             'files' => [
-                'type' => Type::listOf(UploadType::getInstance()),
+                'type' => Type::listOf(GraphQL::type('Upload')),
             ],
         ];
     }

--- a/tests/Unit/UploadTests/UploadSingleFileMutation.php
+++ b/tests/Unit/UploadTests/UploadSingleFileMutation.php
@@ -6,7 +6,7 @@ namespace Rebing\GraphQL\Tests\Unit\UploadTests;
 
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
-use Rebing\GraphQL\Support\UploadType;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class UploadSingleFileMutation extends Mutation
 {
@@ -23,7 +23,7 @@ class UploadSingleFileMutation extends Mutation
     {
         return [
             'file' => [
-                'type' => UploadType::getInstance(),
+                'type' => GraphQL::type('Upload'),
             ],
         ];
     }

--- a/tests/Unit/UploadTests/UploadTest.php
+++ b/tests/Unit/UploadTests/UploadTest.php
@@ -6,6 +6,7 @@ namespace Rebing\GraphQL\Tests\Unit\UploadTests;
 
 use Illuminate\Http\UploadedFile;
 use Rebing\GraphQL\Tests\TestCase;
+use Rebing\GraphQL\Support\UploadType;
 
 class UploadTest extends TestCase
 {
@@ -183,6 +184,9 @@ class UploadTest extends TestCase
                 UploadMultipleFilesMutation::class,
                 UploadSingleFileMutation::class,
             ],
+        ]);
+        $app['config']->set('graphql.types', [
+            UploadType::class,
         ]);
     }
 }


### PR DESCRIPTION
Previously `UploadType::getInstance()` kind of took care of not having to register the type.

But this approach clashes [with possible performance optimizations](https://github.com/rebing/graphql-laravel/pull/394) because the type is handled in a special way.

This PR unifies this so it behaves like any other type. This however means:
- **if you want to use the `Upload` type, you have to register it manually in your configuration**

Spin-off from https://github.com/rebing/graphql-laravel/pull/394#discussion_r301915135