### PR TITLE
Introduce ability to lazy load types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,15 @@ install:
 script:
   - if [[ $STATIC_ANALYSER = 1 ]]; then composer phpstan; fi
   - if [[ $CODE_COVERAGE = 0 ]]; then vendor/bin/phpunit --colors=always --verbose; fi
-  - if [[ $CODE_COVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml; fi
+  - |
+    if [[ $CODE_COVERAGE = 1 ]]; then
+      phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml
+      bash <(curl -s https://codecov.io/bash) -cF lazyload-off
+    fi
+  - |
+    if [[ $CODE_COVERAGE = 1 ]]; then
+      TESTS_ENABLE_LAZYLOAD_TYPES=1 phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml
+      bash <(curl -s https://codecov.io/bash) -cF lazyload-on
+    fi
   - if [[ $INSTALL_LARAVEL = 1 ]]; then export -f travis_retry ; tests/integration-larvavel.sh; fi
   - if [[ $INSTALL_LUMEN = 1 ]]; then export -f travis_retry ; tests/integration-lumen.sh; fi
-
-after_success:
- - if [[ $CODE_COVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
   - Although this could be consider a bug fix, it changes what columns are selected and if your code as a side-effect dependent on all columns being selected, it will break
 
 ### Added
+- Added support for lazy loading types, can improve performance on large type systems [\#405](https://github.com/rebing/graphql-laravel/pull/405)
 - A migration guide for the Folklore library as part of the readme
 - New `make:graphql:input` command
 - New `make:graphql:union` command

--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,7 @@ To work this around:
 - [Field deprecation](#field-deprecation)
 - [Default Field Resolver](#default-field-resolver)
 - [Migrating from Folklore](#migrating-from-folklore)
+- [Performance considerations](#performance-considerations)
 
 ### Schemas
 
@@ -1560,3 +1561,24 @@ The following is not a bullet-proof list but should serve as a guide. It's not a
   - the signature of the method parseLiteral changed (due to upgrade of the webonxy library):
     - from `public function parseLiteral($ast)`
     - to `public function parseLiteral($valueNode, ?array $variables = null)`
+
+## Performance considerations
+
+### Lazy loading of types
+If your schema has a lots of types, loading them all on each request may incur
+a noticable latency overhead due to all types being eager loaded by default.
+
+By changing the configuration `lazyload_types` to `true`, types will be lazy
+loaded and, depending on your use-cae, may improve performance.
+
+However there is a restriction: you **cannot** use aliasing with your types,
+the `name` of a type must be the same name you registered the type under.
+
+I.e. you cannot have a query class `ExampleQuery` with the `$name` property
+`example` but register it with a different one; this will **not** work:
+
+```php
+'query' => [
+    'aliasedEXample' => ExampleQuery::class,
+],
+```

--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,6 @@ use example\Mutation\ExampleMutation;
 use example\Type\ExampleRelationType;
 
 return [
-
     // The prefix for routes
     'prefix' => 'graphql',
 
@@ -107,7 +106,7 @@ return [
                 // 'example_mutation'  => ExampleMutation::class,
             ],
             'middleware' => [],
-            'method'     => ['get', 'post'],
+            'method' => ['get', 'post'],
         ],
     ],
 
@@ -127,7 +126,7 @@ return [
 
     // The types will be loaded on demand. Default is to load all types on each request
     // Can increase performance on schemes with many types
-    // Requires the config type key to match the type class name property
+    // Presupposes the config type key to match the type class name property
     'lazyload_types' => false,
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.
@@ -148,7 +147,7 @@ return [
     'errors_handler' => ['\Rebing\GraphQL\GraphQL', 'handleErrors'],
 
     // You can set the key, which will be used to retrieve the dynamic variables
-    'params_key'    => 'variables',
+    'params_key' => 'variables',
 
     /*
      * Options to limit the query complexity and depth. See the doc
@@ -156,8 +155,8 @@ return [
      * for details. Disabled by default.
      */
     'security' => [
-        'query_max_complexity'  => null,
-        'query_max_depth'       => null,
+        'query_max_complexity' => null,
+        'query_max_depth' => null,
         'disable_introspection' => false,
     ],
 
@@ -171,11 +170,11 @@ return [
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */
     'graphiql' => [
-        'prefix'     => '/graphiql',
+        'prefix' => '/graphiql',
         'controller' => \Rebing\GraphQL\GraphQLController::class.'@graphiql',
         'middleware' => [],
-        'view'       => 'graphql::graphiql',
-        'display'    => env('ENABLE_GRAPHIQL', true),
+        'view' => 'graphql::graphiql',
+        'display' => env('ENABLE_GRAPHIQL', true),
     ],
 
     /*

--- a/config/config.php
+++ b/config/config.php
@@ -125,6 +125,10 @@ return [
         // 'relation_example'  => ExampleRelationType::class,
     ],
 
+    // The types will be loaded on demand. Default is to load all types on each request
+    // Can increase performance on schemes with many types
+    // Requires the config type key to match the type class name property
+    'lazyload_types' => false,
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.
     // Typically:

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,7 @@ use example\Mutation\ExampleMutation;
 use example\Type\ExampleRelationType;
 
 return [
+
     // The prefix for routes
     'prefix' => 'graphql',
 
@@ -106,7 +107,7 @@ return [
                 // 'example_mutation'  => ExampleMutation::class,
             ],
             'middleware' => [],
-            'method' => ['get', 'post'],
+            'method'     => ['get', 'post'],
         ],
     ],
 
@@ -128,6 +129,7 @@ return [
     // Can increase performance on schemes with many types
     // Presupposes the config type key to match the type class name property
     'lazyload_types' => false,
+
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.
     // Typically:
@@ -147,7 +149,7 @@ return [
     'errors_handler' => ['\Rebing\GraphQL\GraphQL', 'handleErrors'],
 
     // You can set the key, which will be used to retrieve the dynamic variables
-    'params_key' => 'variables',
+    'params_key'    => 'variables',
 
     /*
      * Options to limit the query complexity and depth. See the doc
@@ -155,8 +157,8 @@ return [
      * for details. Disabled by default.
      */
     'security' => [
-        'query_max_complexity' => null,
-        'query_max_depth' => null,
+        'query_max_complexity'  => null,
+        'query_max_depth'       => null,
         'disable_introspection' => false,
     ],
 
@@ -170,11 +172,11 @@ return [
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */
     'graphiql' => [
-        'prefix' => '/graphiql',
+        'prefix'     => '/graphiql',
         'controller' => \Rebing\GraphQL\GraphQLController::class.'@graphiql',
         'middleware' => [],
-        'view' => 'graphql::graphiql',
-        'display' => env('ENABLE_GRAPHIQL', true),
+        'view'       => 'graphql::graphiql',
+        'display'    => env('ENABLE_GRAPHIQL', true),
     ],
 
     /*

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -74,21 +74,17 @@ class GraphQL
         ]);
 
         return new Schema([
-            'typeLoader' => config('graphql.lazyload_types', false) ? function ($name) {
-                return $this->type($name);
-            } : null,
-            'types' => function () use ($schema) {
             'query'         => $query,
             'mutation'      => ! empty($schemaMutation) ? $mutation : null,
             'subscription'  => ! empty($schemaSubscription) ? $subscription : null,
+            'types'         => function () use ($schema) {
                 $types = [];
                 $schemaTypes = Arr::get($schema, 'types', []);
 
-                if (count($schemaTypes)) {
+                if ($schemaTypes) {
                     foreach ($schemaTypes as $name => $type) {
-                        $objectType = $this->objectType($type, is_numeric($name) ? [] : [
-                            'name' => $name,
-                        ]);
+                        $opts = is_numeric($name) ? [] : ['name' => $name];
+                        $objectType = $this->objectType($type, $opts);
                         $this->typesInstances[$name] = $objectType;
                         $types[] = $objectType;
                     }
@@ -100,6 +96,11 @@ class GraphQL
 
                 return $types;
             },
+            'typeLoader'    => config('graphql.lazyload_types', false)
+                ? function ($name) {
+                    return $this->type($name);
+                }
+                : null,
         ]);
     }
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -74,13 +74,13 @@ class GraphQL
         ]);
 
         return new Schema([
-            'query' => $query,
-            'mutation' => ! empty($schemaMutation) ? $mutation : null,
-            'subscription' => ! empty($schemaSubscription) ? $subscription : null,
             'typeLoader' => config('graphql.lazyload_types', false) ? function ($name) {
                 return $this->type($name);
             } : null,
             'types' => function () use ($schema) {
+            'query'         => $query,
+            'mutation'      => ! empty($schemaMutation) ? $mutation : null,
+            'subscription'  => ! empty($schemaSubscription) ? $subscription : null,
                 $types = [];
                 $schemaTypes = Arr::get($schema, 'types', []);
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -75,11 +75,11 @@ class GraphQL
 
         return new Schema([
             'query' => $query,
-            'mutation' => !empty($schemaMutation) ? $mutation : null,
-            'subscription' => !empty($schemaSubscription) ? $subscription : null,
+            'mutation' => ! empty($schemaMutation) ? $mutation : null,
+            'subscription' => ! empty($schemaSubscription) ? $subscription : null,
             'typeLoader' => config('graphql.lazyload_types', false) ? function ($name) {
-                    return $this->type($name);
-            }: null, 
+                return $this->type($name);
+            } : null,
             'types' => function () use ($schema) {
                 $types = [];
                 $schemaTypes = Arr::get($schema, 'types', []);
@@ -163,7 +163,7 @@ class GraphQL
 
     public function type(string $name, bool $fresh = false): Type
     {
-        if (!isset($this->types[$name])) {
+        if (! isset($this->types[$name])) {
             $error = "Type $name not found.";
 
             if (config('graphql.lazyload_types', false)) {

--- a/tests/Support/Objects/ExampleType2.php
+++ b/tests/Support/Objects/ExampleType2.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class ExampleType2 extends GraphQLType
+{
+    protected $attributes = [
+        'name'        => 'Example2',
+        'description' => 'An example',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'test' => [
+                'type'        => Type::string(),
+                'description' => 'A test field',
+            ],
+            'test_validation' => ExampleValidationField::class,
+        ];
+    }
+}

--- a/tests/Support/Objects/ExamplesConfigAliasQuery.php
+++ b/tests/Support/Objects/ExamplesConfigAliasQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+
+class ExamplesConfigAliasQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'examplesAlias',
+    ];
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('ExampleConfigAlias'));
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => ['name' => 'index', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $data = include __DIR__.'/data.php';
+
+        if (isset($args['index'])) {
+            return [
+                $data[$args['index']],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -20,6 +20,14 @@ return [
         }
     ',
 
+    'examplesWithConfigAlias' => '
+        query examplesConfigAlias($index: Int) {
+            examplesConfigAlias(index: $index) {
+                test
+            }
+        }
+    ',
+
     'examplesWithVariables' => '
         query QueryExamplesVariables($index: Int) {
             examples(index: $index) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,6 +45,10 @@ class TestCase extends BaseTestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        if (env('TESTS_ENABLE_LAZYLOAD_TYPES') === '1') {
+            $app['config']->set('graphql.lazyload_types', true);
+        }
+
         $app['config']->set('graphql.schemas.default', [
             'query' => [
                 'examples'           => ExamplesQuery::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,12 +18,14 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleType;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleType2;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesFilteredQuery;
 use Rebing\GraphQL\Tests\Support\Objects\UpdateExampleMutation;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesPaginationQuery;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesConfigAliasQuery;
 
 class TestCase extends BaseTestCase
 {
@@ -45,10 +47,11 @@ class TestCase extends BaseTestCase
     {
         $app['config']->set('graphql.schemas.default', [
             'query' => [
-                'examples'           => ExamplesQuery::class,
-                'examplesAuthorize'  => ExamplesAuthorizeQuery::class,
+                'examples' => ExamplesQuery::class,
+                'examplesAuthorize' => ExamplesAuthorizeQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
-                'examplesFiltered'   => ExamplesFilteredQuery::class,
+                'examplesFiltered' => ExamplesFilteredQuery::class,
+                'examplesConfigAlias' => ExamplesConfigAliasQuery::class,
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class,
@@ -58,6 +61,7 @@ class TestCase extends BaseTestCase
         $app['config']->set('graphql.schemas.custom', [
             'query' => [
                 'examplesCustom' => ExamplesQuery::class,
+
             ],
             'mutation' => [
                 'updateExampleCustom' => UpdateExampleMutation::class,
@@ -65,7 +69,8 @@ class TestCase extends BaseTestCase
         ]);
 
         $app['config']->set('graphql.types', [
-            'Example'            => ExampleType::class,
+            'Example' => ExampleType::class,
+            'ExampleConfigAlias' => ExampleType2::class,
             'ExampleFilterInput' => ExampleFilterInputType::class,
         ]);
 
@@ -218,7 +223,8 @@ class TestCase extends BaseTestCase
      */
     private function formatSafeTrace(array $trace): string
     {
-        return implode("\n",
+        return implode(
+            "\n",
             array_map(function (array $row, int $index): string {
                 $line = "#$index ";
                 $line .= $row['file'] ?? '';
@@ -233,6 +239,7 @@ class TestCase extends BaseTestCase
                 }
 
                 return $line;
-            }, $trace, array_keys($trace)));
+            }, $trace, array_keys($trace))
+        );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,10 +47,10 @@ class TestCase extends BaseTestCase
     {
         $app['config']->set('graphql.schemas.default', [
             'query' => [
-                'examples' => ExamplesQuery::class,
-                'examplesAuthorize' => ExamplesAuthorizeQuery::class,
+                'examples'           => ExamplesQuery::class,
+                'examplesAuthorize'  => ExamplesAuthorizeQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
-                'examplesFiltered' => ExamplesFilteredQuery::class,
+                'examplesFiltered'   => ExamplesFilteredQuery::class,
                 'examplesConfigAlias' => ExamplesConfigAliasQuery::class,
             ],
             'mutation' => [
@@ -61,7 +61,6 @@ class TestCase extends BaseTestCase
         $app['config']->set('graphql.schemas.custom', [
             'query' => [
                 'examplesCustom' => ExamplesQuery::class,
-
             ],
             'mutation' => [
                 'updateExampleCustom' => UpdateExampleMutation::class,
@@ -69,7 +68,7 @@ class TestCase extends BaseTestCase
         ]);
 
         $app['config']->set('graphql.types', [
-            'Example' => ExampleType::class,
+            'Example'            => ExampleType::class,
             'ExampleConfigAlias' => ExampleType2::class,
             'ExampleFilterInput' => ExampleFilterInputType::class,
         ]);
@@ -223,8 +222,7 @@ class TestCase extends BaseTestCase
      */
     private function formatSafeTrace(array $trace): string
     {
-        return implode(
-            "\n",
+        return implode("\n",
             array_map(function (array $row, int $index): string {
                 $line = "#$index ";
                 $line .= $row['file'] ?? '';
@@ -239,7 +237,6 @@ class TestCase extends BaseTestCase
                 }
 
                 return $line;
-            }, $trace, array_keys($trace))
-        );
+            }, $trace, array_keys($trace)));
     }
 }

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -42,10 +42,10 @@ class GraphQLQueryTest extends TestCase
         $result = GraphQL::queryAndReturnResult($this->queries['examplesWithConfigAlias']);
         $this->assertObjectHasAttribute('errors', $result);
 
-        $this->assertStringStartsWith(
-            'Type Example2 not found.',
-            $result->errors[0]->message
-        );
+        $expected = "Type Example2 not found.
+Check that the config array key for the type matches the name attribute in the type's class.
+It is required when 'lazyload_types' is enabled";
+        $this->assertSame($expected, $result->errors[0]->message);
     }
 
     /**

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -26,6 +26,10 @@ class GraphQLQueryTest extends TestCase
 
     public function testConfigKeysIsDifferentFromTypeClassNameQuery(): void
     {
+        if (app('config')->get('graphql.lazyload_types')) {
+            $this->markTestSkipped('Skipping test when lazyload_types=true');
+        }
+
         $result = GraphQL::queryAndReturnResult($this->queries['examplesWithConfigAlias']);
 
         $this->assertObjectHasAttribute('data', $result);

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -26,7 +26,6 @@ class GraphQLQueryTest extends TestCase
 
     public function testConfigKeysIsDifferentFromTypeClassNameQuery(): void
     {
-
         $result = GraphQL::queryAndReturnResult($this->queries['examplesWithConfigAlias']);
 
         $this->assertObjectHasAttribute('data', $result);
@@ -44,11 +43,10 @@ class GraphQLQueryTest extends TestCase
         $this->assertObjectHasAttribute('errors', $result);
 
         $this->assertStringStartsWith(
-            "Type Example2 not found.",
+            'Type Example2 not found.',
             $result->errors[0]->message
         );
     }
-
 
     /**
      * Test query methods.

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -24,6 +24,32 @@ class GraphQLQueryTest extends TestCase
         ]);
     }
 
+    public function testConfigKeysIsDifferentFromTypeClassNameQuery(): void
+    {
+
+        $result = GraphQL::queryAndReturnResult($this->queries['examplesWithConfigAlias']);
+
+        $this->assertObjectHasAttribute('data', $result);
+
+        $this->assertEquals($result->data, [
+            'examplesConfigAlias' => $this->data,
+        ]);
+    }
+
+    public function testConfigKeyIsDifferentFromTypeClassNameNotSupportedInLazyLoadingOfTypes(): void
+    {
+        app('config')->set('graphql.lazyload_types', true);
+
+        $result = GraphQL::queryAndReturnResult($this->queries['examplesWithConfigAlias']);
+        $this->assertObjectHasAttribute('errors', $result);
+
+        $this->assertStringStartsWith(
+            "Type Example2 not found.",
+            $result->errors[0]->message
+        );
+    }
+
+
     /**
      * Test query methods.
      */


### PR DESCRIPTION
Enables lazy loading of, when types are used "correctly" by having the same alias in config and in names.

Will make us not fight the underlying framework and make it just work (FAST). Will of cause need some docs to explain how it should be set up.

I noticed about a 4 times speed up, testing on graphql-laravel-performancetest (did have to change all the type alias to match)
