### PR TITLE
Let lazyload_types default to false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
     fi
   - |
     if [[ $CODE_COVERAGE = 1 ]]; then
-      TESTS_DISABLE_LAZYLOAD_TYPES=1 phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml
+      TESTS_ENABLE_LAZYLOAD_TYPES=1 phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-clover=coverage.xml
       bash <(curl -s https://codecov.io/bash) -cF lazyload-on
     fi
   - if [[ $INSTALL_LARAVEL = 1 ]]; then export -f travis_retry ; tests/integration-larvavel.sh; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/v1.24.0...master)
 ------------
 ## Breaking changes
-- Featuring "performance by default", the new `lazyload_types` settings defaults to `true`. The breaking change is that this does not support type aliasing (if your types `$name` is different the one it's registered under) which includes pagination. To still use either, set it to `false`.
 - The `UploadType` now has to be added manually to the `types` in your schema if you want to use it
   - The `::getInstance()` method is gone
 - The order and arguments/types for resolvers has changed:
@@ -17,7 +16,7 @@ CHANGELOG
   - Although this could be consider a bug fix, it changes what columns are selected and if your code as a side-effect dependent on all columns being selected, it will break
 
 ### Added
-- Added support for lazy loading types (config `lazyload_types`), improve performance on large type systems [\#405](https://github.com/rebing/graphql-laravel/pull/405)
+- Added support for lazy loading types (config `lazyload_types`), improve performance on large type systems [\#405](https://github.com/rebing/graphql-laravel/pull/405) but doens't work together with type aliases or `paginate()`.
 - A migration guide for the Folklore library as part of the readme
 - New `make:graphql:input` command
 - New `make:graphql:union` command

--- a/Readme.md
+++ b/Readme.md
@@ -1566,14 +1566,13 @@ The following is not a bullet-proof list but should serve as a guide. It's not a
 
 ### Lazy loading of types
 
-Lazy loading of types is enabled by default, having no drawback for small
-projects but benfiting usages with many types.
+Lazy loading of types is a way of improving the start up performance.
 
 There are however scenarios where it's not supported:
 - types using aliases
 - built-in paginations via `GraphQL::pagination()` (which triggers the former)
 
-In either case `lazyload_types` have to be set to `false`.
+If you use neither, you can enable it with `lazyload_types` set to `true`.
 
 #### Example of aliasing **not** supported by lazy loading
 

--- a/config/config.php
+++ b/config/config.php
@@ -128,7 +128,7 @@ return [
     // The types will be loaded on demand. Default is to load all types on each request
     // Can increase performance on schemes with many types
     // Presupposes the config type key to match the type class name property
-    'lazyload_types' => true,
+    'lazyload_types' => false,
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -96,7 +96,7 @@ class GraphQL
 
                 return $types;
             },
-            'typeLoader'    => config('graphql.lazyload_types', true)
+            'typeLoader'    => config('graphql.lazyload_types', false)
                 ? function ($name) {
                     return $this->type($name);
                 }
@@ -167,7 +167,7 @@ class GraphQL
         if (! isset($this->types[$name])) {
             $error = "Type $name not found.";
 
-            if (config('graphql.lazyload_types', true)) {
+            if (config('graphql.lazyload_types', false)) {
                 $error .= "\nCheck that the config array key for the type matches the name attribute in the type's class.\nIt is required when 'lazyload_types' is enabled";
             }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,8 +45,8 @@ class TestCase extends BaseTestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        if (env('TESTS_DISABLE_LAZYLOAD_TYPES') === '1') {
-            $app['config']->set('graphql.lazyload_types', false);
+        if (env('TESTS_ENABLE_LAZYLOAD_TYPES') === '1') {
+            $app['config']->set('graphql.lazyload_types', true);
         }
 
         $app['config']->set('graphql.schemas.default', [


### PR DESCRIPTION
Although it can give a nice performance boost, it doesn't support
type aliasing and `GraphQL::paginate()`, which especially the latter
could lead to a bad out of the box DX we want avoid.