### PR TITLE
Defer booting of schema and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ CHANGELOG
   - Test suite has been refactored and now features Database (SQLite) tests too
 
 ### Changed
+- Types and Schemas are now only booted when the `graphql` service is requested, improving performance when having this library installed but not using it in certain workloads (pure artisan commands, non-GraphQL web requests, etc.) [\#427](https://github.com/rebing/graphql-laravel/pull/427)
 - Follow Laravel convention and use plural for namspaces (e.g. new queries are placed in `App\GraphQL\Queries`, not `App\GraphQL\Query` anymore); make commands have been adjusted
 - Made the following classes _abstract_: `Support\Field`, `Support\InterfaceType`, `Support\Mutation`, `Support\Query`, `Support\Type`, `Support\UnionType` [\#357](https://github.com/rebing/graphql-laravel/pull/357)
 - Updated GraphiQL to 0.13.0 [\#335](https://github.com/rebing/graphql-laravel/pull/335)

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -33,8 +33,6 @@ class GraphQLServiceProvider extends ServiceProvider
 
         $this->bootTypes();
 
-        $this->bootSchemas();
-
         $this->bootRouter();
     }
 
@@ -83,13 +81,14 @@ class GraphQLServiceProvider extends ServiceProvider
     /**
      * Add schemas from config.
      *
+     * @param  GraphQL  $graphQL
      * @return void
      */
-    protected function bootSchemas(): void
+    protected function bootSchemas(GraphQL $graphQL): void
     {
         $configSchemas = config('graphql.schemas');
         foreach ($configSchemas as $name => $schema) {
-            $this->app->make('graphql')->addSchema($name, $schema);
+            $graphQL->addSchema($name, $schema);
         }
     }
 
@@ -142,6 +141,8 @@ class GraphQLServiceProvider extends ServiceProvider
             $graphql = new GraphQL($app);
 
             $this->applySecurityRules();
+
+            $this->bootSchemas($graphql);
 
             return $graphql;
         });

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -31,8 +31,6 @@ class GraphQLServiceProvider extends ServiceProvider
     {
         $this->bootPublishes();
 
-        $this->bootTypes();
-
         $this->bootRouter();
     }
 
@@ -68,14 +66,15 @@ class GraphQLServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap publishes.
+     * Add types from config.
      *
+     * @param  GraphQL  $graphQL
      * @return void
      */
-    protected function bootTypes(): void
+    protected function bootTypes(GraphQL $graphQL): void
     {
         $configTypes = config('graphql.types');
-        $this->app->make('graphql')->addTypes($configTypes);
+        $graphQL->addTypes($configTypes);
     }
 
     /**
@@ -145,6 +144,10 @@ class GraphQLServiceProvider extends ServiceProvider
             $this->bootSchemas($graphql);
 
             return $graphql;
+        });
+
+        $this->app->afterResolving('graphql', function (GraphQL $graphQL) {
+            $this->bootTypes($graphQL);
         });
     }
 


### PR DESCRIPTION
It's quite possible to have a project but not always need GraphQL to be fully booted.

With this PR booting the types and schema is deferred to only when the `'graphql'` service truly is requested. Mostly this means artisan commands / worker / scheduler will boot faster unless you specifically use some GraphQL related features.

### Benchmarks
A Private project with ~100 Types, ~50 mutations and ~30 queries, running pure artisan:
`until false; do time ./artisan >/dev/null; done 2>&1 | grep real`

#### Without this PR
```
$ until false; do time ./artisan >/dev/null; done 2>&1 | grep real
real	0m0.683s
real	0m0.394s
real	0m0.425s
real	0m0.399s
real	0m0.390s
real	0m0.440s
real	0m0.401s
real	0m0.404s
real	0m0.413s
real	0m0.413s
real	0m0.392s
real	0m0.414s
real	0m0.420s
real	0m0.398s
real	0m0.410s
^C
```
#### With this PR
```
$ until false; do time ./artisan >/dev/null; done 2>&1 | grep real
real	0m0.527s
real	0m0.322s
real	0m0.343s
real	0m0.377s
real	0m0.330s
real	0m0.322s
real	0m0.379s
real	0m0.319s
real	0m0.344s
real	0m0.374s
real	0m0.327s
real	0m0.326s
real	0m0.382s
real	0m0.324s
real	0m0.334s
real	0m0.388s
real	0m0.321s
```

Even this the small project I tested, the savings can be ~50 to ~100ms.

### Implementation detail
Booting the types is a recursive behavior because types itself may reference the facade via `GraphQL::type(…)`,  that's why the types cannot be booted correctly within the singleton registration itself. This is especially true for interfaces.

For this reason `afterResolving` is used, which ensures the service is also properly registered.