### PR TITLE
Prepare the 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG
 =========
 
-[Next release](https://github.com/rebing/graphql-laravel/compare/v1.24.0...master)
-------------
+[Next release](https://github.com/rebing/graphql-laravel/compare/2.0.0...master)
+--------------
+
+2019-08-05, 2.0.0
+-----------------
 ## Breaking changes
 - The `UploadType` now has to be added manually to the `types` in your schema if you want to use it
   - The `::getInstance()` method is gone

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 [![License](https://poser.pugx.org/rebing/graphql-laravel/license)](https://packagist.org/packages/rebing/graphql-laravel)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/rebing-graphql/shared_invite/enQtNTE5NjQzNDI5MzQ4LWVjMTMxNzIyZjBlNTFhZGQ5MDVjZDAwZDNjODA3ODE2NjdiOGJkMjMwMTZkZmNhZjhiYTE1MjEyNDk0MWJmMzk)
 
+### Note: these are the docs for 2.*, [please see the `v1` branch for the 1.* docs](https://github.com/rebing/graphql-laravel/tree/v1#laravel-graphql)
 
 Uses Facebook GraphQL with Laravel 5.5+. It is based on the PHP implementation [here](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](http://facebook.github.io/react/blog/2015/05/01/graphql-introduction.html) on the [React](http://facebook.github.io/react) blog or you can read the [GraphQL specifications](https://facebook.github.io/graphql/). This is a work in progress.
 


### PR DESCRIPTION
The upcoming tag will be `2.0.0`, dropping the `v` prefix (didn't serve any real purpose)