### PR TITLE
[COMPOSER] Temporarily lock transitive phpstan dependency to avoid build breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*",
         "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0",
         "nunomaduro/larastan": "^0.3.17",
-        "mockery/mockery": "^1.2"
+        "mockery/mockery": "^1.2",
+        "phpstan/phpstan": "0.11.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Otherwise the analysis fails with:
```

In TypehintHelper.php line 60:

  Unexpected type: NunoMaduro\Larastan\Properties\ReflectionTypeContainer
```

See https://travis-ci.org/rebing/graphql-laravel/jobs/572225002 for an example of a broken build.