### PR TITLE
Add the current `\Illuminate\Http\Request` as 4th parameter to `\Rebing\GraphQL\GraphQLController::queryContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.0.0...master)
 --------------
+## Breaking changes
+- Add the current `\Illuminate\Http\Request` as 4th parameter to `\Rebing\GraphQL\GraphQLController::queryContext` [\#450 / mfn](https://github.com/rebing/graphql-laravel/pull/450)
+
 ### Added
 - Allow `'alias'` to be a callback [\#452 / crissi](https://github.com/rebing/graphql-laravel/pull/452)
 

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -46,7 +46,7 @@ class GraphQLController extends Controller
 
         // Complete each query in order
         foreach ($inputs as $input) {
-            $completedQueries[] = $this->executeQuery($schema, $input);
+            $completedQueries[] = $this->executeQuery($request, $schema, $input);
         }
 
         $data = $isBatch ? $completedQueries : $completedQueries[0];
@@ -57,7 +57,7 @@ class GraphQLController extends Controller
         return response()->json($data, 200, $headers, $jsonOptions);
     }
 
-    protected function executeQuery(string $schema, array $input): array
+    protected function executeQuery(Request $request, string $schema, array $input): array
     {
         $query = $input['query'];
 
@@ -71,14 +71,14 @@ class GraphQLController extends Controller
             $query,
             $params,
             [
-                'context' => $this->queryContext($query, $params, $schema),
+                'context' => $this->queryContext($query, $params, $schema, $request),
                 'schema' => $schema,
                 'operationName' => Arr::get($input, 'operationName'),
             ]
         );
     }
 
-    protected function queryContext(string $query, ?array $params, string $schema)
+    protected function queryContext(string $query, ?array $params, string $schema, Request $request)
     {
         try {
             return $this->app->make('auth')->user();

--- a/tests/Unit/CustomContext/Context.php
+++ b/tests/Unit/CustomContext/Context.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\CustomContext;
+
+use Illuminate\Http\Request;
+
+class Context
+{
+    /** @var Request */
+    private $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/tests/Unit/CustomContext/CustomContextTest.php
+++ b/tests/Unit/CustomContext/CustomContextTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\CustomContext;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class CustomContextTest extends TestCase
+{
+    public function testRequestAssertedInQuery(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => '{ queryReceivingRequestInContext }',
+        ]);
+
+        $this->assertEquals($response->getStatusCode(), 200);
+
+        $expectedResult = [
+            'data' => [
+                'queryReceivingRequestInContext' => 'The URL used for the GraphQL request: http://localhost/graphql',
+            ],
+        ];
+        $this->assertSame($expectedResult, $response->getData(true));
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.controllers', CustomGraphQLController::class.'@query');
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                QueryReceivingRequestInContextQuery::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/CustomContext/CustomGraphQLController.php
+++ b/tests/Unit/CustomContext/CustomGraphQLController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\CustomContext;
+
+use Illuminate\Http\Request;
+use Rebing\GraphQL\GraphQLController;
+
+class CustomGraphQLController extends GraphQLController
+{
+    protected function queryContext(string $query, ?array $params, string $schema, Request $request)
+    {
+        return new Context($request);
+    }
+}

--- a/tests/Unit/CustomContext/QueryReceivingRequestInContextQuery.php
+++ b/tests/Unit/CustomContext/QueryReceivingRequestInContextQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\CustomContext;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+
+class QueryReceivingRequestInContextQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'queryReceivingRequestInContext',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function resolve($root, $args, Context $ctx): string
+    {
+        return 'The URL used for the GraphQL request: '.$ctx->getRequest()->url();
+    }
+}


### PR DESCRIPTION
This allows creating a context with the current request without having to inject it via `request()` or other means when needed in a resolver.

This, unfortunately, is a breaking change for everyone currently implementing a custom context because the signature of `queryContext()` changed and needs to be adapted.

Fixes https://github.com/rebing/graphql-laravel/issues/444