### PR TITLE
Provide query arguments to custom query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.0.1...master)
 --------------
+### Changed
+- Custom `'query'` for relations now receive not only the local `'args'` defined but also merged in the ones from the initial query/mutation [\#460 / nurges](https://github.com/rebing/graphql-laravel/pull/460)
+  - Local arguments with the same name override the ones from the query / mutation
 
 2019-08-18, 2.0.1
 -----------------

--- a/Readme.md
+++ b/Readme.md
@@ -990,7 +990,12 @@ class UserType extends GraphQLType
             'posts' => [
                 'type'          => Type::listOf(GraphQL::type('post')),
                 'description'   => 'A list of posts written by the user',
-                // The first args are the parameters passed to the query
+                'args'          => [
+                    'date_from' => [
+                        'type' => Type::string(),
+                    ],
+                 ],
+                // The $args are the combination of the query/mutation arguments merged with the local arguments
                 'query'         => function(array $args, $query) {
                     return $query->where('posts.created_at', '>', $args['date_from']);
                 }

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -94,9 +94,9 @@ class SelectFields
         if ($topLevel) {
             return [$select, $with];
         } else {
-            return function ($query) use ($with, $select, $customQuery, $queryArgs) {
+            return function ($query) use ($with, $select, $customQuery, $queryArgs, $requestedFields) {
                 if ($customQuery) {
-                    $query = $customQuery($queryArgs, $query);
+                    $query = $customQuery(array_merge($queryArgs, $requestedFields['args']), $query);
                 }
 
                 $query->select($select);

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -94,9 +94,9 @@ class SelectFields
         if ($topLevel) {
             return [$select, $with];
         } else {
-            return function ($query) use ($with, $select, $customQuery, $requestedFields) {
+            return function ($query) use ($with, $select, $customQuery, $queryArgs) {
                 if ($customQuery) {
-                    $query = $customQuery($requestedFields['args'], $query);
+                    $query = $customQuery($queryArgs, $query);
                 }
 
                 $query->select($select);


### PR DESCRIPTION
Fix a bug where empty argument array was passed to custom query.