### PR TITLE
Add GraphQL context as 3rd argument to custom relation 'query'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.0.1...master)
 --------------
 ### Added
+- The custom `'query'` now receives the GraphQL context as the 3rd arg (same as any resolver) [\#464 / mfn](https://github.com/rebing/graphql-laravel/pull/464)
 - Allow to load deeper nested queries by allowing to change the depth when calling `$getSelectFields(int $depth)` [\#472 / mfn](https://github.com/rebing/graphql-laravel/pull/472)
 
 2019-08-18, 2.0.1

--- a/Readme.md
+++ b/Readme.md
@@ -997,8 +997,15 @@ class UserType extends GraphQLType
             'posts' => [
                 'type'          => Type::listOf(GraphQL::type('post')),
                 'description'   => 'A list of posts written by the user',
-                // The first args are the parameters passed to the query
-                'query'         => function(array $args, $query) {
+                'args'          => [
+                    'date_from' => [
+                        'type' => Type::string(),
+                    ],
+                 ],
+                // $args are the local arguments passed to the relation
+                // $query is the relation builder object
+                // $ctx is the GraphQL context (can be customized by overriding `\Rebing\GraphQL\GraphQLController::queryContext`
+                'query'         => function(array $args, $query, $ctx) {
                     return $query->where('posts.created_at', '>', $args['date_from']);
                 }
             ]

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -195,7 +195,9 @@ abstract class Field
             // Add the 'selects and relations' feature as 5th arg
             if (isset($arguments[3])) {
                 $arguments[] = function (int $depth = null) use ($arguments): SelectFields {
-                    return new SelectFields($arguments[3], $this->type(), $arguments[1], $depth ?? 5);
+                    $ctx = $arguments[2] ?? null;
+
+                    return new SelectFields($arguments[3], $this->type(), $arguments[1], $depth ?? 5, $ctx);
                 };
             }
 

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/CommentType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/CommentType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+
+class CommentType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Comment',
+        'model' => Comment::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLContext.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLContext.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+class GraphQLContext
+{
+    public $data;
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLController.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use Rebing\GraphQL\GraphQLController as BaseGraphQLController;
+
+class GraphQLController extends BaseGraphQLController
+{
+    protected function queryContext(string $query, ?array $params, string $schema)
+    {
+        return new GraphQLContext();
+    }
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
@@ -1,0 +1,958 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+
+class NestedRelationLoadingTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testGraphqlQueryFlagOverridesCustomQueryThrougContext(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                $post = factory(Post::class)
+                    ->create([
+                        'flag' => true,
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'flag' => true,
+                        'post_id' => $post->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+
+                $post = factory(Post::class)
+                    ->create([
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'flag' => true,
+                        'post_id' => $post->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+            });
+
+        // flag on posts is ignored, overridden from GraphQL via context
+        $graphql = <<<'GRAQPHQL'
+{
+  users(flag: false, select: true, with: true) {
+    id
+    name
+    posts(flag: true) {
+      body
+      id
+      title
+      comments(flag: true) {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQueryNoSelectFields(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select * from "users" order by "users"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQuerySelect(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQueryWith(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(with: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select * from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQuerySelectAndWith(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class, 2)
+                    ->create([
+                        'user_id' => $user->id,
+                    ])
+                    ->each(function (Post $post): void {
+                        factory(Comment::class, 2)
+                            ->create([
+                                'post_id' => $post->id,
+                            ]);
+                    });
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    posts {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[0]->posts[1]->body,
+                                'id' => (string) $users[0]->posts[1]->id,
+                                'title' => $users[0]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[0]->id,
+                                        'title' => $users[0]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[1]->comments[1]->id,
+                                        'title' => $users[0]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                            [
+                                'body' => $users[1]->posts[1]->body,
+                                'id' => (string) $users[1]->posts[1]->id,
+                                'title' => $users[1]->posts[1]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[0]->id,
+                                        'title' => $users[1]->posts[1]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[1]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[1]->comments[1]->id,
+                                        'title' => $users[1]->posts[1]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQuerySelectAndWithAndSubArgs(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                $post = factory(Post::class)
+                    ->create([
+                        'flag' => true,
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class, 2)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+
+                $post = factory(Post::class)
+                    ->create([
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class, 2)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    posts(flag: true) {
+      body
+      id
+      title
+      comments {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[1]->id,
+                                        'title' => $users[0]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[1]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[1]->id,
+                                        'title' => $users[1]->posts[0]->comments[1]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testQuerySelectAndWithAndNestedSubArgs(): void
+    {
+        /** @var User[] $users */
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user): void {
+                $post = factory(Post::class)
+                    ->create([
+                        'flag' => true,
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'flag' => true,
+                        'post_id' => $post->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+
+                $post = factory(Post::class)
+                    ->create([
+                        'user_id' => $user->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'flag' => true,
+                        'post_id' => $post->id,
+                    ]);
+                factory(Comment::class)
+                    ->create([
+                        'post_id' => $post->id,
+                    ]);
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    posts(flag: true) {
+      body
+      id
+      title
+      comments(flag: true) {
+        body
+        id
+        title
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
+select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) and "comments"."flag" = ? order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[0]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[0]->posts[0]->comments[0]->id,
+                                        'title' => $users[0]->posts[0]->comments[0]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => (string) $users[1]->id,
+                        'name' => $users[1]->name,
+                        'posts' => [
+                            [
+                                'body' => $users[1]->posts[0]->body,
+                                'id' => (string) $users[1]->posts[0]->id,
+                                'title' => $users[1]->posts[0]->title,
+                                'comments' => [
+                                    [
+                                        'body' => $users[1]->posts[0]->comments[0]->body,
+                                        'id' => (string) $users[1]->posts[0]->comments[0]->id,
+                                        'title' => $users[1]->posts[0]->comments[0]->title,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testRelationshipAlias(): void
+    {
+        $users = factory(User::class, 1)
+            ->create()
+            ->each(function (User $user): void {
+                factory(Post::class)
+                    ->create([
+                        'flag' => true,
+                        'user_id' => $user->id,
+                    ]);
+            });
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(select: true, with: true) {
+    id
+    name
+    flaggedPosts {
+      body
+      id
+      title
+
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id", "users"."name" from "users" order by "users"."id" asc;
+select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?) and "posts"."flag" = ? order by "posts"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $users[0]->id,
+                        'name' => $users[0]->name,
+                        'flaggedPosts' => [
+                            [
+                                'body' => $users[0]->posts[0]->body,
+                                'id' => (string) $users[0]->posts[0]->id,
+                                'title' => $users[0]->posts[0]->title,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.controllers', GraphQLController::class.'@query');
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                UsersQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.schemas.custom', null);
+
+        $app['config']->set('graphql.types', [
+            CommentType::class,
+            PostType::class,
+            UserType::class,
+        ]);
+    }
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PostType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Post',
+        'model' => Post::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'comments' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
+                'args' => [
+                    'flag' => [
+                        Type::boolean(),
+                    ],
+                ],
+                'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {
+                    if (isset($ctx->data['flag'])) {
+                        $query->where('comments.flag', '=', $ctx->data['flag']);
+                    } elseif (isset($args['flag'])) {
+                        $query->where('comments.flag', '=', $args['flag']);
+                    }
+
+                    return $query;
+                },
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UserType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'User',
+        'model' => User::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'name' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+            'posts' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
+                'args' => [
+                    'flag' => [
+                        Type::boolean(),
+                    ],
+                ],
+                'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {
+                    if (isset($ctx->data['flag'])) {
+                        $query->where('posts.flag', '=', $ctx->data['flag']);
+                    } elseif (isset($args['flag'])) {
+                        $query->where('posts.flag', '=', $args['flag']);
+                    }
+
+                    return $query;
+                },
+            ],
+            'flaggedPosts' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
+                'alias' => 'posts',
+                'query' => function (array $args, HasMany $query): HasMany {
+                    $query->where('posts.flag', '=', 1);
+
+                    return $query;
+                },
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests;
+
+use Closure;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'users',
+    ];
+
+    public function args(): array
+    {
+        return [
+            'flag' => [
+                Type::boolean(),
+            ],
+            'select' => [
+                'type' => Type::boolean(),
+            ],
+            'with' => [
+                'type' => Type::boolean(),
+            ],
+        ];
+    }
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('User'))));
+    }
+
+    public function resolve($root, $args, GraphQLContext $ctx, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    {
+        if (isset($args['flag'])) {
+            $ctx->data['flag'] = $args['flag'];
+        }
+
+        $users = User::query();
+
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields();
+
+        if (isset($args['select']) && $args['select']) {
+            $users->select($selectFields->getSelect());
+        }
+
+        if (isset($args['with']) && $args['with']) {
+            $users->with($selectFields->getRelations());
+        }
+
+        return $users->orderBy('users.id')->get();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -185,9 +185,10 @@ class TestCase extends BaseTestCase
      *
      * @param  string  $query
      * @param  array  $options
-     * @return array Supports the following options:
-     *  - `expectErrors` (default: false): if no errors are expected but present, let's the test fail
-     *  - `variables` (default: null): GraphQL variables for the query
+     *   Supports the following options:
+     *   - `expectErrors` (default: false): if no errors are expected but present, let's the test fail
+     *   - `variables` (default: null): GraphQL variables for the query
+     * @return array GraphQL result
      */
     protected function graphql(string $query, array $options = []): array
     {
@@ -215,6 +216,34 @@ class TestCase extends BaseTestCase
         }
 
         return $result;
+    }
+
+    /**
+     * Helper to dispatch an HTTP GraphQL requests.
+     *
+     * @param  string  $query
+     * @param  array  $options
+     *   Supports the following options:
+     *   - `httpStatusCode` (default: 200): the HTTP status code to expect
+     * @return array GraphQL result
+     */
+    protected function httpGraphql(string $query, array $options = []): array
+    {
+        $expectedHttpStatusCode = $options['httpStatusCode'] ?? 200;
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $query,
+        ]);
+
+        $httpStatusCode = $response->getStatusCode();
+
+        if ($expectedHttpStatusCode !== $httpStatusCode) {
+            $result = $response->getData(true);
+            $msg = var_export($result, true)."\n";
+            $this->assertSame($expectedHttpStatusCode, $httpStatusCode, $msg);
+        }
+
+        return $response->getData(true);
     }
 
     /**


### PR DESCRIPTION
Allows to mutate the context from within e.g. a GraphQL query and safely
pass data down to custom relation queries.

The test `\Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests\NestedRelationLoadingTest::testGraphqlQueryFlagOverridesCustomQueryThrougContext` shows off the high picture working:
- The context is `\Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests\GraphQLContext`
- In `\Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests\UsersQuery::resolve` the context receives the $args data
- And in `'query'` in `\Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests\PostType::fields` and `\Rebing\GraphQL\Tests\Database\SelectFields\QueryArgsAndContextTests\UserType::fields` is it used

Fixes https://github.com/rebing/graphql-laravel/issues/459