### PR TITLE
Allow changing the depth for SelectFields to support deeper nested queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.0.1...master)
 --------------
+### Added
+- Allow to load deeper nested queries by allowing to change the depth when calling `$getSelectFields(int $depth)` [\#472 / mfn](https://github.com/rebing/graphql-laravel/pull/472)
 
 2019-08-18, 2.0.1
 -----------------

--- a/Readme.md
+++ b/Readme.md
@@ -817,6 +817,8 @@ to eager load related Eloquent models.
 
 This way only the required fields will be queried from the database.
 
+The Closure accepts an optional parameter for the depth of the query to analyse.
+
 Your Query would look like:
 
 ```php
@@ -824,6 +826,7 @@ Your Query would look like:
 
 namespace App\GraphQL\Queries;
 
+use Closure;
 use App\User;
 use GraphQL;
 use GraphQL\Type\Definition\Type;
@@ -854,6 +857,10 @@ class UsersQuery extends Query
     {
         // $info->getFieldSelection($depth = 3);
 
+        // If your GraphQL query exceeds the default nesting query, you can increase it here:
+        // $fields = $getSelectFields(11);
+
+        /** @var SelectFields $fields */
         $fields = $getSelectFields();
         $select = $fields->getSelect();
         $with = $fields->getRelations();

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -194,8 +194,8 @@ abstract class Field
 
             // Add the 'selects and relations' feature as 5th arg
             if (isset($arguments[3])) {
-                $arguments[] = function () use ($arguments): SelectFields {
-                    return new SelectFields($arguments[3], $this->type(), $arguments[1]);
+                $arguments[] = function (int $depth = null) use ($arguments): SelectFields {
+                    return new SelectFields($arguments[3], $this->type(), $arguments[1], $depth ?? 5);
                 };
             }
 

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -33,15 +33,16 @@ class SelectFields
     /**
      * @param  ResolveInfo  $info
      * @param  GraphqlType  $parentType
-     * @param  array  $queryArgs Arguments given with the query/mutation
+     * @param  array  $queryArgs  Arguments given with the query/mutation
+     * @param  int  $depth The depth to walk the AST and introspect for nested relations
      */
-    public function __construct(ResolveInfo $info, GraphqlType $parentType, array $queryArgs)
+    public function __construct(ResolveInfo $info, GraphqlType $parentType, array $queryArgs, int $depth)
     {
         if ($parentType instanceof WrappingType) {
             $parentType = $parentType->getWrappedType(true);
         }
 
-        $requestedFields = $this->getFieldSelection($info, $queryArgs, 5);
+        $requestedFields = $this->getFieldSelection($info, $queryArgs, $depth);
         $fields = self::getSelectableFieldsAndRelations($queryArgs, $requestedFields, $parentType);
         $this->select = $fields[0];
         $this->relations = $fields[1];

--- a/tests/Database/SelectFields/DepthTests/DepthTest.php
+++ b/tests/Database/SelectFields/DepthTests/DepthTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\DepthTests;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+
+class DepthTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testDefaultDepthExceeded(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        factory(Post::class)->create([
+            'user_id' => $user->id,
+        ]);
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users {
+    id
+    posts {
+      id
+      user {
+        id
+        posts {
+          id
+          user {
+            id
+            posts {
+              id
+              user {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($graphql, [
+            'expectErrors' => true,
+        ]);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('Internal server error', $result['errors'][0]['message']);
+        $this->assertSame('SQLSTATE[HY000]: General error: 1 no such column: posts.user (SQL: select "posts"."id", "posts"."user", "posts"."user_id" from "posts" where "posts"."user_id" in (1) order by "posts"."id" asc)', $result['errors'][0]['debugMessage']);
+    }
+
+    public function testDefaultDepthAdjusted(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create([
+            'user_id' => $user->id,
+        ]);
+
+        $graphql = <<<'GRAQPHQL'
+{
+  users(depth: 6) {
+    id
+    posts {
+      id
+      user {
+        id
+        posts {
+          id
+          user {
+            id
+            posts {
+              id
+              user {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($graphql);
+
+        $this->assertSqlQueries(<<<'SQL'
+select "users"."id" from "users";
+select "posts"."id", "posts"."user_id" from "posts" where "posts"."user_id" in (?) order by "posts"."id" asc;
+select "users"."id" from "users" where "users"."id" in (?);
+select "posts"."id", "posts"."user_id" from "posts" where "posts"."user_id" in (?) order by "posts"."id" asc;
+select "users"."id" from "users" where "users"."id" in (?);
+select "posts"."id", "posts"."user_id" from "posts" where "posts"."user_id" in (?) order by "posts"."id" asc;
+select "users"."id" from "users" where "users"."id" in (?);
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => (string) $user->id,
+                        'posts' => [
+                            [
+                                'id' => (string) $post->id,
+                                'user' => [
+                                    'id' => (string) $user->id,
+                                    'posts' => [
+                                        [
+                                            'id' => (string) $post->id,
+                                            'user' => [
+                                                'id' => (string) $user->id,
+                                                'posts' => [
+                                                    [
+                                                        'id' => (string) $post->id,
+                                                        'user' => [
+                                                            'id' => (string) $user->id,
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expectedResult, $result);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                UsersQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.schemas.custom', null);
+
+        $app['config']->set('graphql.types', [
+            PostType::class,
+            UserType::class,
+        ]);
+    }
+}

--- a/tests/Database/SelectFields/DepthTests/PostType.php
+++ b/tests/Database/SelectFields/DepthTests/PostType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\DepthTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class PostType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Post',
+        'model' => Post::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'user' => [
+                'type' => Type::nonNull(GraphQL::type('User')),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/DepthTests/UserType.php
+++ b/tests/Database/SelectFields/DepthTests/UserType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\DepthTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class UserType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'User',
+        'model' => User::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'posts' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/DepthTests/UsersQuery.php
+++ b/tests/Database/SelectFields/DepthTests/UsersQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\DepthTests;
+
+use Closure;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'users',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('User'))));
+    }
+
+    public function args(): array
+    {
+        return [
+            'depth' => [
+                'type' => Type::int(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    {
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields($args['depth'] ?? null);
+
+        return User::with($selectFields->getRelations())->select($selectFields->getSelect())->get();
+    }
+}


### PR DESCRIPTION
The approach taken keeps the current default but allows to override it when calling `$getSelectFields(int $depth)` if necessary.

`\Rebing\GraphQL\Tests\Database\SelectFields\DepthTests\DepthTest::testDefaultDepthAdjusted` gives an example of it working, specifically `\Rebing\GraphQL\Tests\Database\SelectFields\DepthTests\UsersQuery::resolve` how it is applied.

Fixes https://github.com/rebing/graphql-laravel/issues/469