### PR TITLE
Fix validation of list of scalar types

### DIFF
--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -7,15 +7,15 @@ namespace Rebing\GraphQL\Support;
 use Closure;
 use Validator;
 use Illuminate\Support\Arr;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\WrappingType;
 use Rebing\GraphQL\Error\ValidationError;
 use GraphQL\Type\Definition\InputObjectType;
 use Rebing\GraphQL\Error\AuthorizationError;
 use GraphQL\Type\Definition\Type as GraphqlType;
-use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Definition\ScalarType;
 
 abstract class Field
 {
@@ -169,7 +169,7 @@ abstract class Field
 
     protected function getResolver(): ?Closure
     {
-        if (!method_exists($this, 'resolve')) {
+        if (! method_exists($this, 'resolve')) {
             return null;
         }
 
@@ -180,7 +180,7 @@ abstract class Field
             $arguments = func_get_args();
 
             // Get all given arguments
-            if (!is_null($arguments[2]) && is_array($arguments[2])) {
+            if (! is_null($arguments[2]) && is_array($arguments[2])) {
                 $arguments[1] = array_merge($arguments[1], $arguments[2]);
             }
 

--- a/tests/Support/Objects/ExampleValidationInputObject.php
+++ b/tests/Support/Objects/ExampleValidationInputObject.php
@@ -38,6 +38,11 @@ class ExampleValidationInputObject extends InputType
                 'type'  => Type::listOf(GraphQL::type('ExampleNestedValidationInputObject')),
                 'rules' => ['required'],
             ],
+            'list_of_mails' => [
+                'name' => 'list_of_mails',
+                'type' => Type::listOf(Type::string()),
+                'rules' => ['email'],
+            ],
         ];
     }
 

--- a/tests/Support/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Support/Objects/UpdateExampleMutationWithInputType.php
@@ -60,6 +60,11 @@ class UpdateExampleMutationWithInputType extends Mutation
                 'type'  => Type::nonNull(GraphQL::type('ExampleValidationInputObject')),
                 'rules' => ['required'],
             ],
+            'list_of_mails' => [
+                'name' => 'list_of_mails',
+                'type' => Type::listOf(Type::string()),
+                'rules' => ['email'],
+            ],
         ];
     }
 

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -24,8 +24,8 @@ class MutationTest extends FieldTest
         parent::getEnvironmentSetUp($app);
 
         $app['config']->set('graphql.types', [
-            'Example'                            => ExampleType::class,
-            'ExampleValidationInputObject'       => ExampleValidationInputObject::class,
+            'Example' => ExampleType::class,
+            'ExampleValidationInputObject' => ExampleValidationInputObject::class,
             'ExampleNestedValidationInputObject' => ExampleNestedValidationInputObject::class,
         ]);
     }
@@ -60,6 +60,15 @@ class MutationTest extends FieldTest
         $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.list.*.email'), ['email']);
     }
 
+    public function testRulesForListOfScalarType()
+    {
+        $class = $this->getFieldClass();
+        $field = new $class();
+        $rules = $field->getRules();
+        $this->assertEquals(Arr::get($rules, 'list_of_mails.*'), ['email']);
+        $this->assertEquals(Arr::get($rules, 'test_with_rules_non_nullable_input_object.list_of_mails.*'), ['email']);
+    }
+
     /**
      * Test resolve.
      */
@@ -75,18 +84,18 @@ class MutationTest extends FieldTest
 
         $attributes = $field->getAttributes();
         $attributes['resolve'](null, [
-            'test'                                  => 'test',
-            'test_with_rules'                       => 'test',
-            'test_with_rules_closure'               => 'test',
+            'test' => 'test',
+            'test_with_rules' => 'test',
+            'test_with_rules_closure' => 'test',
             'test_with_rules_nullable_input_object' => [
-                'val'  => 'test',
+                'val' => 'test',
                 'nest' => ['email' => 'test@test.com'],
                 'list' => [
                     ['email' => 'test@test.com'],
                 ],
             ],
             'test_with_rules_non_nullable_input_object' => [
-                'val'  => 'test',
+                'val' => 'test',
                 'nest' => ['email' => 'test@test.com'],
                 'list' => [
                     ['email' => 'test@test.com'],


### PR DESCRIPTION
this would actually apply ex. the **email** rule for each element in a list of strings.

The downside of this is that you can no longer create a rule for the whole array. 
Maybe a kind of Rule wrapper could be created to make a specific rule work for the whole list...

I am not sure this is the right way to fix this actually, maybe it should be fixed in userland code..?!?