### PR TITLE
Forward PHP engine errors to the application error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.1.0...master)
 --------------
+### Changed
+- Forward PHP engine errors to the application error handler
 
 2019-08-27, 2.1.0
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/2.1.0...master)
 --------------
 ### Changed
-- Forward PHP engine errors to the application error handler
+- Forward PHP engine errors to the application error handler [\487 / mfn](https://github.com/rebing/graphql-laravel/pull/487)
 
 2019-08-27, 2.1.0
 -----------------

--- a/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
+++ b/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\EngineErrorInResolverTests;
+
+use Mockery;
+use Rebing\GraphQL\Tests\TestCase;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
+
+class EngineErrorInResolverTest extends TestCase
+{
+    private const ERROR_REGEX = '/QueryWithEngineErrorInCodeQuery::getResult\(\) must be of the type int\w*, string given, called in/';
+
+    public function testForEngineError(): void
+    {
+        $result = $this->graphql('query { queryWithEngineErrorInCode }', [
+            'expectErrors' => true,
+        ]);
+
+        $this->assertRegExp(static::ERROR_REGEX, $result['errors'][0]['debugMessage']);
+    }
+
+    protected function resolveApplicationExceptionHandler($app)
+    {
+        // We expect the error in QueryWithEngineErrorInCodeQuery  to trigger
+        // reporting to the handler (as opposed to swallowing it silently).
+        $handlerMock = Mockery::mock(ExceptionHandler::class);
+        $handlerMock
+            ->shouldReceive('report')
+            ->with(Mockery::on(
+                function (FatalThrowableError $error) {
+                    $this->assertRegExp(static::ERROR_REGEX, $error->getMessage());
+
+                    return true;
+                }
+            ))
+            ->once();
+
+        $app->instance(ExceptionHandler::class, $handlerMock);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                QueryWithEngineErrorInCodeQuery::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
+++ b/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
@@ -11,15 +11,14 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class EngineErrorInResolverTest extends TestCase
 {
-    private const ERROR_REGEX = '/QueryWithEngineErrorInCodeQuery::getResult\(\) must be of the type int\w*, string given, called in/';
-
     public function testForEngineError(): void
     {
         $result = $this->graphql('query { queryWithEngineErrorInCode }', [
             'expectErrors' => true,
         ]);
 
-        $this->assertRegExp(static::ERROR_REGEX, $result['errors'][0]['debugMessage']);
+        // Using a regex here because in some cases the message gets prefixed with "Type error:"
+        $this->assertRegExp('/Simulating a TypeError/', $result['errors'][0]['debugMessage']);
     }
 
     protected function resolveApplicationExceptionHandler($app)
@@ -31,7 +30,8 @@ class EngineErrorInResolverTest extends TestCase
             ->shouldReceive('report')
             ->with(Mockery::on(
                 function (FatalThrowableError $error) {
-                    $this->assertRegExp(static::ERROR_REGEX, $error->getMessage());
+                    // Using a regex here because in some cases the message gets prefixed with "Type error:"
+                    $this->assertRegExp('/Simulating a TypeError/', $error->getMessage());
 
                     return true;
                 }

--- a/tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
+++ b/tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\EngineErrorInResolverTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class QueryWithEngineErrorInCodeQuery extends Mutation
+{
+    protected $attributes = [
+        'name' => 'queryWithEngineErrorInCode',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function resolve($root, $args): string
+    {
+        // This code deliberately creates a PHP error!
+        return $this->getResult('result');
+    }
+
+    private function getResult(int $string): string
+    {
+    }
+}

--- a/tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
+++ b/tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Unit\EngineErrorInResolverTests;
 
+use TypeError;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
 
@@ -20,11 +21,6 @@ class QueryWithEngineErrorInCodeQuery extends Mutation
 
     public function resolve($root, $args): string
     {
-        // This code deliberately creates a PHP error!
-        return $this->getResult('result');
-    }
-
-    private function getResult(int $string): string
-    {
+        throw new TypeError('Simulating a TypeError');
     }
 }


### PR DESCRIPTION
Otherwise PHP errors, like `TypeError` happening (as part of bugs 🤷‍♀️) inside PHP code executed in GraphQL queries are not reported via the application error handler.

Only a regular "internal error" was returned but the actual error was nowhere found in the logs or 3rd party error handling services.

### TODO
- [x] Add test
- [x] Need to find another way to trigger such error because otherwise PHPStan/Larastan complaints because it "sees" that the  code is wrong

### Note
This is a change in behaviour of the library and thus subject to semver requiring a major version bump (as established in https://github.com/rebing/graphql-laravel/issues/481#issuecomment-535380509 ). I.e. the next release has to be `3` after this is merged.