### PR TITLE
[BREAKING CHANGE 🚨] Change arguments for `authorize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 ### Added
 - Add `wrapType()`, allowing to add more information for queries/mutations [\#496 / albertcito](https://github.com/rebing/graphql-laravel/pull/496)
 ### Changed
+- The signature of `authorize` changed, receiving not the exact same argumenst the resolver would [\#489 / mfn](https://github.com/rebing/graphql-laravel/pull/489)
+  - before: `public function authorize(array $args)`
+  - after: `public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool`
 - Forward PHP engine errors to the application error handler [\#487 / mfn](https://github.com/rebing/graphql-laravel/pull/487)
 
 2019-08-27, 2.1.0

--- a/Readme.md
+++ b/Readme.md
@@ -590,10 +590,12 @@ An example of Laravel's `'auth'` middleware:
 
 ```php
 use Auth;
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
 
 class UsersQuery extends Query
 {
-    public function authorize(array $args): bool
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
     {
         // true, if logged in
         return ! Auth::guest();
@@ -607,10 +609,12 @@ Or we can make use of arguments passed via the GraphQL query:
 
 ```php
 use Auth;
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
 
 class UsersQuery extends Query
 {
-    public function authorize(array $args): bool
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
     {
         if (isset($args['id'])) {
             return Auth::id() == $args['id'];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,4 +39,6 @@ parameters:
         - '/Anonymous function should return string but returns string\|false/'
         # tests/Unit/UploadTests/UploadSingleFileMutation.php
         - '/Method Rebing\\GraphQL\\Tests\\Unit\\UploadTests\\UploadSingleFileMutation::resolve\(\) should return string but returns string\|false/'
+        # tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+        - '/Trying to invoke Closure\|null but it might not be a callable/'
     reportUnmatchedIgnoredErrors: true

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -164,6 +164,11 @@ abstract class Field
         $authorize = [$this, 'authorize'];
 
         return function () use ($resolver, $authorize) {
+            // 0 - the "root" object; `null` for queries, otherwise the parent of a type
+            // 1 - the provided `args` of the query or type (if applicable), empty array otherwise
+            // 2 - the "GraphQL query context" (see \Rebing\GraphQL\GraphQLController::queryContext)
+            // 3 - \GraphQL\Type\Definition\ResolveInfo as provided by the underlying GraphQL PHP library
+            // 4 (!) - added by this library, encapsulates creating a `SelectFields` instance
             $arguments = func_get_args();
 
             // Validate mutation arguments

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -172,7 +172,7 @@ abstract class Field
             $arguments = func_get_args();
 
             // Validate mutation arguments
-            $args = Arr::get($arguments, 1, []);
+            $args = $arguments[1];
             $rules = call_user_func_array([$this, 'getRules'], [$args]);
             if (count($rules)) {
 

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -166,11 +166,6 @@ abstract class Field
         return function () use ($resolver, $authorize) {
             $arguments = func_get_args();
 
-            // Get all given arguments
-            if (! is_null($arguments[2]) && is_array($arguments[2])) {
-                $arguments[1] = array_merge($arguments[1], $arguments[2]);
-            }
-
             // Validate mutation arguments
             if (method_exists($this, 'getRules')) {
                 $args = Arr::get($arguments, 1, []);

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -172,18 +172,16 @@ abstract class Field
             $arguments = func_get_args();
 
             // Validate mutation arguments
-            if (method_exists($this, 'getRules')) {
-                $args = Arr::get($arguments, 1, []);
-                $rules = call_user_func_array([$this, 'getRules'], [$args]);
-                if (count($rules)) {
+            $args = Arr::get($arguments, 1, []);
+            $rules = call_user_func_array([$this, 'getRules'], [$args]);
+            if (count($rules)) {
 
-                    // allow our error messages to be customised
-                    $messages = $this->validationErrorMessages($args);
+                // allow our error messages to be customised
+                $messages = $this->validationErrorMessages($args);
 
-                    $validator = Validator::make($args, $rules, $messages);
-                    if ($validator->fails()) {
-                        throw new ValidationError('validation', $validator);
-                    }
+                $validator = Validator::make($args, $rules, $messages);
+                if ($validator->fails()) {
+                    throw new ValidationError('validation', $validator);
                 }
             }
 

--- a/tests/Database/AuthorizeArgsTests/AuthorizeArgsTest.php
+++ b/tests/Database/AuthorizeArgsTests/AuthorizeArgsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\AuthorizeArgsTests;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class AuthorizeArgsTest extends TestCaseDatabase
+{
+    public function testAuthorizeArgs(): void
+    {
+        $graphql = <<<'GRAPHQL'
+query {
+  testAuthorizationArgs(id: "foobar")
+}
+GRAPHQL;
+
+        // All relevant test assertions are in \Rebing\GraphQL\Tests\Database\AuthorizeArgsTests\TestAuthorizationArgsQuery::authorize
+        $this->httpGraphql($graphql);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.controllers', GraphQLController::class.'@query');
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                TestAuthorizationArgsQuery::class,
+            ],
+        ]);
+    }
+}

--- a/tests/Database/AuthorizeArgsTests/GraphQLContext.php
+++ b/tests/Database/AuthorizeArgsTests/GraphQLContext.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\AuthorizeArgsTests;
+
+class GraphQLContext
+{
+    public $data;
+}

--- a/tests/Database/AuthorizeArgsTests/GraphQLController.php
+++ b/tests/Database/AuthorizeArgsTests/GraphQLController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\AuthorizeArgsTests;
+
+use Rebing\GraphQL\GraphQLController as BaseGraphQLController;
+
+class GraphQLController extends BaseGraphQLController
+{
+    protected function queryContext(string $query, ?array $params, string $schema)
+    {
+        return new GraphQLContext();
+    }
+}

--- a/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+++ b/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\AuthorizeArgsTests;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\SelectFields;
+
+class TestAuthorizationArgsQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'testAuthorizationArgs',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => [
+                Type::nonNull(Type::ID()),
+            ],
+        ];
+    }
+
+    public function authorize(
+        $root,
+        array $args,
+        $ctx,
+        ResolveInfo $resolveInfo = null,
+        Closure $getSelectFields = null
+    ): bool {
+        Assert::assertNull($root);
+
+        $expectedArgs = [
+            'id' => 'foobar',
+        ];
+        Assert::assertSame($expectedArgs, $args);
+
+        Assert::assertInstanceOf(GraphQLContext::class, $ctx);
+
+        Assert::assertInstanceOf(ResolveInfo::class, $resolveInfo);
+
+        $selectFields = $getSelectFields();
+        Assert::assertInstanceOf(SelectFields::class, $selectFields);
+    }
+
+    public function resolve()
+    {
+    }
+}

--- a/tests/Support/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Support/Objects/ExamplesAuthorizeQuery.php
@@ -16,7 +16,7 @@ class ExamplesAuthorizeQuery extends Query
         'name' => 'Examples authorize query',
     ];
 
-    public function authorize(array $args): bool
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
     {
         return false;
     }

--- a/tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
+++ b/tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Unit\ValidationAuthorizationTests;
 
+use Closure;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
+use GraphQL\Type\Definition\ResolveInfo;
 
 class ValidationAndAuthorizationMutation extends Mutation
 {
@@ -13,7 +15,7 @@ class ValidationAndAuthorizationMutation extends Mutation
         'name' => 'validationAndAuthorization',
     ];
 
-    public function authorize(array $args): bool
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
     {
         return $args['arg1'] === 'value1';
     }


### PR DESCRIPTION
For background, see https://github.com/rebing/graphql-laravel/issues/481 and specifically https://github.com/rebing/graphql-laravel/issues/481#issuecomment-532926120 and further comments.

The basic change:
- before: `public function authorize(array $args): bool`
- after: `public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool`

The astute reader will recognize that these are exactly the same arguments passed to `resolve`, and this isn't a coincidence.

This is also made even clearer in the small refactor I did in the code regarding calling them:
```php
            // Authorize
            if (call_user_func_array($authorize, $arguments) != true) {
                throw new AuthorizationError('Unauthorized');
            }

            return call_user_func_array($resolver, $arguments);
```
The only difference is that checking if the returned value and the (automatic) reaction to it (this fact was never different, but due to aligning the arguments it's now even more clear how this works).

Additional changes:
- Don't merge `$arguments[2]` (context) into `$arguments[1]` (args), this seems like a strange thing to do, another one of those implicit behaviours without clear indication as to way (blame didn't offer me much more insights)
- Remove `method_exists` for `getRules`, that method is already there and can never be "not there"

### TODO
- [ ] Add a test making use of all args