### PR TITLE
Allow passing through the rootValue as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/3.0.0...master)
 --------------
+### Added
+- Allow passing through the `rootValue` as an option [\#492 / tuurbo](https://github.com/rebing/graphql-laravel/pull/492)
 
 2019-10-20, 3.0.0
 -----------------

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -134,6 +134,7 @@ class GraphQL
         $context = Arr::get($opts, 'context');
         $schemaName = Arr::get($opts, 'schema');
         $operationName = Arr::get($opts, 'operationName');
+        $rootValue = Arr::get($opts, 'rootValue', null);
 
         $schema = $this->schema($schemaName);
 
@@ -141,7 +142,7 @@ class GraphQL
         $errorsHandler = config('graphql.errors_handler', [static::class, 'handleErrors']);
         $defaultFieldResolver = config('graphql.defaultFieldResolver', null);
 
-        $result = GraphQLBase::executeQuery($schema, $query, null, $context, $params, $operationName, $defaultFieldResolver)
+        $result = GraphQLBase::executeQuery($schema, $query, $rootValue, $context, $params, $operationName, $defaultFieldResolver)
             ->setErrorsHandler($errorsHandler)
             ->setErrorFormatter($errorFormatter);
 

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -361,4 +361,38 @@ class GraphQLTest extends TestCase
         ];
         $this->assertSame($expectedResult, $result);
     }
+
+    public function testAddSchemaObjectAndExecuteQueryWithRootValue(): void
+    {
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'testQuery' => [
+                        'type' => Type::string(),
+                        'resolve' => function ($root) {
+                            return strtolower($root['testQuery']);
+                        },
+                    ],
+                ],
+            ]),
+        ]);
+
+        GraphQL::addSchema('schema_from_object', $schema);
+
+        $result = GraphQL::query('{ testQuery }', null, [
+            'schema' => 'schema_from_object',
+            'rootValue' => [
+                'testQuery' => 'CONVERTED TO LOWERCASE',
+            ],
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'testQuery' => 'converted to lowercase',
+            ],
+        ];
+
+        $this->assertSame($expectedResult, $result);
+    }
 }


### PR DESCRIPTION
As seen in https://github.com/webonyx/graphql-php/blob/master/docs/executing-queries.md