### PR TITLE
[REFACTOR] Remove Arr::get use where there's cler no benefit

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -9,7 +9,6 @@ use Error as PhpError;
 use GraphQL\Error\Debug;
 use GraphQL\Error\Error;
 use GraphQL\Type\Schema;
-use Illuminate\Support\Arr;
 use GraphQL\Error\FormattedError;
 use GraphQL\Type\Definition\Type;
 use GraphQL\GraphQL as GraphQLBase;
@@ -64,9 +63,9 @@ class GraphQL
             return $schema;
         }
 
-        $schemaQuery = Arr::get($schema, 'query', []);
-        $schemaMutation = Arr::get($schema, 'mutation', []);
-        $schemaSubscription = Arr::get($schema, 'subscription', []);
+        $schemaQuery = $schema['query'] ?? [];
+        $schemaMutation = $schema['mutation'] ?? [];
+        $schemaSubscription = $schema['subscription'] ?? [];
 
         $query = $this->objectType($schemaQuery, [
             'name' => 'Query',
@@ -86,7 +85,7 @@ class GraphQL
             'subscription'  => ! empty($schemaSubscription) ? $subscription : null,
             'types'         => function () use ($schema) {
                 $types = [];
-                $schemaTypes = Arr::get($schema, 'types', []);
+                $schemaTypes = $schema['types'] ?? [];
 
                 if ($schemaTypes) {
                     foreach ($schemaTypes as $name => $type) {
@@ -131,10 +130,10 @@ class GraphQL
      */
     public function queryAndReturnResult(string $query, ?array $params = [], array $opts = []): ExecutionResult
     {
-        $context = Arr::get($opts, 'context');
-        $schemaName = Arr::get($opts, 'schema');
-        $operationName = Arr::get($opts, 'operationName');
-        $rootValue = Arr::get($opts, 'rootValue', null);
+        $context = $opts['context'] ?? null;
+        $schemaName = $opts['schema'] ?? null;
+        $operationName = $opts['operationName'] ?? null;
+        $rootValue = $opts['rootValue'] ?? null;
 
         $schema = $this->schema($schemaName);
 

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rebing\GraphQL;
 
 use Exception;
-use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
@@ -62,7 +61,7 @@ class GraphQLController extends Controller
         $query = $input['query'];
 
         $paramsKey = config('graphql.params_key', 'variables');
-        $params = Arr::get($input, $paramsKey);
+        $params = $input[$paramsKey] ?? null;
         if (is_string($params)) {
             $params = json_decode($params, true);
         }
@@ -73,7 +72,7 @@ class GraphQLController extends Controller
             [
                 'context' => $this->queryContext($query, $params, $schema),
                 'schema' => $schema,
-                'operationName' => Arr::get($input, 'operationName'),
+                'operationName' => $input['operationName'] ?? null,
             ]
         );
     }

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -6,7 +6,6 @@ namespace Rebing\GraphQL\Support;
 
 use Closure;
 use RuntimeException;
-use Illuminate\Support\Arr;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -163,7 +162,7 @@ class SelectFields
             $canSelect = self::validateField($fieldObject, $queryArgs);
             if ($canSelect === true) {
                 // Add a query, if it exists
-                $customQuery = Arr::get($fieldObject->config, 'query');
+                $customQuery = $fieldObject->config['query'] ?? null;
 
                 // Check if the field is a relation that needs to be requested from the DB
                 $queryable = self::isQueryable($fieldObject->config);
@@ -177,7 +176,7 @@ class SelectFields
                     if (isset($parentType->config['model'])) {
                         // Get the next parent type, so that 'with' queries could be made
                         // Both keys for the relation are required (e.g 'id' <-> 'user_id')
-                        $relationsKey = Arr::get($fieldObject->config, 'alias', $key);
+                        $relationsKey = $fieldObject->config['alias'] ?? $key;
                         $relation = call_user_func([app($parentType->config['model']), $relationsKey]);
 
                         // Add the foreign key here, if it's a 'belongsTo'/'belongsToMany' relation
@@ -315,7 +314,7 @@ class SelectFields
      */
     private static function isQueryable(array $fieldObject): bool
     {
-        return Arr::get($fieldObject, 'is_relation', true) === true;
+        return ($fieldObject['is_relation'] ?? true) === true;
     }
 
     /**

--- a/tests/Support/Objects/UpdateExampleMutation.php
+++ b/tests/Support/Objects/UpdateExampleMutation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use Closure;
-use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -56,7 +55,7 @@ class UpdateExampleMutation extends Mutation
     public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
     {
         return [
-            'test' => Arr::get($args, 'test'),
+            'test' => $args['test'],
         ];
     }
 }

--- a/tests/Support/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Support/Objects/UpdateExampleMutationWithInputType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
-use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Mutation;
 use Rebing\GraphQL\Support\Facades\GraphQL;
@@ -66,7 +65,7 @@ class UpdateExampleMutationWithInputType extends Mutation
     public function resolve($root, $args): array
     {
         return [
-            'test' => Arr::get($args, 'test'),
+            'test' => $args['test'],
         ];
     }
 }


### PR DESCRIPTION
Arr:get does a lot of magic but there's no point using it when we don't need that magic.

Nowadays `??` is simply more idiomatic for most cases.

Arr::get has been left in places where it's still useful. Seems so especially in the routing file.