### PR TITLE
add morph type to returned models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 --------------
 ### Fixed
 - Fix validation rules for non-null list of non-null objects [\#511 / crissi](https://github.com/rebing/graphql-laravel/pull/511/files)
+- Add morph type to returned models [\#503 / crissi](https://github.com/rebing/graphql-laravel/pull/503)
 
 2019-10-23, 3.1.0
 -----------------

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -27,7 +27,7 @@ class SelectFields
     /** @var array */
     private $relations = [];
 
-    const FOREIGN_KEY = 'foreignKey';
+    const ALWAYS_RELATION_KEY = 'ALWAYS_RELATION_KEY';
 
     /**
      * @param  ResolveInfo  $info
@@ -142,7 +142,7 @@ class SelectFields
             }
 
             // Always select foreign key
-            if ($field === self::FOREIGN_KEY) {
+            if ($field === self::ALWAYS_RELATION_KEY) {
                 self::addFieldToSelect($key, $select, $parentTable, false);
                 continue;
             }
@@ -212,7 +212,11 @@ class SelectFields
                             $segments = explode('.', $foreignKey);
                             $foreignKey = end($segments);
                             if (! array_key_exists($foreignKey, $field)) {
-                                $field['fields'][$foreignKey] = self::FOREIGN_KEY;
+                                $field['fields'][$foreignKey] = self::ALWAYS_RELATION_KEY;
+                            }
+
+                            if (is_a($relation, MorphMany::class) || is_a($relation, MorphOne::class)) {
+                                $field['fields'][$relation->getMorphType()] = self::ALWAYS_RELATION_KEY;
                             }
                         }
 
@@ -295,7 +299,8 @@ class SelectFields
 
                 default:
                     throw new RuntimeException(
-                        sprintf("Unsupported use of 'privacy' configuration on field '%s'.",
+                        sprintf(
+                            "Unsupported use of 'privacy' configuration on field '%s'.",
                             $fieldObject->name
                         )
                     );

--- a/tests/Database/SelectFields/MorphRelationshipTests/CommentType.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/CommentType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+
+class CommentType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Comment',
+        'model' => Comment::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'likes' => [
+                'type' => Type::listOf(GraphQL::Type('Like')),
+            ],
+            'post' => [
+                'type' => Type::nonNull(GraphQL::type('Post')),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+
+    public function interfaces(): array
+    {
+        return [
+            GraphQL::type('LikableInterface'),
+        ];
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\InterfaceType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class LikableInterfaceType extends InterfaceType
+{
+    protected $attributes = [
+        'name' => 'LikableInterface',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+        ];
+    }
+
+    public function resolveType($root)
+    {
+        if ($root instanceof Post) {
+            return GraphQL::type('Post');
+        } elseif ($root instanceof Comment) {
+            return GraphQL::type('Comment');
+        }
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/LikeType.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/LikeType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Like;
+
+class LikeType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Like',
+        'model' => Like::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+            'likable' => [
+                'type' => Type::nonNull(GraphQL::type('LikableInterface')),
+            ],
+            'user' => [
+                'type' => Type::nonNull(GraphQL::type('User')),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
@@ -54,9 +54,7 @@ GRAQPHQL;
 
         $this->sqlCounterReset();
 
-        $result = $this->graphql($query, [
-            'expectErrors' => true,
-        ]);
+        $result = $this->graphql($query);
 
         $this->assertSqlQueries(
             <<<'SQL'

--- a/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use Rebing\GraphQL\Tests\Support\Models\Like;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Models\User;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class MorphRelationshipTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testMorphRelationship(): void
+    {
+        $user = factory(User::class)->create([
+            'name' => 'User Name',
+        ]);
+
+        $otherUser = factory(User::class)->create();
+
+        $post = factory(Post::class)->create([
+            'user_id' => $user->id,
+        ]);
+
+        $like = factory(Like::class)->make([
+            'user_id' => $otherUser->id,
+        ]);
+
+        $post->likes()->save($like);
+
+        $this->assertNotNull($user->posts[0]->likes[0]->user);
+
+        $query = <<<'GRAQPHQL'
+{
+  users {
+    id
+    posts {
+      id
+      title
+      likes {
+        id
+        user {
+            id
+        }
+      }
+    }
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($query, [
+            'expectErrors' => true,
+        ]);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "users"."id" from "users";
+select "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
+select "likes"."id", "likes"."user_id", "likes"."likable_id", "likes"."likable_type" from "likes" where "likes"."likable_id" in (?) and "likes"."likable_type" = ?;
+select "users"."id" from "users" where "users"."id" in (?);
+select * from "posts" where "posts"."id" = ? limit 1;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'users' => [
+                    [
+                        'id' => $user->id,
+                        'posts' => [
+                            [
+                                'id' => $post->id,
+                                'title' => $post->title,
+                                'likes' => [
+                                    [
+                                        'id' => $like->id,
+                                        'user' => [
+                                            'id' => $otherUser->id,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => $otherUser->id,
+                        'posts' => [],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                UsersQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.schemas.custom', null);
+
+        $app['config']->set('graphql.types', [
+            LikableInterfaceType::class,
+            CommentType::class,
+            LikeType::class,
+            PostType::class,
+            UserType::class,
+        ]);
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/PostType.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/PostType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class PostType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Post',
+        'model' => Post::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'body' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+            'comments' => [
+                'type' => Type::listOf(GraphQL::type('Comment')),
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+            'likes' => [
+                'type' => Type::listOf(GraphQL::Type('Like')),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+            'user' => [
+                'type' => GraphQL::type('User'),
+            ],
+        ];
+    }
+
+    public function interfaces(): array
+    {
+        return [
+            GraphQL::type('LikableInterface'),
+        ];
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/UserType.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/UserType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+class UserType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'User',
+        'model' => User::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+            'likes' => [
+                'type' => Type::listOf(GraphQL::Type('Like')),
+            ],
+            'name' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+            'posts' => [
+                'type' => Type::listOf(GraphQL::type('Post')),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\MorphRelationshipTests;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Assert;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Models\User;
+
+class UsersQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'users',
+    ];
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('User'));
+    }
+
+    public function resolve($root, $args, $contxt, ResolveInfo $info, Closure $getSelectFields)
+    {
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields();
+
+        $users = User
+            ::query()
+            ->select($selectFields->getSelect())
+            ->with($selectFields->getRelations())
+            ->get();
+
+        Assert::assertNotNull($users[0]->posts[0]->likes[0]->likable);
+
+        return $users;
+    }
+}

--- a/tests/Support/database/factories/LikeFactory.php
+++ b/tests/Support/database/factories/LikeFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Faker\Generator as Faker;
+use Rebing\GraphQL\Tests\Support\Models\Like;
+
+/* @var Factory $factory */
+$factory->define(Like::class, function (Faker $faker) {
+    return [
+    ];
+});


### PR DESCRIPTION
when you retrieve the morphed models in your query resolver the type is missing so don't know what type it is


**Are we going to continue to support 5.5? can see the tests are failing for that version**