### PR TITLE
fixes re-declare issue

### DIFF
--- a/src/GraphQLLumenServiceProvider.php
+++ b/src/GraphQLLumenServiceProvider.php
@@ -20,7 +20,7 @@ class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 
     public function register()
     {
-        if (class_exists('Laravel\Lumen\Routing\Controller')) {
+        if (class_exists('Laravel\Lumen\Routing\Controller') && ! class_exists('Illuminate\Routing\Controller')) {
             class_alias('Laravel\Lumen\Routing\Controller', 'Illuminate\Routing\Controller');
         }
 


### PR DESCRIPTION
```
ErrorException: Cannot declare class Illuminate\Routing\Controller, because the name is already in use
/var/www/html/vendor/rebing/graphql-laravel/src/GraphQLLumenServiceProvider.php:24
/var/www/html/vendor/laravel/lumen-framework/src/Application.php:193
/var/www/html/app/Providers/AppServiceProvider.php:35
```