### PR TITLE
resolve method can use dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 --------------
 ### Added
 - Allow passing through an instance of a `Field` [\#521 / georgeboot](https://github.com/rebing/graphql-laravel/pull/521/files)
+- Classes can now be injected in the Resolve method from the query/mutation similarly to Laravel controller methods [\#520 / crissi](https://github.com/rebing/graphql-laravel/pull/520/files)
 ### Fixed
 - Fix validation rules for non-null list of non-null objects [\#511 / crissi](https://github.com/rebing/graphql-laravel/pull/511/files)
 - Add morph type to returned models [\#503 / crissi](https://github.com/rebing/graphql-laravel/pull/503)

--- a/Readme.md
+++ b/Readme.md
@@ -601,17 +601,18 @@ Note: You can test your file upload implementation using [Altair](https://altair
 ### Resolve method
 The resolve method is used in both queries and mutations and it here the response are created.
 
-The first 3 params to the resolve method is required. The `$root`, `$args`, `$context`.
+The first three parameters to the resolve method are hard-coded:
+1. The `$root` object this resolve method belongs to (can be `null`)
+2. The arguments passed as `array $args` (can be an empty array)
+3. The query specific GraphQL context, can be customized by overriding `\Rebing\GraphQL\GraphQLController::queryContext`
 
-Arguments here after will be attempted to be injected. Similar to how controller methods works in Laravel.
+Arguments here after will be attempted to be injected, similar to how controller methods works in Laravel.
 
 You can typehint any class that you will need an instance of.
 
-Classes that might be useful to inject:
-
-`GraphQL\Type\Definition\ResolveInfo` has information useful for field resolution process.
-
-`Rebing\GraphQL\Support\SelectFields` allows eager loading of related models, see [Eager loading relationships](#eager-loading-relationships).
+There are two hardcoded classes which depend on the local data for the query:
+- `GraphQL\Type\Definition\ResolveInfo` has information useful for field resolution process.
+- `Rebing\GraphQL\Support\SelectFields` allows eager loading of related models, see [Eager loading relationships](#eager-loading-relationships).
 
 Example:
 ```php

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -14,8 +14,10 @@ use GraphQL\Type\Definition\WrappingType;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use InvalidArgumentException;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
+use ReflectionMethod;
 
 /**
  * @property string $name
@@ -203,22 +205,51 @@ abstract class Field
                 }
             }
 
-            // Add the 'selects and relations' feature as 5th arg
-            if (isset($arguments[3])) {
-                $arguments[] = function (int $depth = null) use ($arguments): SelectFields {
-                    $ctx = $arguments[2] ?? null;
-
-                    return new SelectFields($arguments[3], $this->type(), $arguments[1], $depth ?? 5, $ctx);
-                };
-            }
-
             // Authorize
-            if (call_user_func_array($authorize, $arguments) != true) {
+            if (true != call_user_func_array($authorize, $arguments)) {
                 throw new AuthorizationError('Unauthorized');
             }
 
-            return call_user_func_array($resolver, $arguments);
+            $method = new ReflectionMethod($this, 'resolve');
+
+            $additionalParams = array_slice($method->getParameters(), 3);
+
+            $additionalArguments = array_map(function ($param) use ($arguments) {
+                $className = null !== $param->getClass() ? $param->getClass()->getName() : null;
+
+                if (null === $className) {
+                    throw new InvalidArgumentException("'{$param->name}' could not be injected");
+                }
+
+                if (Closure::class === $param->getType()->getName()) {
+                    return function (int $depth = null) use ($arguments): SelectFields {
+                        return $this->instanciateSelectFields($arguments, $depth);
+                    };
+                }
+
+                if (SelectFields::class === $className) {
+                    return $this->instanciateSelectFields($arguments);
+                }
+
+                if (ResolveInfo::class === $className) {
+                    return $arguments[3];
+                }
+
+                return app()->make($className);
+            }, $additionalParams);
+
+            return call_user_func_array($resolver, array_merge(
+                [$arguments[0], $arguments[1], $arguments[2]],
+                $additionalArguments
+            ));
         };
+    }
+
+    private function instanciateSelectFields(array $arguments, int $depth = null): SelectFields
+    {
+        $ctx = $arguments[2] ?? null;
+
+        return new SelectFields($arguments[3], $this->type(), $arguments[1], $depth ?? 5, $ctx);
     }
 
     /**

--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -9,6 +9,8 @@ use Rebing\GraphQL\Tests\Support\Models\Comment;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 use Rebing\GraphQL\Tests\Support\Queries\PostNonNullWithSelectFieldsAndModelQuery;
 use Rebing\GraphQL\Tests\Support\Queries\PostQuery;
+use Rebing\GraphQL\Tests\Support\Queries\PostQueryWithNonInjectableTypehintsQuery;
+use Rebing\GraphQL\Tests\Support\Queries\PostQueryWithSelectFieldsClassInjectionQuery;
 use Rebing\GraphQL\Tests\Support\Queries\PostsListOfWithSelectFieldsAndModelQuery;
 use Rebing\GraphQL\Tests\Support\Queries\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery;
 use Rebing\GraphQL\Tests\Support\Queries\PostsNonNullAndListOfWithSelectFieldsAndModelQuery;
@@ -65,6 +67,95 @@ SQL
 
         $this->assertEquals($response->getStatusCode(), 200);
         $this->assertEquals($expectedResult, $response->json());
+    }
+
+    public function testWithSelectFieldsClassInjection(): void
+    {
+        $post = factory(Post::class)->create([
+            'title' => 'Title of the post',
+        ]);
+
+        $graphql = <<<GRAQPHQL
+{
+  postWithSelectFieldClassInjection(id: $post->id) {
+    id
+    title
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $graphql,
+        ]);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "id", "title" from "posts" where "posts"."id" = ? limit 1;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'postWithSelectFieldClassInjection' => [
+                    'id'    => "$post->id",
+                    'title' => 'Title of the post',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($response->getStatusCode(), 200);
+        $this->assertEquals($expectedResult, $response->json());
+    }
+
+    public function testWithSelectFieldsNonInjectableTypehints(): void
+    {
+        $post = factory(Post::class)->create([
+            'title' => 'Title of the post',
+        ]);
+
+        $graphql = <<<GRAQPHQL
+{
+  postQueryWithNonInjectableTypehints(id: $post->id) {
+    id
+    title
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($graphql, [
+            'expectErrors' => true,
+        ]);
+
+        unset($result['errors'][0]['trace']);
+
+        $expectedResult = [
+            'errors' => [
+                [
+                    'debugMessage' => "'coolNumber' could not be injected",
+                    'message'      => 'Internal server error',
+                    'extensions'   => [
+                        'category' => 'internal',
+                    ],
+                    'locations' => [
+                        [
+                            'line'   => 2,
+                            'column' => 3,
+                        ],
+                    ],
+                    'path' => [
+                        'postQueryWithNonInjectableTypehints',
+                    ],
+                ],
+            ],
+            'data' => [
+                'postQueryWithNonInjectableTypehints' => null,
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
     }
 
     public function testWithSelectFieldsAndModel(): void
@@ -445,6 +536,8 @@ SQL
                 PostWithSelectFieldsAndModelQuery::class,
                 PostWithSelectFieldsNoModelQuery::class,
                 PostWithSelectFieldsAndModelAndAliasCallbackQuery::class,
+                PostQueryWithSelectFieldsClassInjectionQuery::class,
+                PostQueryWithNonInjectableTypehintsQuery::class,
             ],
         ]);
 

--- a/tests/Support/Objects/ClassToInject.php
+++ b/tests/Support/Objects/ClassToInject.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+class ClassToInject
+{
+}

--- a/tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+++ b/tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Queries;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class PostQueryWithNonInjectableTypehintsQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'postQueryWithNonInjectableTypehints',
+    ];
+
+    public function type(): Type
+    {
+        return GraphQL::type('Post');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args, $ctx, SelectFields $fields, int $coolNumber)
+    {
+        return Post::select($fields->getSelect())
+            ->findOrFail($args['id']);
+    }
+}

--- a/tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+++ b/tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Queries;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Objects\ClassToInject;
+
+class PostQueryWithSelectFieldsClassInjectionQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'postWithSelectFieldClassInjection',
+    ];
+
+    public function type(): Type
+    {
+        return GraphQL::type('Post');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args, $ctx, SelectFields $fields, ResolveInfo $info, Closure $selectFields, ClassToInject $class)
+    {
+        $selectClass = $selectFields(5);
+
+        return Post::select($fields->getSelect())
+            ->findOrFail($args['id']);
+    }
+}


### PR DESCRIPTION
- the resolve method now only  have 3 params that are required
- any class can be injected in the resolve method, including the ResolveInfo and SelectFields class
- you no longer need to use $selectfields as a closure, but is still supported for when you want to change the depth

*make resolve works more like the controller methods
