### PR TITLE
Implementing ClientAware on exceptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 ### Checklist
 - [ ] Existing tests have been adapted and/or new tests have been added
-- [ ] Code style has been fixed via `composer fix-tyle`
+- [ ] Code style has been fixed via `composer fix-style`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
 - Add morph type to returned models [\#503 / crissi](https://github.com/rebing/graphql-laravel/pull/503)
 ### Changed
 - Switch Code Style handling from StyleCI to PHP-CS Fixer [\#502 / crissi](https://github.com/rebing/graphql-laravel/pull/502)
-- Implemented [ClientAware](https://webonyx.github.io/graphql-php/error-handling/#default-error-formatting) interface on integrated exceptions [\#502 / georgeboot](https://github.com/rebing/graphql-laravel/pull/530)
+- Implemented [ClientAware](https://webonyx.github.io/graphql-php/error-handling/#default-error-formatting) interface on integrated exceptions [\#530 / georgeboot](https://github.com/rebing/graphql-laravel/pull/530)
 
 2019-10-23, 3.1.0
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 - Add morph type to returned models [\#503 / crissi](https://github.com/rebing/graphql-laravel/pull/503)
 ### Changed
 - Switch Code Style handling from StyleCI to PHP-CS Fixer [\#502 / crissi](https://github.com/rebing/graphql-laravel/pull/502)
+- Implemented [ClientAware](https://webonyx.github.io/graphql-php/error-handling/#default-error-formatting) interface on integrated exceptions [\#502 / georgeboot](https://github.com/rebing/graphql-laravel/pull/530)
 
 2019-10-23, 3.1.0
 -----------------

--- a/src/Error/AuthorizationError.php
+++ b/src/Error/AuthorizationError.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Error;
 
+use GraphQL\Error\ClientAware;
 use GraphQL\Error\Error;
 
-class AuthorizationError extends Error
+class AuthorizationError extends Error implements ClientAware
 {
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return 'authorization';
+    }
 }

--- a/src/Error/ValidationError.php
+++ b/src/Error/ValidationError.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Error;
 
+use GraphQL\Error\ClientAware;
 use GraphQL\Error\Error;
 use Illuminate\Contracts\Support\MessageBag;
 use Illuminate\Contracts\Validation\Validator;
 
-class ValidationError extends Error
+class ValidationError extends Error implements ClientAware
 {
     /** @var Validator */
     private $validator;
@@ -28,5 +29,15 @@ class ValidationError extends Error
     public function getValidator(): Validator
     {
         return $this->validator;
+    }
+
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return 'validation';
     }
 }

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
@@ -159,6 +159,32 @@ SQL
         $this->assertSame($expectedMessages, $messageBag->all());
     }
 
+    public function testErrorExtension(): void
+    {
+        /* @var User $user */
+        factory(User::class)
+            ->create([
+                'name' => 'name_unique',
+            ]);
+
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg_unique_rule_fail: String) {
+  mutationWithCustomRuleWithRuleObject(arg_unique_rule_fail: $arg_unique_rule_fail)
+}
+GRAPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($graphql, [
+            'expectErrors' => true,
+            'variables' => [
+                'arg_unique_rule_fail' => 'name_unique',
+            ],
+        ]);
+
+        $this->assertSame('validation', $result['errors'][0]['extensions']['category']);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);


### PR DESCRIPTION
## Summary

Implement the `ClientAware` interface on the `ValidationError` and `AuthorizationError`.

This will add the error category to an error response. Please refer to https://webonyx.github.io/graphql-php/error-handling/.

Technically this could be a breaking change, because error category changes from `graphql` to `validation|authorization`. However, I don't believe that anyone implemented that since the `graphql` category was used everywhere, and it would thus be pointless to check for it.

I also fixed a small typo in the pull request template.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] Code style has been fixed via `composer fix-style`
