### PR TITLE
more control over validation through optional user-generated validator

### DIFF
--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -11,10 +11,11 @@ use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type as GraphqlType;
 use GraphQL\Type\Definition\WrappingType;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
-use Validator;
 
 /**
  * @property string $name
@@ -167,6 +168,14 @@ abstract class Field
         return $rules;
     }
 
+    public function getValidator(array $args, array $rules): ValidatorContract
+    {
+        // allow our error messages to be customised
+        $messages = $this->validationErrorMessages($args);
+
+        return Validator::make($args, $rules, $messages);
+    }
+
     protected function getResolver(): ?Closure
     {
         if (! method_exists($this, 'resolve')) {
@@ -188,11 +197,7 @@ abstract class Field
             $args = $arguments[1];
             $rules = call_user_func_array([$this, 'getRules'], [$args]);
             if (count($rules)) {
-
-                // allow our error messages to be customised
-                $messages = $this->validationErrorMessages($args);
-
-                $validator = Validator::make($args, $rules, $messages);
+                $validator = $this->getValidator($args, $rules);
                 if ($validator->fails()) {
                     throw new ValidationError('validation', $validator);
                 }


### PR DESCRIPTION
## Summary
My issues #505, #506 and #507 indicated that the actual validation implementation is not customizable enough for some cases. @mfn had the idea in #506 to add a `getValidator` method to implement the functionality. I did the needed minimal changes and verified that all 3 issues can be solved by this small code change.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Code style has been fixed via `composer fix-tyle`
