### PR TITLE
composer: temporarily restrict upper testbench-core version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|4.0.*",
+        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|< 4.4.0",
+        "orchestra/testbench-core": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|< 4.4.0",
         "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0",
         "nunomaduro/larastan": "0.4.2",
         "mockery/mockery": "^1.2",


### PR DESCRIPTION
## Summary
Fixes:
> Call to undefined method NunoMaduro\Larastan\ApplicationResolver::getAnnotations()

See https://github.com/nunomaduro/larastan/issues/376

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
