### PR TITLE
[TRAVIS] Allow Laravels dev-master to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
     - php: '7.4snapshot'
       env: LARAVEL='dev-master'
   allow_failures:
+    - php: '7.2'
+      env: LARAVEL='dev-master'
+    - php: '7.3'
+      env: LARAVEL='dev-master'
     - php: '7.4snapshot'
       env: LARAVEL='5.8.*'
     - php: '7.4snapshot'


### PR DESCRIPTION
## Summary
Doesn't make sense to "require" it. Currently they're moving to
Symfony 5 so all kind of dependencies are going ot change in the
future I suspect.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- ~Code style has been fixed via `composer fix-tyle`~
  => doesn't apply
