### PR TITLE
wrong return type of getFields in type

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -41,4 +41,6 @@ parameters:
         - '/Method Rebing\\GraphQL\\Tests\\Unit\\UploadTests\\UploadSingleFileMutation::resolve\(\) should return string but returns string\|false/'
         # tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
         - '/Trying to invoke Closure\|null but it might not be a callable/'
+        - '/Property Rebing\\GraphQL\\Support\\Field\:\:\$name \(string\) does not accept int\|string\./'
+        - '/Parameter #1 \$name of method Rebing\\GraphQL\\Support\\Type\:\:getFieldResolver\(\) expects string, int\|string given\./'
     reportUnmatchedIgnoredErrors: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -41,6 +41,6 @@ parameters:
         - '/Method Rebing\\GraphQL\\Tests\\Unit\\UploadTests\\UploadSingleFileMutation::resolve\(\) should return string but returns string\|false/'
         # tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
         - '/Trying to invoke Closure\|null but it might not be a callable/'
-        - '/Property Rebing\\GraphQL\\Support\\Field\:\:\$name \(string\) does not accept int\|string\./'
-        - '/Parameter #1 \$name of method Rebing\\GraphQL\\Support\\Type\:\:getFieldResolver\(\) expects string, int\|string given\./'
+        - '/Property Rebing\\GraphQL\\Support\\Field\:\:\$name \(string\) does not accept int\|string/'
+        - '/Parameter #1 \$name of method Rebing\\GraphQL\\Support\\Type\:\:getFieldResolver\(\) expects string, int\|string given/'
     reportUnmatchedIgnoredErrors: true

--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -39,7 +39,7 @@ abstract class Type implements TypeConvertible
     }
 
     /**
-     * @return array<string,array|string|FieldDefinition|Field>
+     * @return array<int|string,array|string|FieldDefinition|Field>
      */
     public function fields(): array
     {


### PR DESCRIPTION
## Summary

Types does not match usage, see here, it allows numeric int for keys when FieldDefinition:
https://github.com/rebing/graphql-laravel#even-better-reusable-fields

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

