### PR TITLE
[GITHUB] Revert "Add preamble to PRs to ignore StyleCI"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,3 @@
-<!--
-    Please ignore the StyleCI erro checks for now, only use `composer fix-style`
-    We're currently in the process of removing StyleCI but it hasn't happened yet
--->
-
 ## Summary
 <!-- Please provide an exhaustive description. -->
 


### PR DESCRIPTION
## Summary
This reverts commit 9ac55667

Integration has now been removed
## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)
