### PR TITLE
[PHPCS] Tune configuration and fix sources

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,7 @@ return (new MattAllan\LaravelCodeStyle\Config())
             '@Laravel:risky' => true,
             // Project specific
             'declare_strict_types' => true,
+            'modernize_types_casting' => true,
             'method_argument_space' => [
                 'on_multiline' => 'ensure_fully_multiline',
             ],

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -7,5 +7,7 @@ return (new MattAllan\LaravelCodeStyle\Config())
         ->setRules([
             '@Laravel' => true,
             '@Laravel:risky' => true,
+            // Project specific
+            'declare_strict_types' => true,
         ])
         ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,6 +10,7 @@ return (new MattAllan\LaravelCodeStyle\Config())
             // Project specific
             'array_indentation' => true,
             'declare_strict_types' => true,
+            'is_null' => true,
             'modernize_types_casting' => true,
             'method_argument_space' => [
                 'on_multiline' => 'ensure_fully_multiline',

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,5 +9,8 @@ return (new MattAllan\LaravelCodeStyle\Config())
             '@Laravel:risky' => true,
             // Project specific
             'declare_strict_types' => true,
+            'method_argument_space' => [
+                'on_multiline' => 'ensure_fully_multiline',
+            ],
         ])
         ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,6 +8,7 @@ return (new MattAllan\LaravelCodeStyle\Config())
             '@Laravel' => true,
             '@Laravel:risky' => true,
             // Project specific
+            'array_indentation' => true,
             'declare_strict_types' => true,
             'modernize_types_casting' => true,
             'method_argument_space' => [

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -239,10 +239,12 @@ class GraphQL
 
         if (! $type instanceof TypeConvertible) {
             throw new TypeNotFound(
-                sprintf('Unable to convert %s to a GraphQL type, please add/implement the interface %s',
+                sprintf(
+                    'Unable to convert %s to a GraphQL type, please add/implement the interface %s',
                     get_class($type),
                     TypeConvertible::class
-                ));
+                )
+            );
         }
 
         foreach ($opts as $key => $value) {

--- a/src/Support/ResolveInfoFieldsAndArguments.php
+++ b/src/Support/ResolveInfoFieldsAndArguments.php
@@ -130,12 +130,16 @@ class ResolveInfoFieldsAndArguments
                 $spreadName = $selectionNode->name->value;
                 if (isset($this->info->fragments[$spreadName])) {
                     $fragment = $this->info->fragments[$spreadName];
-                    $fields = (array) array_replace_recursive($this->foldSelectionSet($fragment->selectionSet, $descend),
-                        $fields);
+                    $fields = (array) array_replace_recursive(
+                        $this->foldSelectionSet($fragment->selectionSet, $descend),
+                        $fields
+                    );
                 }
             } elseif ($selectionNode instanceof InlineFragmentNode) {
-                $fields = (array) array_replace_recursive($this->foldSelectionSet($selectionNode->selectionSet, $descend),
-                    $fields);
+                $fields = (array) array_replace_recursive(
+                    $this->foldSelectionSet($selectionNode->selectionSet, $descend),
+                    $fields
+                );
             }
         }
 

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -190,8 +190,14 @@ class SelectFields
                 if (is_a($parentType, config('graphql.pagination_type', PaginationType::class))) {
                     /* @var GraphqlType $fieldType */
                     $fieldType = $fieldObject->config['type'];
-                    self::handleFields($queryArgs, $field, $fieldType->getWrappedType(), $select,
-                        $with, $ctx);
+                    self::handleFields(
+                        $queryArgs,
+                        $field,
+                        $fieldType->getWrappedType(),
+                        $select,
+                        $with,
+                        $ctx
+                    );
                 }
                 // With
                 elseif (is_array($field['fields']) && $queryable) {
@@ -208,11 +214,26 @@ class SelectFields
 
                         self::addAlwaysFields($fieldObject, $field, $parentTable, true);
 
-                        $with[$relationsKey] = self::getSelectableFieldsAndRelations($queryArgs, $field, $newParentType,
-                            $customQuery, false, $ctx);
+                        $with[$relationsKey] = self::getSelectableFieldsAndRelations(
+                            $queryArgs,
+                            $field,
+                            $newParentType,
+                            $customQuery,
+                            false,
+                            $ctx
+                        );
                     } elseif (is_a($parentTypeUnwrapped, \GraphQL\Type\Definition\InterfaceType::class)) {
-                        self::handleInterfaceFields($queryArgs, $field, $parentTypeUnwrapped, $select, $with, $ctx,
-                            $fieldObject, $key, $customQuery);
+                        self::handleInterfaceFields(
+                            $queryArgs,
+                            $field,
+                            $parentTypeUnwrapped,
+                            $select,
+                            $with,
+                            $ctx,
+                            $fieldObject,
+                            $key,
+                            $customQuery
+                        );
                     } else {
                         self::handleFields($queryArgs, $field, $fieldObject->config['type'], $select, $with, $ctx);
                     }
@@ -361,8 +382,11 @@ class SelectFields
         } else {
             $foreignKey = $relation->getQualifiedForeignKeyName();
         }
-        $foreignKey = $parentTable ? ($parentTable.'.'.preg_replace('/^'.preg_quote($parentTable, '/').'\./',
-                '', $foreignKey)) : $foreignKey;
+        $foreignKey = $parentTable ? ($parentTable.'.'.preg_replace(
+            '/^'.preg_quote($parentTable, '/').'\./',
+            '',
+            $foreignKey
+        )) : $foreignKey;
         if (is_a($relation, MorphTo::class)) {
             $foreignKeyType = $relation->getMorphType();
             $foreignKeyType = $parentTable ? ($parentTable.'.'.$foreignKeyType) : $foreignKeyType;
@@ -377,8 +401,10 @@ class SelectFields
                 $select[] = $foreignKey;
             }
         } // If 'HasMany', then add it in the 'with'
-        elseif ((is_a($relation, HasMany::class) || is_a($relation, MorphMany::class) || is_a($relation,
-                    HasOne::class) || is_a($relation, MorphOne::class))
+        elseif ((is_a($relation, HasMany::class) || is_a($relation, MorphMany::class) || is_a(
+            $relation,
+            HasOne::class
+        ) || is_a($relation, MorphOne::class))
             && ! array_key_exists($foreignKey, $field)) {
             $segments = explode('.', $foreignKey);
             $foreignKey = end($segments);
@@ -478,7 +504,8 @@ class SelectFields
                     function (GraphqlType $type) use ($query) {
                         /* @var Relation $query */
                         return app($type->config['model'])->getTable() === $query->getParent()->getTable();
-                    });
+                    }
+                );
                 $typesFiltered = array_values($typesFiltered ?? []);
 
                 if (count($typesFiltered) === 1) {
@@ -496,8 +523,14 @@ class SelectFields
             }
 
             /** @var callable $callable */
-            $callable = self::getSelectableFieldsAndRelations($queryArgs, $field, $newParentType, $customQuery,
-                false, $ctx);
+            $callable = self::getSelectableFieldsAndRelations(
+                $queryArgs,
+                $field,
+                $newParentType,
+                $customQuery,
+                false,
+                $ctx
+            );
 
             return $callable($query);
         };

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
@@ -36,7 +36,8 @@ GRAPHQL;
             ],
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select count(*) as aggregate from "users" where "name" = ?;
 SQL
         );
@@ -72,7 +73,8 @@ GRAPHQL;
             ],
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select count(*) as aggregate from "users" where "name" = ?;
 SQL
         );
@@ -143,7 +145,8 @@ GRAPHQL;
             ],
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select count(*) as aggregate from "users" where "name" = ?;
 SQL
         );

--- a/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
+++ b/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
@@ -51,7 +51,8 @@ GRAQPHQL;
             'expectErrors' => true,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id" from "users";
 SQL
         );
@@ -134,7 +135,8 @@ GRAQPHQL;
             'expectErrors' => true,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."name", "users"."id" from "users";
 SQL
         );

--- a/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
+++ b/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
@@ -44,7 +44,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id", "comments"."body" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -99,7 +100,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id", "comments"."body", "comments"."title" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -154,7 +156,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id", "comments"."body", "comments"."title" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -209,7 +212,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id", "comments"."body" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL

--- a/tests/Database/SelectFields/ArrayTests/ArrayTest.php
+++ b/tests/Database/SelectFields/ArrayTests/ArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Database\SelectFields\ArrayTests;
 
 use Rebing\GraphQL\Tests\Support\Models\Post;

--- a/tests/Database/SelectFields/ComputedPropertiesTests/ComputedPropertiesTest.php
+++ b/tests/Database/SelectFields/ComputedPropertiesTests/ComputedPropertiesTest.php
@@ -42,7 +42,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users";
 select "posts"."id", "posts"."published_at", "posts"."user_id" from "posts" where "posts"."user_id" in (?) order by "posts"."id" asc;
 SQL

--- a/tests/Database/SelectFields/DepthTests/DepthTest.php
+++ b/tests/Database/SelectFields/DepthTests/DepthTest.php
@@ -96,7 +96,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id" from "users";
 select "posts"."id", "posts"."user_id" from "posts" where "posts"."user_id" in (?) order by "posts"."id" asc;
 select "users"."id" from "users" where "users"."id" in (?);

--- a/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
+++ b/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
@@ -34,7 +34,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "title" from "posts";
 SQL
         );
@@ -79,7 +80,8 @@ GRAPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "id", "title" from "posts";
 select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?) and "id" >= ? order by "comments"."id" asc;
 SQL
@@ -141,14 +143,16 @@ GRAPHQL;
         $result = $this->graphql($graphql);
 
         if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
 select * from "posts" where "posts"."id" in (?);
 SQL
             );
         } else {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
 select "id", "title" from "posts" where "posts"."id" in (?);
@@ -223,7 +227,8 @@ GRAPHQL;
         $result = $this->graphql($graphql);
 
         if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
 select * from "posts" where "posts"."id" in (?);
@@ -231,7 +236,8 @@ select "likes"."id", "likes"."likable_id", "likes"."likable_type" from "likes" w
 SQL
             );
         } else {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
 select "id", "title" from "posts" where "posts"."id" in (?);
@@ -334,7 +340,8 @@ GRAPHQL;
         $result = $this->graphql($graphql);
 
         if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
 select * from "comments" where "comments"."id" in (?);
@@ -342,7 +349,8 @@ select "likes"."id", "likes"."likable_id", "likes"."likable_type" from "likes" w
 SQL
             );
         } else {
-            $this->assertSqlQueries(<<<'SQL'
+            $this->assertSqlQueries(
+                <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
 select "id", "title" from "comments" where "comments"."id" in (?);

--- a/tests/Database/SelectFields/InterfaceTests/PostType.php
+++ b/tests/Database/SelectFields/InterfaceTests/PostType.php
@@ -21,7 +21,8 @@ class PostType extends GraphQLType
     {
         $interface = GraphQL::type('LikableInterface');
 
-        return [
+        return
+            [
                 'likes' => [
                     'type' => Type::listOf(GraphQL::type('Like')),
                     'query' => function (array $args, MorphMany $query) {

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
@@ -55,7 +55,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select * from "users" order by "users"."id" asc;
 select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
 select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
@@ -196,7 +197,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
 select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
@@ -337,7 +339,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select * from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
@@ -474,7 +477,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
@@ -624,7 +628,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) order by "comments"."id" asc;
@@ -750,7 +755,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) and "comments"."flag" = ? order by "comments"."id" asc;
@@ -833,7 +839,8 @@ GRAQPHQL;
 
         $result = $this->graphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?) and "posts"."flag" = ? order by "posts"."id" asc;
 SQL

--- a/tests/Database/SelectFields/PrimaryKeyTests/PaginationTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PaginationTest.php
@@ -56,7 +56,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select count(*) as aggregate from "posts";
 select "posts"."title", "posts"."id" from "posts" limit 1 offset 0;
 select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;

--- a/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
@@ -34,7 +34,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id" from "posts";
 select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -99,7 +100,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select count(*) as aggregate from "posts";
 select "posts"."title", "posts"."id" from "posts" limit 1 offset 0;
 select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
@@ -74,7 +74,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
 SQL
@@ -140,7 +141,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select * from "users" order by "users"."id" asc;
 select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
 select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
@@ -281,7 +283,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null order by "posts"."id" asc;
 select * from "comments" where "comments"."post_id" = ? and "comments"."post_id" is not null order by "comments"."id" asc;
@@ -422,7 +425,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select * from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
@@ -559,7 +563,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?, ?, ?) order by "comments"."id" asc;
@@ -704,7 +709,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) order by "comments"."id" asc;
@@ -825,7 +831,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) and "posts"."flag" = ? order by "posts"."id" asc;
 select "comments"."body", "comments"."id", "comments"."title", "comments"."post_id" from "comments" where "comments"."post_id" in (?, ?) and "comments"."flag" = ? order by "comments"."id" asc;
@@ -908,7 +915,8 @@ GRAQPHQL;
 
         $result = $this->httpGraphql($graphql);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users" order by "users"."id" asc;
 select "posts"."body", "posts"."id", "posts"."title", "posts"."user_id" from "posts" where "posts"."user_id" in (?) and "posts"."flag" = ? order by "posts"."id" asc;
 SQL

--- a/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
+++ b/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Database\SelectFields\ValidateDiffNodeTests;
 
 use Rebing\GraphQL\Tests\Support\Models\Post;

--- a/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
+++ b/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
@@ -47,7 +47,8 @@ GRAQPHQL;
         $this->sqlCounterReset();
 
         $result = $this->graphql($graphql);
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id", "users"."name" from "users";
 select "posts"."id", "posts"."body", "posts"."user_id" from "posts" where "posts"."user_id" in (?, ?) order by "posts"."id" asc;
 SQL

--- a/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
@@ -46,7 +46,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -101,7 +102,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -156,7 +158,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."body", "posts"."title", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
@@ -199,7 +202,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 SQL
         );
@@ -235,7 +239,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id" from "posts";
 SQL
         );
@@ -271,7 +276,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 SQL
         );
@@ -307,7 +313,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id" from "posts";
 SQL
         );
@@ -354,7 +361,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 SQL
         );
@@ -394,7 +402,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 SQL
         );
@@ -433,7 +442,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."title", "posts"."id" from "posts";
 SQL
         );

--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -258,13 +258,13 @@ GRAQPHQL;
 
         $expectedResult = [
             'data' => [
-                    'postsListOfWithSelectFieldsAndModel' => [
-                                [
-                                    'id' => "$post->id",
-                                    'title' => 'Title of the post',
-                                ],
-                        ],
+                'postsListOfWithSelectFieldsAndModel' => [
+                    [
+                        'id' => "$post->id",
+                        'title' => 'Title of the post',
+                    ],
                 ],
+            ],
         ];
 
         $this->assertEquals($response->getStatusCode(), 200);

--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -51,7 +51,8 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select * from "posts" where "posts"."id" = ? limit 1;
 SQL
         );
@@ -179,7 +180,8 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id", "posts"."title" from "posts" where "posts"."id" = ? limit 1;
 SQL
         );
@@ -408,7 +410,8 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id", "posts"."title" from "posts" where "posts"."id" = ? limit 1;
 SQL
         );
@@ -507,7 +510,8 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "posts"."id", "posts"."title" from "posts" where "posts"."id" = ? limit 1;
 SQL
         );
@@ -548,7 +552,8 @@ GRAQPHQL;
             'query' => $graphql,
         ]);
 
-        $this->assertSqlQueries(<<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "id", "title" from "posts" where "posts"."id" = ? limit 1;
 SQL
         );

--- a/tests/Support/Traits/SqlAssertionTrait.php
+++ b/tests/Support/Traits/SqlAssertionTrait.php
@@ -56,13 +56,16 @@ trait SqlAssertionTrait
             $msg .= "\n\n";
         }
 
-        $msg .= sprintf("Expected number of SQL statements of %d does not match the actual value of %d\nQueries:\n\n%s\n",
+        $msg .= sprintf(
+            "Expected number of SQL statements of %d does not match the actual value of %d\nQueries:\n\n%s\n",
             $expectedCount,
             $numSqlQueries,
-            implode("\n",
+            implode(
+                "\n",
                 array_map(
                     function (QueryExecuted $query) {
-                        return sprintf('[%s] %s',
+                        return sprintf(
+                            '[%s] %s',
                             $query->connectionName,
                             $query->sql
                         );
@@ -86,7 +89,8 @@ trait SqlAssertionTrait
     {
         $expectedQueries = trim($expectedQueries);
         $actualQueries = trim(
-            implode("\n",
+            implode(
+                "\n",
                 array_map(
                     function (QueryExecuted $query): string {
                         // Replace any numeric literals with "fake" bind
@@ -96,17 +100,18 @@ trait SqlAssertionTrait
                         // IDs which may change during multiple test
                         // runs, which we now manually need to normalize
                         return preg_replace(
-                                [
+                            [
                                     // Covers integers in `WHERE IN ()`
                                     '/\d+(,|\))/',
                                     // Covers simple `WHERE x =`
                                     '/= \d+/',
                                 ],
-                                [
+                            [
                                     '?$1',
                                     '= ?',
                                 ],
-                                $query->sql).';';
+                            $query->sql
+                        ).';';
                     },
                     $this->sqlQueryEvents
                 )

--- a/tests/Support/Traits/SqlAssertionTrait.php
+++ b/tests/Support/Traits/SqlAssertionTrait.php
@@ -101,15 +101,15 @@ trait SqlAssertionTrait
                         // runs, which we now manually need to normalize
                         return preg_replace(
                             [
-                                    // Covers integers in `WHERE IN ()`
-                                    '/\d+(,|\))/',
-                                    // Covers simple `WHERE x =`
-                                    '/= \d+/',
-                                ],
+                                // Covers integers in `WHERE IN ()`
+                                '/\d+(,|\))/',
+                                // Covers simple `WHERE x =`
+                                '/= \d+/',
+                            ],
                             [
-                                    '?$1',
-                                    '= ?',
-                                ],
+                                '?$1',
+                                '= ?',
+                            ],
                             $query->sql
                         ).';';
                     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -255,7 +255,8 @@ class TestCase extends BaseTestCase
      */
     private function formatSafeTrace(array $trace): string
     {
-        return implode("\n",
+        return implode(
+            "\n",
             array_map(function (array $row, int $index): string {
                 $line = "#$index ";
                 $line .= $row['file'] ?? '';
@@ -270,6 +271,7 @@ class TestCase extends BaseTestCase
                 }
 
                 return $line;
-            }, $trace, array_keys($trace)));
+            }, $trace, array_keys($trace))
+        );
     }
 }

--- a/tests/Unit/Console/PublishCommandTest.php
+++ b/tests/Unit/Console/PublishCommandTest.php
@@ -45,8 +45,11 @@ class PublishCommandTest extends TestCase
                     return true;
                 }),
                 $this->callback(function (string $to): bool {
-                    $this->assertRegExp('|laravel[/\\\\]resources/views/vendor/graphql/graphiql.php|', $to,
-                        '2nd call to copy, $to');
+                    $this->assertRegExp(
+                        '|laravel[/\\\\]resources/views/vendor/graphql/graphiql.php|',
+                        $to,
+                        '2nd call to copy, $to'
+                    );
 
                     return true;
                 })
@@ -59,7 +62,9 @@ class PublishCommandTest extends TestCase
 
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertRegExp('|Copied File.*[/\\\\]config[/\\\\]config.php.* To|', $tester->getDisplay());
-        $this->assertRegExp('|Copied File.*[/\\\\]resources[/\\\\]views[/\\\\]graphiql.php.* To|',
-            $tester->getDisplay());
+        $this->assertRegExp(
+            '|Copied File.*[/\\\\]resources[/\\\\]views[/\\\\]graphiql.php.* To|',
+            $tester->getDisplay()
+        );
     }
 }

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -195,14 +195,17 @@ It is required when 'lazyload_types' is enabled";
     {
         $this->app['config']->set('graphql.defaultFieldResolver', [static::class, 'exampleDefaultFieldResolverForTest']);
 
-        $result = GraphQL::queryAndReturnResult($this->queries['examplesCustom'],
-            null, [
+        $result = GraphQL::queryAndReturnResult(
+            $this->queries['examplesCustom'],
+            null,
+            [
                 'schema' => [
                     'query' => [
                         'examplesCustom' => ExamplesQuery::class,
                     ],
                 ],
-            ]);
+            ]
+        );
 
         $expectedDataResult = [
             'examplesCustom' => [
@@ -235,14 +238,17 @@ It is required when 'lazyload_types' is enabled";
             return 'defaultFieldResolver closure value';
         });
 
-        $result = GraphQL::queryAndReturnResult($this->queries['examplesCustom'],
-            null, [
+        $result = GraphQL::queryAndReturnResult(
+            $this->queries['examplesCustom'],
+            null,
+            [
                 'schema' => [
                     'query' => [
                         'examplesCustom' => ExamplesQuery::class,
                     ],
                 ],
-            ]);
+            ]
+        );
 
         $expectedDataResult = [
             'examplesCustom' => [

--- a/tests/Unit/InstantiableTypesTest/UserType.php
+++ b/tests/Unit/InstantiableTypesTest/UserType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Unit\InstantiableTypesTest;
 
 use GraphQL\Type\Definition\Type;

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -160,7 +160,7 @@ class MutationTest extends FieldTest
                 'test_with_rules_non_nullable_input_object' => [
                     'nest' => ['email' => 'invalidTestEmail.com'],
                 ],
-             ], [], null);
+            ], [], null);
         } catch (ValidationError $e) {
             $messages = $e->getValidatorMessages();
 

--- a/tests/Unit/UploadTests/UploadTest.php
+++ b/tests/Unit/UploadTests/UploadTest.php
@@ -166,9 +166,9 @@ class UploadTest extends TestCase
             [
                 'data' => [
                     'uploadMultipleFiles' => [
-                            'File 2 to upload',
-                            'File 3 to upload',
-                        ],
+                        'File 2 to upload',
+                        'File 3 to upload',
+                    ],
                 ],
             ],
         ];

--- a/tests/Unit/WithTypeTests/PostType.php
+++ b/tests/Unit/WithTypeTests/PostType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Unit\WithTypeTests;
 
 use GraphQL\Type\Definition\Type;

--- a/tests/Unit/WithTypeTests/SimpleMessage.php
+++ b/tests/Unit/WithTypeTests/SimpleMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Unit\WithTypeTests;
 
 class SimpleMessage

--- a/tests/Unit/WithTypeTests/SimpleMessageType.php
+++ b/tests/Unit/WithTypeTests/SimpleMessageType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rebing\GraphQL\Tests\Unit\WithTypeTests;
 
 use GraphQL\Type\Definition\Type;


### PR DESCRIPTION
## Summary
Although I prefer default settings of software when possible (maintenance…), this library uses certain style configuration to improve Quality of Life we don't want to miss:
- `array_indentation`
  Ensure they're always correctly aligned => there were some violations found
- `declare_strict_types`
  Enforce having `declare(strict_types=1);` in all files
- `is_null`
  Enforce to use `null ===`; this library uses it and we've had PRs with a different style
- `modernize_types_casting`
  No actual violations present, just a precaution
- `method_argument_space` with `'on_multiline' => 'ensure_fully_multiline'`
  Make multiline wrapping consistent. Otherwise we break anywhere in a method call and can become harder to read.

## Type of change
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- ~Existing tests have been adapted and/or new tests have been added~
- ~Add a CHANGELOG.md entry~
- ~Update the README.md~
- [x] Code style has been fixed via `composer fix-style`
