### PR TITLE
[TRAVIS] Test against 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ matrix:
     - php: '7.3'
       env: LARAVEL='dev-master'
     - php: '7.4'
-      env: LARAVEL='5.8.*'
-    - php: '7.4'
-      env: LARAVEL='^6.0'
-    - php: '7.4'
       env: LARAVEL='dev-master'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,22 +33,22 @@ matrix:
       env: LARAVEL='^6.0' INSTALL_LARAVEL=1 INSTALL_LUMEN=1
     - php: '7.3'
       env: LARAVEL='dev-master'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='5.8.*'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='^6.0'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='dev-master'
   allow_failures:
     - php: '7.2'
       env: LARAVEL='dev-master'
     - php: '7.3'
       env: LARAVEL='dev-master'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='5.8.*'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='^6.0'
-    - php: '7.4snapshot'
+    - php: '7.4'
       env: LARAVEL='dev-master'
 
 before_script:


### PR DESCRIPTION
## Summary
It's been officially released on 2019-11-28

However there's no 7.4 yet available on travis, so this PR is blocked until there is.

## Type of change
expected)
- [x] Misc. change (internal, infrastructure, maintenance, etc.)
