### PR TITLE
Fix type example in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -208,7 +208,7 @@ class UserType extends GraphQLType
             'email' => [
                 'type' => Type::string(),
                 'description' => 'The email of user',
-                'resolve => function($root, $args) {
+                'resolve' => function($root, $args) {
                     // If you want to resolve the field yourself, 
                     // it can be done here
                     return strtolower($root->email);


### PR DESCRIPTION
## Summary
There is a quote missing typo in the source example provided in Readme.md

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
