### PR TITLE
Add support for custom authorization message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/4.0.0...master)
 --------------
 
+### Added
+- Add support for custom authorization message
+
 2019-12-09, 4.0.0
 -----------------
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -710,6 +710,33 @@ class UsersQuery extends Query
 }
 ```
 
+You can also provide a custom error message when the authorization fails (defaults to Unauthorized):
+
+```php
+use Auth;
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class UsersQuery extends Query
+{
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        if (isset($args['id'])) {
+            return Auth::id() == $args['id'];
+        }
+
+        return true;
+    }
+
+    public function getAuthorizationMessage(): string
+    {
+        return 'You are not authorized to perform this action';
+    }
+
+    // ...
+}
+```
+
 ### Privacy
 
 You can set custom privacy attributes for every Type's Field. If a field is not

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -210,7 +210,7 @@ abstract class Field
 
             // Authorize
             if (true != call_user_func_array($authorize, $arguments)) {
-                throw new AuthorizationError('Unauthorized');
+                throw new AuthorizationError($this->getAuthorizationMessage());
             }
 
             $method = new ReflectionMethod($this, 'resolve');
@@ -288,6 +288,11 @@ abstract class Field
         }
 
         return $attributes;
+    }
+
+    public function getAuthorizationMessage(): string
+    {
+        return 'Unauthorized';
     }
 
     /**

--- a/tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+++ b/tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+class ExamplesAuthorizeMessageQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Examples authorize query',
+    ];
+
+    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        return false;
+    }
+
+    public function getAuthorizationMessage(): string
+    {
+        return 'You are not authorized to perform this action';
+    }
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('Example'));
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => ['name' => 'index', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    {
+        $data = include __DIR__.'/data.php';
+
+        if (isset($args['index'])) {
+            return [
+                $data[$args['index']],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -58,6 +58,14 @@ return [
         }
     ',
 
+    'examplesWithAuthorizeMessage' => '
+        query QueryExamplesAuthorizeMessage {
+            examplesAuthorizeMessage {
+                test
+            }
+        }
+    ',
+
     'examplesWithError' => '
         query QueryExamplesWithError {
             examplesQueryNotFound {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesConfigAliasQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesFilteredQuery;
@@ -53,6 +54,7 @@ class TestCase extends BaseTestCase
             'query' => [
                 'examples' => ExamplesQuery::class,
                 'examplesAuthorize' => ExamplesAuthorizeQuery::class,
+                'examplesAuthorizeMessage' => ExamplesAuthorizeMessageQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
                 'examplesFiltered' => ExamplesFilteredQuery::class,
                 'examplesConfigAlias' => ExamplesConfigAliasQuery::class,

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -104,6 +104,24 @@ class EndpointTest extends TestCase
     }
 
     /**
+     * Test get with unauthorized query and custom error message.
+     */
+    public function testGetUnauthorizedWithCustomError(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => $this->queries['examplesWithAuthorizeMessage'],
+        ]);
+
+        $this->assertEquals($response->getStatusCode(), 200);
+
+        $content = $response->getData(true);
+        $this->assertArrayHasKey('data', $content);
+        $this->assertArrayHasKey('errors', $content);
+        $this->assertEquals($content['errors'][0]['message'], 'You are not authorized to perform this action');
+        $this->assertNull($content['data']['examplesAuthorizeMessage']);
+    }
+
+    /**
      * Test support batched queries.
      */
     public function testBatchedQueries(): void

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -121,6 +121,18 @@ It is required when 'lazyload_types' is enabled";
     }
 
     /**
+     * Test query with authorize.
+     */
+    public function testQueryAndReturnResultWithCustomAuthorizeMessage(): void
+    {
+        $result = $this->graphql($this->queries['examplesWithAuthorizeMessage'], [
+            'expectErrors' => true,
+        ]);
+        $this->assertNull($result['data']['examplesAuthorizeMessage']);
+        $this->assertEquals('You are not authorized to perform this action', $result['errors'][0]['message']);
+    }
+
+    /**
      * Test query with schema.
      */
     public function testQueryAndReturnResultWithSchema(): void


### PR DESCRIPTION
## Summary
Currently it is not possible to override the authorization message in case the authorization message returns false.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
