### PR TITLE
Fix infinite loop

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -446,7 +446,13 @@ class UpdateUserEmailMutation extends Mutation
     {
         return [
             'id' => ['required'],
-            'email' => ['required', 'email']
+            'email' => ['required', 'email'],
+            'password' => function($inputArguments, $mutationArguments) {
+                if ($inputArguments['id'] !== 1337) {
+                    return ['required'];
+                }
+                return [];
+            }
         ];
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -110,15 +110,6 @@ parameters:
 			count: 1
 			path: src/GraphQLServiceProvider.php
 
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/AliasArguments/AliasArguments.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) has parameter \\$typedArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/AliasArguments/AliasArguments.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -127,11 +118,6 @@ parameters:
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/AliasArguments/AliasArguments.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$parentType with no typehint specified\\.$#"
 			count: 1
 			path: src/Support/AliasArguments/AliasArguments.php
 
@@ -202,56 +188,6 @@ parameters:
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:validationErrorMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:inferRulesFromType\\(\\) has parameter \\$resolutionArguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:inferRulesFromType\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getInputTypeRules\\(\\) has parameter \\$resolutionArguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Field.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getInputTypeRules\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/Field.php
 
@@ -584,31 +520,6 @@ parameters:
 			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
 			count: 5
 			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
-
-		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:\\$attributes has no typehint specified\\.$#"
-			count: 1
-			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\RuleObjectFail\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -1661,71 +1572,6 @@ parameters:
 			path: tests/Support/Objects/ExamplesQuery.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:\\$attributes has no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutation.php
-
-		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:\\$attributes has no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
-
-		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
@@ -2311,16 +2157,6 @@ parameters:
 			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
 			count: 1
 			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
@@ -2329,31 +2165,6 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
 			count: 1
 			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
-
-		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:\\$attributes has no typehint specified\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\RuleObject\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -2375,25 +2186,6 @@ parameters:
 			count: 1
 			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
 
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\RuleObjectFail\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -108,6 +108,7 @@ class GraphQLController extends Controller
     protected function getRouteParameters(Request $request): array
     {
         if (Helpers::isLumen()) {
+            /** @var array<int,mixed> $route */
             $route = $request->route();
 
             return $route[2] ?? [];

--- a/src/Support/Rules.php
+++ b/src/Support/Rules.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support;
+
+use GraphQL\Type\Definition\InputObjectField;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\Type as GraphqlType;
+
+class Rules
+{
+    /**
+     * @var  array<string,mixed>
+     */
+    private $queryArguments;
+    /**
+     * @var array<string,mixed>
+     */
+    private $requestArguments;
+
+    /**
+     * @param array<string,mixed> $queryArguments
+     * @param array<string,mixed> $requestArguments
+     */
+    public function __construct(array $queryArguments, array $requestArguments)
+    {
+        $this->queryArguments = $queryArguments;
+        $this->requestArguments = $requestArguments;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function get(): array
+    {
+        return $this->getRules($this->queryArguments, null, $this->requestArguments);
+    }
+
+    /**
+     * @param  array<string,mixed>|string|callable  $rules
+     * @param  array<string,mixed>  $arguments
+     * @return array<string,mixed>|string
+     */
+    protected function resolveRules($rules, array $arguments)
+    {
+        if (is_callable($rules)) {
+            return call_user_func($rules, $arguments, $this->requestArguments);
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param GraphqlType $type
+     * @param string $prefix
+     * @param array<string,mixed> $resolutionArguments
+     * @return array<string,mixed>
+     */
+    protected function inferRulesFromType(GraphqlType $type, string $prefix, array $resolutionArguments): array
+    {
+        $isList = false;
+        $rules = [];
+
+        // make sure we are dealing with the actual type
+        if ($type instanceof NonNull) {
+            $type = $type->getWrappedType();
+        }
+
+        // if it is an array type, add an array validation component
+        if ($type instanceof ListOfType) {
+            $type = $type->getWrappedType();
+
+            $isList = true;
+        }
+
+        if ($type instanceof NonNull) {
+            $type = $type->getWrappedType();
+        }
+
+        // if it is an input object type - the only type we care about here...
+        if ($type instanceof InputObjectType) {
+            // merge in the input type's rules
+
+            if ($isList) {
+                if (empty($resolutionArguments)) {
+                    return [];
+                }
+
+                foreach ($resolutionArguments as $index => $input) {
+                    $key = "{$prefix}.{$index}";
+                    if ($input !== null) {
+                        $rules = $rules + $this->getInputTypeRules($type, $key, $input);
+                    }
+                }
+
+                return $rules;
+            }
+
+            $rules = $rules + $this->getInputTypeRules($type, $prefix, $resolutionArguments);
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param InputObjectType $input
+     * @param string $prefix
+     * @param array<string,mixed> $resolutionArguments
+     * @return array<string,mixed>
+     */
+    protected function getInputTypeRules(InputObjectType $input, string $prefix, array $resolutionArguments): array
+    {
+        return $this->getRules($input->getFields(), $prefix, $resolutionArguments);
+    }
+
+    /**
+     * Get rules from fields.
+     *
+     * @param array<string,mixed> $fields
+     * @param string|null $prefix
+     * @param array<string,mixed> $resolutionArguments
+     * @return array<string,mixed>
+     */
+    protected function getRules(array $fields, ?string $prefix, array $resolutionArguments): array
+    {
+        $rules = [];
+
+        foreach ($fields as $name => $field) {
+            $field = $field instanceof InputObjectField ? $field : (object) $field;
+
+            $key = $prefix === null ? $name : "{$prefix}.{$name}";
+
+            // get any explicitly set rules
+            if (isset($field->rules)) {
+                $rules[$key] = $this->resolveRules($field->rules, $resolutionArguments);
+            }
+
+            if (property_exists($field, 'type') && array_key_exists($name, $resolutionArguments) && is_array($resolutionArguments[$name])) {
+                $rules = $rules + $this->inferRulesFromType($field->type, $key, $resolutionArguments[$name]);
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -9,6 +9,9 @@ use Rebing\GraphQL\Support\Mutation;
 
 class MutationWithCustomRuleWithRuleObject extends Mutation
 {
+    /**
+     * @var array<string,string>
+     */
     protected $attributes = [
         'name' => 'mutationWithCustomRuleWithRuleObject',
     ];
@@ -44,7 +47,12 @@ class MutationWithCustomRuleWithRuleObject extends Mutation
         ];
     }
 
-    public function resolve($root, $args): string
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return string
+     */
+    public function resolve($root, array $args): string
     {
         return 'mutation result';
     }

--- a/tests/Support/Objects/ExampleRuleTestingInputObject.php
+++ b/tests/Support/Objects/ExampleRuleTestingInputObject.php
@@ -6,13 +6,17 @@ namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Assert;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\InputType;
 
-class ExampleValidationInputObject extends InputType
+class ExampleRuleTestingInputObject extends InputType
 {
+    /**
+     * @var array<string,string>
+     */
     protected $attributes = [
-        'name' => 'ExampleValidationInputObject',
+        'name' => 'ExampleRuleTestingInputObject',
     ];
 
     public function type(): ListOfType
@@ -29,7 +33,12 @@ class ExampleValidationInputObject extends InputType
             ],
             'otherValue' => [
                 'type' => Type::int(),
-                'rules' => function ($rules) {
+                'rules' => function ($arguments) {
+                    Assert::assertSame(
+                        $arguments,
+                        ['otherValue' => 1337]
+                    );
+
                     return ['required'];
                 },
             ],
@@ -46,7 +55,12 @@ class ExampleValidationInputObject extends InputType
         ];
     }
 
-    public function resolve($root, $args): array
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return array<string>
+     */
+    public function resolve($root, array $args): array
     {
         return ['test'];
     }

--- a/tests/Support/Objects/UpdateExampleMutation.php
+++ b/tests/Support/Objects/UpdateExampleMutation.php
@@ -12,6 +12,9 @@ use Rebing\GraphQL\Support\Mutation;
 
 class UpdateExampleMutation extends Mutation
 {
+    /**
+     * @var array<string,string>
+     */
     protected $attributes = [
         'name' => 'updateExample',
     ];
@@ -52,7 +55,15 @@ class UpdateExampleMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @param mixed $context
+     * @param ResolveInfo $resolveInfo
+     * @param Closure $getSelectFields
+     * @return array<string,mixed>
+     */
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
     {
         return [
             'test' => $args['test'],

--- a/tests/Support/Objects/UpdateExampleMutationForRuleTesting.php
+++ b/tests/Support/Objects/UpdateExampleMutationForRuleTesting.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Assert;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Mutation;
 
-class UpdateExampleMutationWithInputType extends Mutation
+class UpdateExampleMutationForRuleTesting extends Mutation
 {
     /**
      * @var array<string,string>
      */
     protected $attributes = [
-        'name' => 'updateExample',
+        'name' => 'updateExampleMutationForRuleTesting',
     ];
 
     public function type(): Type
@@ -22,6 +23,10 @@ class UpdateExampleMutationWithInputType extends Mutation
         return GraphQL::type('Example');
     }
 
+    /**
+     * @param array<string,mixed> $args
+     * @return array<string,mixed>
+     */
     protected function rules(array $args = []): array
     {
         return [
@@ -29,19 +34,12 @@ class UpdateExampleMutationWithInputType extends Mutation
         ];
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function args(): array
     {
         return [
-            'test' => [
-                'name' => 'test',
-                'type' => Type::string(),
-            ],
-
-            'test_with_rules' => [
-                'name' => 'test',
-                'type' => Type::string(),
-                'rules' => ['required'],
-            ],
             'test_with_rules_closure' => [
                 'name' => 'test',
                 'type' => Type::string(),
@@ -49,22 +47,30 @@ class UpdateExampleMutationWithInputType extends Mutation
                     return ['required'];
                 },
             ],
+            'test_with_rules_callback_params' => [
+                'type' => GraphQL::type('ExampleRuleTestingInputObject'),
+                'rules' => function ($inputArguments, $mutationArguments) {
+                    $fullParamsExpected = [
+                        'test_with_rules_callback_params' => [
+                            'otherValue' => 1337,
+                        ],
+                    ];
 
-            'test_with_rules_nullable_input_object' => [
-                'type' => GraphQL::type('ExampleValidationInputObject'),
-                'rules' => ['nullable'],
+                    Assert::assertSame(
+                        $mutationArguments,
+                        $fullParamsExpected
+                    );
+
+                    Assert::assertSame(
+                        $inputArguments,
+                        $fullParamsExpected
+                    );
+
+                    return ['required'];
+                },
+
             ],
 
-            'test_with_rules_non_nullable_input_object' => [
-                'name' => 'test',
-                'type' => Type::nonNull(GraphQL::type('ExampleValidationInputObject')),
-                'rules' => ['required'],
-            ],
-
-            'test_with_rules_non_nullable_list_of_non_nullable_input_object' => [
-                'name'  => 'test',
-                'type'  => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('ExampleValidationInputObject')))),
-            ],
         ];
     }
 

--- a/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -9,6 +9,9 @@ use Rebing\GraphQL\Support\Mutation;
 
 class MutationWithCustomRuleWithRuleObject extends Mutation
 {
+    /**
+     * @var array<string,string>
+     */
     protected $attributes = [
         'name' => 'mutationWithCustomRuleWithRuleObject',
     ];
@@ -37,7 +40,12 @@ class MutationWithCustomRuleWithRuleObject extends Mutation
         ];
     }
 
-    public function resolve($root, $args): string
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return string
+     */
+    public function resolve($root, array $args): string
     {
         return 'mutation result';
     }

--- a/tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+++ b/tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
@@ -44,7 +44,12 @@ class MutationWithCustomRuleWithRuleObject extends Mutation
         ];
     }
 
-    public function resolve($root, $args): string
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return string
+     */
+    public function resolve($root, array $args): string
     {
         return 'mutation result';
     }

--- a/tests/Unit/RecursionTest/Inputs/AuthorInput.php
+++ b/tests/Unit/RecursionTest/Inputs/AuthorInput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\InputType;
+
+class AuthorInput extends InputType
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $attributes = [
+        'name' => 'AuthorInput',
+        'description' => 'An example input',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::int(),
+            ],
+            'name' => [
+                'type' => Type::string(),
+            ],
+            'books' => [
+                'type' => Type::listOf(GraphQL::type('BookInput')),
+            ],
+            'bestSellingBook' => [
+                'type' => GraphQL::type('BookInput'),
+            ],
+        ];
+    }
+}

--- a/tests/Unit/RecursionTest/Inputs/BookInput.php
+++ b/tests/Unit/RecursionTest/Inputs/BookInput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\InputType;
+
+class BookInput extends InputType
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $attributes = [
+        'name' => 'BookInput',
+        'description' => 'An example input',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::int(),
+            ],
+            'name' => [
+                'type' => Type::string(),
+            ],
+            'publisher' => [
+                'type' => GraphQL::type('PublisherInput'),
+            ],
+            'author' => [
+                'type' => GraphQL::type('AuthorInput'),
+            ],
+        ];
+    }
+}

--- a/tests/Unit/RecursionTest/Inputs/PublisherInput.php
+++ b/tests/Unit/RecursionTest/Inputs/PublisherInput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\InputType;
+
+class PublisherInput extends InputType
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $attributes = [
+        'name' => 'PublisherInput',
+        'description' => 'An example input',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::int(),
+            ],
+            'name' => [
+                'type' => Type::string(),
+            ],
+            'authors' => [
+                'type' => Type::listOf(GraphQL::type('AuthorInput')),
+            ],
+            'bestSellingAuthor' => [
+                'type' => GraphQL::type('AuthorInput'),
+            ],
+        ];
+    }
+}

--- a/tests/Unit/RecursionTest/Mutations/SaveAuthor.php
+++ b/tests/Unit/RecursionTest/Mutations/SaveAuthor.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest\Mutations;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Mutation;
+
+class SaveAuthor extends Mutation
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $attributes = [
+        'name' => 'SaveAuthor',
+    ];
+
+    public function type(): Type
+    {
+        return Type::boolean();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function args(): array
+    {
+        return [
+            'author' => [
+                'name' => 'author',
+                'type' => GraphQL::type('AuthorInput'),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $args
+     * @return array<string,mixed>
+     */
+    protected function rules(array $args = []): array
+    {
+        return [
+            'author' => ['required'],
+        ];
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return bool
+     */
+    public function resolve($root, $args): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/RecursionTest/Mutations/SavePublisher.php
+++ b/tests/Unit/RecursionTest/Mutations/SavePublisher.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest\Mutations;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Mutation;
+
+class SavePublisher extends Mutation
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $attributes = [
+        'name' => 'SavePublisher',
+    ];
+
+    public function type(): Type
+    {
+        return Type::boolean();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function args(): array
+    {
+        return [
+            'publisher' => [
+                'name' => 'publisher',
+                'type' => GraphQL::type('PublisherInput'),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $args
+     * @return array<string,mixed>
+     */
+    protected function rules(array $args = []): array
+    {
+        return [
+            'publisher' => ['required'],
+        ];
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @return bool
+     */
+    public function resolve($root, array $args): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/RecursionTest/RecursionTest.php
+++ b/tests/Unit/RecursionTest/RecursionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\RecursionTest;
+
+use Rebing\GraphQL\Tests\TestCase;
+use Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs\AuthorInput;
+use Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs\BookInput;
+use Rebing\GraphQL\Tests\Unit\RecursionTest\Inputs\PublisherInput;
+use Rebing\GraphQL\Tests\Unit\RecursionTest\Mutations\SaveAuthor;
+use Rebing\GraphQL\Tests\Unit\RecursionTest\Mutations\SavePublisher;
+
+class RecursionTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                SaveAuthor::class,
+                SavePublisher::class,
+            ],
+        ]);
+        $app['config']->set('graphql.types', [
+            AuthorInput::class,
+            BookInput::class,
+            PublisherInput::class,
+        ]);
+    }
+
+    /** @test */
+    public function infiniteLoopDirectToOne(): void
+    {
+        $post = [
+            'query' => 'mutation SaveAuthor($author: AuthorInput!) {
+                SaveAuthor(author: $author)
+            }',
+            'variables' => [
+                'author' => [
+                    'name' => 'Some Author Name',
+                    'bestSellingBook' => [
+                        'name' => 'Book Name',
+                    ],
+                ],
+            ],
+            'operationName' => 'SaveAuthor',
+        ];
+        $response = $this->json('POST', '/graphql', $post);
+        $response->assertJson(['data' => ['SaveAuthor' => true]]);
+    }
+
+    /** @test */
+    public function infiniteLoopDirectToMany(): void
+    {
+        $post = [
+            'query' => 'mutation SaveAuthor($author: AuthorInput!) {
+                SaveAuthor(author: $author)
+            }',
+            'variables' => [
+                'author' => [
+                    'name' => 'Some Author Name',
+                    'books' => [
+                        ['name' => 'Book Name'],
+                    ],
+                ],
+            ],
+            'operationName' => 'SaveAuthor',
+        ];
+        $response = $this->json('POST', '/graphql', $post);
+        $response->assertJson(['data' => ['SaveAuthor' => true]]);
+    }
+
+    /** @test */
+    public function infiniteLoopIndirectToOne(): void
+    {
+        $post = [
+            'query' => 'mutation SavePublisher($publisher: PublisherInput!) {
+                SavePublisher(publisher: $publisher)
+            }',
+            'variables' => [
+                'publisher' => [
+                    'name' => 'Some Publisher Name',
+                    'bestSellingAuthor' => [
+                        'name' => 'Author Name',
+                        'bestSellingBook' => [
+                            'name' => 'Book Name',
+                        ],
+                    ],
+                ],
+            ],
+            'operationName' => 'SavePublisher',
+        ];
+        $response = $this->json('POST', '/graphql', $post);
+        $response->assertJson(['data' => ['SavePublisher' => true]]);
+    }
+
+    /** @test */
+    public function infiniteLoopIndirectToMany(): void
+    {
+        $post = [
+            'query' => 'mutation SavePublisher($publisher: PublisherInput!) {
+                SavePublisher(publisher: $publisher)
+            }',
+            'variables' => [
+                'publisher' => [
+                    'name' => 'Some Publisher Name',
+                    'authors' => [
+                        [
+                            'name' => 'Author Name',
+                            'books' => [
+                                ['name' => 'Book Name'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'operationName' => 'SavePublisher',
+        ];
+        $response = $this->json('POST', '/graphql', $post);
+        $response->assertJson(['data' => ['SavePublisher' => true]]);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #512

Fix the infinite loop as well as sending the correct matching input data to the rule-callback.

If people have been using rule-callback in a nested input object, the input to the object was before always the full input, now the input data matches the level of nesting.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

