### PR TITLE
Upgrade larastan to 0.5.0 and introduce a phpstan baseline file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|4.0.*",
         "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0",
-        "nunomaduro/larastan": "0.4.3",
+        "nunomaduro/larastan": "0.5.0",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "matt-allan/laravel-code-style": "0.5.0"

--- a/larastan.neon
+++ b/larastan.neon
@@ -5,7 +5,6 @@
 parameters:
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
-        - Illuminate\Database\Eloquent\Model
         - Illuminate\Http\Resources\Json\JsonResource
         - Illuminate\Http\Request
         - Illuminate\Contracts\Auth\Authenticatable
@@ -23,9 +22,34 @@ parameters:
 
 services:
     -
+        class: NunoMaduro\Larastan\Methods\AnnotationExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Methods\AnnotationExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Methods\EloquentBuilderForwardsCallsExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\Methods\Extension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+
+    -
+            class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
+            tags:
+                - phpstan.broker.propertiesClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\Properties\Extension
@@ -33,7 +57,17 @@ services:
             - phpstan.broker.propertiesClassReflectionExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\RelationCreateExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\ModelExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ModelFindExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
@@ -43,9 +77,29 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\AuthManagerExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\RequestExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\EloquentBuilderExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\TestCaseExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\AuthExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\CookieExtension
@@ -81,3 +135,8 @@ services:
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\TransExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.functionTypeSpecifyingExtension

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2507 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:schema\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:query\\(\\) has parameter \\$opts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:query\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:query\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:queryAndReturnResult\\(\\) has parameter \\$opts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:queryAndReturnResult\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:addTypes\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:objectType\\(\\) has parameter \\$type with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:buildObjectTypeFromClass\\(\\) has parameter \\$opts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:buildObjectTypeFromFields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:buildObjectTypeFromFields\\(\\) has parameter \\$opts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:addSchema\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:mergeSchemas\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:getSchemas\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:formatError\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:getSchemaConfiguration\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:getSchemaConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLController\\:\\:executeQuery\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLController\\:\\:executeQuery\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLController\\:\\:queryContext\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLController\\:\\:queryContext\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLServiceProvider\\:\\:provides\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/GraphQLServiceProvider.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) has parameter \\$typedArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$parentType with no typehint specified\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$prefix with no typehint specified\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:modify\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:modify\\(\\) has parameter \\$pathKeyMappings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:modify\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:orderPaths\\(\\) has parameter \\$paths with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:changeKey\\(\\) has parameter \\$segments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:changeKey\\(\\) has parameter \\$target with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:changeKey\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/ArrayKeyChange.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:validationErrorMessages\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:validationErrorMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:resolveRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:inferRulesFromType\\(\\) has parameter \\$resolutionArguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:inferRulesFromType\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getInputTypeRules\\(\\) has parameter \\$resolutionArguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getInputTypeRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getValidator\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getValidator\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on ReflectionType\\|null\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:instanciateSelectFields\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:aliasArgs\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:aliasArgs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getArgs\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getArgs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:__set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\InterfaceType\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/InterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\PaginationType\\:\\:getPaginationFields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/PaginationType.php
+
+		-
+			message: "#^Anonymous function never returns null so it can be removed from the return typehint\\.$#"
+			count: 2
+			path: src/Support/PaginationType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Privacy\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Privacy.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getFieldsAndArgumentsSelection\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:foldSelectionSet\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getInputObjectValue\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getInputListObjectValue\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:\\$select type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:\\$relations type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:__construct\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getFieldSelection\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getFieldSelection\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getSelectableFieldsAndRelations\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getSelectableFieldsAndRelations\\(\\) has parameter \\$requestedFields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getSelectableFieldsAndRelations\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleFields\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleFields\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleFields\\(\\) has parameter \\$with with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:addFieldToSelect\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:validateField\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:isQueryable\\(\\) has parameter \\$fieldObject with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleRelation\\(\\) has parameter \\$field with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleRelation\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:addAlwaysFields\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleInterfaceFields\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleInterfaceFields\\(\\) has parameter \\$field with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleInterfaceFields\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleInterfaceFields\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:handleInterfaceFields\\(\\) has parameter \\$with with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getSelect\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:getRelations\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/SelectFields.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:getFieldResolver\\(\\) has parameter \\$field with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:getFields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:__set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Support/Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\UnionType\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/UnionType.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Support/UploadType.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$queryTypesMap has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/routes.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$router contains unknown class Laravel\\\\Lumen\\\\Routing\\\\Router\\.$#"
+			count: 1
+			path: src/routes.php
+
+		-
+			message: "#^Call to method get\\(\\) on an unknown class Laravel\\\\Lumen\\\\Routing\\\\Router\\.$#"
+			count: 2
+			path: src/routes.php
+
+		-
+			message: "#^Call to method post\\(\\) on an unknown class Laravel\\\\Lumen\\\\Routing\\\\Router\\.$#"
+			count: 2
+			path: src/routes.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLContext\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/GraphQLContext.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLController\\:\\:queryContext\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLController\\:\\:queryContext\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/GraphQLController.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\TestAuthorizationArgsQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\TestAuthorizationArgsQuery\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\TestAuthorizationArgsQuery\\:\\:authorize\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\TestAuthorizationArgsQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 5
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\RuleObjectFail\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectFail.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\MutationValidationUniqueWithCustomRulesTests\\\\RuleObjectPass\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectPass.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 6
+			path: tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/CommentType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\CommentType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/LikableInterfaceType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikeType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/LikeType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/PostType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\PostType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 8
+			path: tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/AlwaysTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/ArrayTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\PropertyType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ArrayTests/PropertyType.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: tests/Database/SelectFields/ComputedPropertiesTests/ComputedPropertiesTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 4
+			path: tests/Database/SelectFields/DepthTests/DepthTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/CommentType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\CommentType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleRelationType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/ExampleRelationType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\InterfaceImpl1Type\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/InterfaceImpl1Type.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\InterfaceImpl1Type\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/InterfaceImpl1Type.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 14
+			path: tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:types\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikeType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/LikeType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/PostType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\PostType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/InterfaceTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/CommentType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\CommentType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikeType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/LikeType.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 4
+			path: tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/PostType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\PostType\\:\\:interfaces\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/CommentType.php
+
+		-
+			message: "#^Function factory invoked with 2 parameters, 0 required\\.$#"
+			count: 17
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 9
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/CommentType.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 4
+			path: tests/Database/SelectFields/PrimaryKeyTests/PaginationTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 6
+			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\GraphQLContext\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLContext.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\GraphQLController\\:\\:queryContext\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLController.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\GraphQLController\\:\\:queryContext\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLController.php
+
+		-
+			message: "#^Function factory invoked with 2 parameters, 0 required\\.$#"
+			count: 18
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 15
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\EpisodeEnum\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/EpisodeEnum.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\FilterInput\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/FilterInput.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UserType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
+
+		-
+			message: "#^Function factory invoked with 2 parameters, 0 required\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\CommentType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/CommentType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/PostType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyAllowed\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyAllowed.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyArgs\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyArgs.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyDenied\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyDenied.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 14
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$contxt with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
+
+		-
+			message: "#^Function factory invoked with 1 parameter, 0 required\\.$#"
+			count: 15
+			path: tests/Database/SelectFieldsTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Models\\\\Like\\:\\:\\$guarded has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Models/Like.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Models\\\\Post\\:\\:\\$dates has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Models/Post.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Models\\\\Post\\:\\:\\$casts has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Models/Post.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExampleType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/CustomExampleType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ErrorFormatter\\:\\:formatError\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ErrorFormatter.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleEnumType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleEnumType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleField.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleFilterInputType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleFilterInputType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleInputType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleInputType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleInterfaceType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleInterfaceType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleInterfaceType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleType2\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleType2.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleUnionType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleUnionType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleUnionType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationField.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationField.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleValidationInputObject.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesFilteredQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesFilteredQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesFilteredQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesFilteredQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesFilteredQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesPaginationQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) return type has no value type specified in iterable type Illuminate\\\\Pagination\\\\LengthAwarePaginator\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesPaginationQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutation\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutation.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/UpdateExampleMutationWithInputType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\ReturnScalarQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Queries/ReturnScalarQuery.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: tests/Support/Types/MyCustomScalarString.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Types\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Types/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Types\\\\PostWithModelAndAliasAndCustomResolverType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Types/PostWithModelAndAliasAndCustomResolverType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Types\\\\PostWithModelAndAliasType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Types/PostWithModelAndAliasType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Types\\\\PostWithModelType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Types/PostWithModelType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$queries has no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchema\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:getPackageProviders\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:getPackageAliases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:__call\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:__call\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:runCommand\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:runCommand\\(\\) has parameter \\$interactiveInput with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:graphql\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:graphql\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:httpGraphql\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:httpGraphql\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:formatSafeTrace\\(\\) has parameter \\$trace with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCaseDatabase\\:\\:setUpTraits\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/TestCaseDatabase.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\ExampleNestedValidationInputObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/ExampleNestedValidationInputObject.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\ExampleType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/ExampleType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\ExampleValidationInputObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/ExampleValidationInputObject.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\EnumMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/EnumMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InputMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/InputMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InterfaceMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/InterfaceMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MutationMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/MutationMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\QueryMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/QueryMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\ScalarMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/ScalarMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\TypeMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/TypeMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\UnionMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/UnionMakeCommandTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/FieldTest.php
+
+		-
+			message: "#^Unable to resolve the template type RealInstanceType in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
+			count: 1
+			path: tests/Unit/FieldTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:\\$defaultFormat has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:resolve\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/UserQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/UserQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/InstantiableTypesTest/UserType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\LaravelValidatorTests\\\\RuleObjectFail\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/LaravelValidatorTests/RuleObjectFail.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\LaravelValidatorTests\\\\RuleObjectPass\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/LaravelValidatorTests/RuleObjectPass.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\RuleObject\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationCustomRulesTests/RuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Unable to resolve the template type RealInstanceType in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
+			count: 1
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:rules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\MutationWithCustomRuleWithRuleObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/MutationWithCustomRuleWithRuleObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\RuleObjectFail\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectFail.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationValidationInWithCustomRulesTests\\\\RuleObjectPass\\:\\:message\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectPass.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\QueryTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/QueryTest.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\ValidationAuthorizationTests\\\\ValidationAndAuthorizationMutation\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\ValidationAuthorizationTests\\\\ValidationAndAuthorizationMutation\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/PostType.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$message has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/SimpleMessage.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$type has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/SimpleMessage.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$code has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/SimpleMessage.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessageType\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/SimpleMessageType.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\WrapperType\\:\\:getMessagesFields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/WithTypeTests/WrapperType.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - larastan.neon
+    - phpstan-baseline.neon
 parameters:
     level: max
     paths:


### PR DESCRIPTION
## Summary
The change to phpstan 0.12.0 brought a LOT of new messages due to using `max`.

This is kind of an experiment to see if moving forward with the baseline file makes sense.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
