### PR TITLE
Fix spelling for "use Closure" in some README examples 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -333,7 +333,7 @@ For example, a mutation to update the password of a user. First you need to defi
 
 namespace App\GraphQL\Mutations;
 
-use CLosure;
+use Closure;
 use App\User;
 use GraphQL;
 use GraphQL\Type\Definition\Type;
@@ -1720,7 +1720,7 @@ class UserInput extends InputType
 
 namespace App\GraphQL\Mutations;
 
-use CLosure;
+use Closure;
 use App\User;
 use GraphQL;
 use GraphQL\Type\Definition\Type;


### PR DESCRIPTION


## Summary
In some examples, Closure is spelt as "CLosure"

## Type of change

README update

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
