### PR TITLE
Add explicit phpstan dependency on specific version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         }
     },
     "scripts": {
-        "phpstan": "phpstan analyse",
+        "phpstan": "phpstan analyse --memory-limit=512M",
         "lint": "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
         "fix-style": "php-cs-fixer fix"
     },

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "nunomaduro/larastan": "0.5.0",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "matt-allan/laravel-code-style": "0.5.0"
+        "matt-allan/laravel-code-style": "0.5.0",
+        "phpstan/phpstan": "0.12.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
We used to only depend on larastan, which uses `^0.12` to depend on phpstan.

But sometimes updated of only phpstan break builds (even if it fixes bugs) and this leads to frictions with contributed PRs.

Also added explicit memory limit as for me, locally, it wouldn't work at all although the defaults were at 128M (OSX, homebrew, 7.4.x)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
