### PR TITLE
Remove return type from SelectFields::getPrimaryKeyFromParentType()

### DIFF
--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -121,7 +121,7 @@ class SelectFields
         return isset($parentType->config['model']) ? app($parentType->config['model'])->getTable() : null;
     }
 
-    private static function getPrimaryKeyFromParentType(GraphqlType $parentType): ?string
+    private static function getPrimaryKeyFromParentType(GraphqlType $parentType)
     {
         return isset($parentType->config['model']) ? app($parentType->config['model'])->getKeyName() : null;
     }


### PR DESCRIPTION
While `SelectFields::getSelectableFieldsAndRelations()` handles a composite primary key array, the `?string` return type on `getPrimaryKeyFromParentType()` causes a fatal error.

## Summary

Using `HasCompositePrimaryKey` from LaravelTreats allows composite primary keys, but the return type on `getPrimaryKeyFromParentType()` is incompatible with an array. Removing the return type declaration fixes the fatal error and allows querying such a model.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
