### PR TITLE
Resolver middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ CHANGELOG
 - Support Laravel 7 [\#597 / exodusanto](https://github.com/rebing/graphql-laravel/pull/597)
 - Add support for custom authorization message [\#578 / Sh1d0w](https://github.com/rebing/graphql-laravel/pull/578)
 - Add support for macros on the GraphQL service/facade [\#592 / stevelacey](https://github.com/rebing/graphql-laravel/pull/592)
+- Add support for resolver middleware [\#594 / stevelacey](https://github.com/rebing/graphql-laravel/pull/594)
 ### Fixed
 - Fix the infinite loop as well as sending the correct matching input data to the rule-callback [\#579 / crissi](https://github.com/rebing/graphql-laravel/pull/579)
 - Fix selecting not the correct columns for interface fields [\#607 / illambo](https://github.com/rebing/graphql-laravel/pull/607)

--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ To create a new middleware, use the `make:graphql:middleware` Artisan command
 php artisan make:graphql:middleware ResolvePage
 ```
 
-This command will place a new ResolvePage class within your app/Http/Middleware directory.
+This command will place a new ResolvePage class within your app/GraphQL/Middleware directory.
 In this middleware, we will set the Paginator current page to the argument we accept via our `PaginationType`:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -644,14 +644,14 @@ Note: You can test your file upload implementation using [Altair](https://altair
         bodyFormData.set('operationName', null);
         bodyFormData.set('map', JSON.stringify({"file":["variables.file"]}));
         bodyFormData.append('file', this.file);
-        
+
         // Post the request to GraphQL controller
         let res = await axios.post('/graphql', bodyFormData, {
           headers: {
             "Content-Type": "multipart/form-data"
           }
         });
-        
+
         if (res.data.status.code == 200) {
           // On success file upload
           this.file = null;
@@ -832,6 +832,15 @@ abstract class Query extends BaseQuery
         Middleware\ResolvePage::class,
     ];
 }
+```
+
+Alternatively, you can override `getMiddleware` to supply your own logic:
+
+```php
+    protected function getMiddleware(): array
+    {
+        return array_merge([...], $this->middleware);
+    }
 ```
 
 #### Terminable middleware

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ To work this around:
       - [Adding validation to a mutation](#adding-validation-to-a-mutation)
       - [File uploads](#file-uploads)
     - [Resolve method](#resolve-method)
+    - [Resolver middleware](#resolver-middleware)
+      - [Defining middleware](#defining-middleware)
+      - [Registering middleware](#registering-middleware)
+      - [Terminable middleware](#terminable-middleware)
     - [Authorization](#authorization)
     - [Privacy](#privacy)
     - [Query variables](#query-variables)
@@ -757,6 +761,150 @@ class UsersQuery extends Query
 }
 ```
 
+### Resolver middleware
+
+#### Defining middleware
+
+To create a new middleware, use the `make:graphql:middleware` Artisan command
+
+```sh
+php artisan make:graphql:middleware ResolvePage
+```
+
+This command will place a new ResolvePage class within your app/Http/Middleware directory.
+In this middleware, we will set the Paginator current page to the argument we accept via our `PaginationType`:
+
+```php
+namespace App\GraphQL\Middleware;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Pagination\Paginator;
+use Rebing\GraphQL\Support\Middleware;
+
+class ResolvePage extends Middleware
+{
+    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    {
+        Paginator::currentPageResolver(function () use ($args) {
+            return $args['pagination']['page'] ?? 1;
+        });
+
+        return $next($root, $args, $context, $info);
+    }
+}
+```
+
+#### Registering middleware
+
+If you would like to assign middleware to specific queries/mutations,
+list the middleware class in the `$middleware` property of your query class.
+
+```php
+namespace App\GraphQL\Queries;
+
+use App\GraphQL\Middleware;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\Query;
+
+class UsersQuery extends Query
+{
+    protected $middleware = [
+        Middleware\Logstash::class,
+        Middleware\ResolvePage::class,
+    ];
+}
+```
+
+If you want a middleware to run during every GraphQL query/mutation to your application,
+list the middleware class in the `$middleware` property of your base query class.
+
+```php
+namespace App\GraphQL\Queries;
+
+use App\GraphQL\Middleware;
+use Rebing\GraphQL\Support\Query as BaseQuery;
+
+abstract class Query extends BaseQuery
+{
+    protected $middleware = [
+        Middleware\Logstash::class,
+        Middleware\ResolvePage::class,
+    ];
+}
+```
+
+#### Terminable middleware
+
+Sometimes a middleware may need to do some work after the response has been sent to the browser.
+If you define a terminate method on your middleware and your web server is using FastCGI,
+the terminate method will automatically be called after the response is sent to the browser:
+
+```php
+namespace App\GraphQL\Middleware;
+
+use Countable;
+use GraphQL\Language\Printer;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use Rebing\GraphQL\Support\Middleware;
+
+class Logstash extends Middleware
+{
+    public function terminate($root, $args, $context, ResolveInfo $info, $result): void
+    {
+        Log::channel('logstash')->info('', (
+            collect([
+                'query' => $info->fieldName,
+                'operation' => $info->operation->name->value ?? null,
+                'type' => $info->operation->operation,
+                'fields' => array_keys(Arr::dot($info->getFieldSelection($depth = PHP_INT_MAX))),
+                'schema' => Arr::first(Route::current()->parameters()) ?? config('graphql.default_schema'),
+                'vars' => $this->formatVariableDefinitions($info->operation->variableDefinitions),
+            ])
+                ->when($result instanceof Countable, function ($metadata) use ($result) {
+                    return $metadata->put('count', $result->count());
+                })
+                ->when($result instanceof AbstractPaginator, function ($metadata) use ($result) {
+                    return $metadata->put('per_page', $result->perPage());
+                })
+                ->when($result instanceof LengthAwarePaginator, function ($metadata) use ($result) {
+                    return $metadata->put('total', $result->total());
+                })
+                ->merge($this->formatArguments($args))
+                ->toArray()
+        ));
+    }
+
+    private function formatArguments(array $args): array
+    {
+        return collect(Arr::sanitize($args))
+            ->mapWithKeys(function ($value, $key) {
+                return ["\${$key}" => $value];
+            })
+            ->toArray();
+    }
+
+    private function formatVariableDefinitions(?iterable $variableDefinitions = []): array
+    {
+        return collect($variableDefinitions)
+            ->map(function ($def) {
+                return Printer::doPrint($def);
+            })
+            ->toArray();
+    }
+}
+```
+
+The terminate method receives both the resolver arguments and the query result.
+
+Once you have defined a terminable middleware, you should add it to the list of
+middleware in your queries and mutations.
+
 ### Authorization
 
 For authorization similar to Laravel's Request (or middleware) functionality, we can override the `authorize()` function in a Query or Mutation.
@@ -1330,7 +1478,9 @@ class UserType extends GraphQLType
 ### Pagination
 
 Pagination will be used, if a query or mutation returns a `PaginationType`.
-Note that you have to manually handle the limit and page values:
+
+Note that unless you use [resolver middleware](#defining-middleware),
+you will have to manually supply both the limit and page values:
 
 ```php
 namespace App\GraphQL\Queries;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1936,6 +1936,11 @@ parameters:
 			path: tests/Unit/Console/InterfaceMakeCommandTest.php
 
 		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MiddlewareMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/MiddlewareMakeCommandTest.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MutationMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/MutationMakeCommandTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,13 +23,27 @@ parameters:
         - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'
         - '/Parameter #4 \$currentPage of class Illuminate\\Pagination\\LengthAwarePaginator constructor expects int\|null, float\|int given/'
         - '/Parameter #1 \$offset of method Illuminate\\Support\\Collection<mixed,mixed>::slice\(\) expects int, float\|int given/'
-        # Rebing\GraphQL\Support\Middleware::handle
+        # \Rebing\GraphQL\Support\Middleware
         - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has no return typehint specified/'
         - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$args with no typehint specified/'
         - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$context with no typehint specified/'
         - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$root with no typehint specified/'
         - '/Method Rebing\\GraphQL\\Support\\Middleware::resolve\(\) has no return typehint specified/'
         - '/Method Rebing\\GraphQL\\Support\\Middleware::resolve\(\) has parameter \$arguments with no value type specified in iterable type array/'
+        # \Rebing\GraphQL\Support\Objects\ExampleMiddleware
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::handle\(\) has no return typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::handle\(\) has parameter \$args with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::handle\(\) has parameter \$context with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::handle\(\) has parameter \$root with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::terminate\(\) has parameter \$args with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::terminate\(\) has parameter \$context with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::terminate\(\) has parameter \$result with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExampleMiddleware::terminate\(\) has parameter \$root with no typehint specified/'
+        # \Rebing\GraphQL\Support\Objects\ExamplesMiddlewareQuery
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExamplesMiddlewareQuery::\$attributes has no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExamplesMiddlewareQuery::resolve\(\) has no return typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExamplesMiddlewareQuery::resolve\(\) has parameter \$args with no typehint specified/'
+        - '/Rebing\\GraphQL\\Tests\\Support\\Objects\\ExamplesMiddlewareQuery::resolve\(\) has parameter \$root with no typehint specified/'
         # tests/Unit/GraphQLTest.php
         - '/Call to an undefined method GraphQL\\Type\\Definition\\Type::getFields\(\)/'
         - '/Call to an undefined method Mockery\\/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,13 @@ parameters:
         - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'
         - '/Parameter #4 \$currentPage of class Illuminate\\Pagination\\LengthAwarePaginator constructor expects int\|null, float\|int given/'
         - '/Parameter #1 \$offset of method Illuminate\\Support\\Collection<mixed,mixed>::slice\(\) expects int, float\|int given/'
+        # Rebing\GraphQL\Support\Middleware::handle
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has no return typehint specified/'
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$args with no typehint specified/'
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$context with no typehint specified/'
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::handle\(\) has parameter \$root with no typehint specified/'
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::resolve\(\) has no return typehint specified/'
+        - '/Method Rebing\\GraphQL\\Support\\Middleware::resolve\(\) has parameter \$arguments with no value type specified in iterable type array/'
         # tests/Unit/GraphQLTest.php
         - '/Call to an undefined method GraphQL\\Type\\Definition\\Type::getFields\(\)/'
         - '/Call to an undefined method Mockery\\/'

--- a/src/Console/MiddlewareMakeCommand.php
+++ b/src/Console/MiddlewareMakeCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class MiddlewareMakeCommand extends GeneratorCommand
+{
+    protected $signature = 'make:graphql:middleware {name}';
+    protected $description = 'Create a new GraphQL middleware class';
+    protected $type = 'Middleware';
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/middleware.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\GraphQL\Middleware';
+    }
+}

--- a/src/Console/stubs/middleware.stub
+++ b/src/Console/stubs/middleware.stub
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DummyNamespace;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\Middleware;
+
+class DummyClass extends Middleware
+{
+    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    {
+        return $next($root, $args, $context, $info);
+    }
+}

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -14,6 +14,7 @@ use Rebing\GraphQL\Console\EnumMakeCommand;
 use Rebing\GraphQL\Console\FieldMakeCommand;
 use Rebing\GraphQL\Console\InputMakeCommand;
 use Rebing\GraphQL\Console\InterfaceMakeCommand;
+use Rebing\GraphQL\Console\MiddlewareMakeCommand;
 use Rebing\GraphQL\Console\MutationMakeCommand;
 use Rebing\GraphQL\Console\QueryMakeCommand;
 use Rebing\GraphQL\Console\ScalarMakeCommand;
@@ -163,6 +164,7 @@ class GraphQLServiceProvider extends ServiceProvider
         $this->commands(InputMakeCommand::class);
         $this->commands(InterfaceMakeCommand::class);
         $this->commands(InterfaceMakeCommand::class);
+        $this->commands(MiddlewareMakeCommand::class);
         $this->commands(MutationMakeCommand::class);
         $this->commands(QueryMakeCommand::class);
         $this->commands(ScalarMakeCommand::class);

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -121,7 +121,7 @@ abstract class Field
         return Validator::make($args, $rules, $messages);
     }
 
-    protected function getResolver() : ?Closure
+    protected function getResolver(): ?Closure
     {
         $resolver = $this->originalResolver();
 

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -6,8 +6,10 @@ namespace Rebing\GraphQL\Support;
 
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Type\Definition\Type as GraphqlType;
+use GraphQL\Type\Definition\Type as GraphQLType;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Pipeline\Pipeline;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Validator;
 use InvalidArgumentException;
 use Rebing\GraphQL\Error\AuthorizationError;
@@ -28,6 +30,9 @@ abstract class Field
     protected $depth = 5;
 
     protected $attributes = [];
+
+    /** @var string[] */
+    protected $middleware = [];
 
     /**
      * Override this in your queries or mutations
@@ -50,7 +55,7 @@ abstract class Field
         return [];
     }
 
-    abstract public function type(): GraphqlType;
+    abstract public function type(): GraphQLType;
 
     /**
      * @return array<string,array>
@@ -116,7 +121,38 @@ abstract class Field
         return Validator::make($args, $rules, $messages);
     }
 
-    protected function getResolver(): ?Closure
+    protected function getResolver() : ?Closure
+    {
+        $resolver = $this->originalResolver();
+
+        if (! $resolver) {
+            return null;
+        }
+
+        return function ($root, ...$arguments) use ($resolver) {
+            return app(Pipeline::class)
+                ->send(array_merge([$this], $arguments))
+                ->through($this->middleware)
+                ->via('resolve')
+                ->then(function ($arguments) use ($resolver, $root) {
+                    $result = $resolver($root, ...array_slice($arguments, 1));
+
+                    foreach ($this->middleware as $name) {
+                        $middleware = App::make($name);
+
+                        if (method_exists($middleware, 'terminate')) {
+                            App::terminating(function () use ($arguments, $middleware, $result) {
+                                $middleware->terminate($this, ...array_slice($arguments, 1), ...[$result]);
+                            });
+                        }
+                    }
+
+                    return $result;
+                });
+        };
+    }
+
+    protected function originalResolver(): ?Closure
     {
         if (! method_exists($this, 'resolve')) {
             return null;

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -130,7 +130,7 @@ abstract class Field
         }
 
         return function ($root, ...$arguments) use ($resolver) {
-            return app(Pipeline::class)
+            return App::make(Pipeline::class)
                 ->send(array_merge([$this], $arguments))
                 ->through($this->middleware)
                 ->via('resolve')
@@ -218,7 +218,7 @@ abstract class Field
                     return $arguments[3];
                 }
 
-                return app()->make($className);
+                return App::make($className);
             }, $additionalParams);
 
             return call_user_func_array($resolver, array_merge(

--- a/src/Support/Middleware.php
+++ b/src/Support/Middleware.php
@@ -14,6 +14,9 @@ abstract class Middleware
         return $next($root, $args, $context, $info);
     }
 
+    /**
+     * @see Field::getResolver()  Middleware is resolved in the field resolver pipeline
+     */
     public function resolve(array $arguments, Closure $next)
     {
         return $this->handle(...$arguments, ...[

--- a/src/Support/Middleware.php
+++ b/src/Support/Middleware.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+
+abstract class Middleware
+{
+    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    {
+        return $next($root, $args, $context, $info);
+    }
+
+    public function resolve(array $arguments, Closure $next)
+    {
+        return $this->handle(...$arguments, ...[
+            function (...$arguments) use ($next) {
+                return $next($arguments);
+            },
+        ]);
+    }
+}

--- a/tests/Support/Objects/ExampleMiddleware.php
+++ b/tests/Support/Objects/ExampleMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rebing\GraphQL\Tests\Support\Objects;
 
 use Closure;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use Rebing\GraphQL\Support\Middleware;
 
@@ -17,7 +18,7 @@ class ExampleMiddleware extends Middleware
         }
 
         if ($args['index'] === 5) {
-            throw new \Exception('Index 5 is not allowed');
+            throw new Exception('Index 5 is not allowed');
         }
 
         $result = $next($root, $args, $context, $info);
@@ -27,7 +28,7 @@ class ExampleMiddleware extends Middleware
         }
 
         if ($result[0]['test'] === 'Example 3') {
-            throw new \Exception('Example 3 is not allowed');
+            throw new Exception('Example 3 is not allowed');
         }
 
         return $result;
@@ -36,7 +37,7 @@ class ExampleMiddleware extends Middleware
     public function terminate($root, $args, $context, ResolveInfo $info, $result): void
     {
         if ($args['index'] === 6) {
-            throw new \Exception('Terminate happens after the response is sent');
+            throw new Exception('Terminate happens after the response is sent');
         }
     }
 }

--- a/tests/Support/Objects/ExampleMiddleware.php
+++ b/tests/Support/Objects/ExampleMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Rebing\GraphQL\Support\Middleware;
+
+class ExampleMiddleware extends Middleware
+{
+    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    {
+        if ($args['index'] === 4) {
+            $args['index'] = 0;
+        }
+
+        if ($args['index'] === 5) {
+            throw new \Exception('Index 5 is not allowed');
+        }
+
+        $result = $next($root, $args, $context, $info);
+
+        if ($result[0]['test'] === 'Example 2') {
+            $result[0]['test'] = 'ExampleMiddleware changed me!';
+        }
+
+        if ($result[0]['test'] === 'Example 3') {
+            throw new \Exception('Example 3 is not allowed');
+        }
+
+        return $result;
+    }
+
+    public function terminate($root, $args, $context, ResolveInfo $info, $result): void
+    {
+        if ($args['index'] === 6) {
+            throw new \Exception('Terminate happens after the response is sent');
+        }
+    }
+}

--- a/tests/Support/Objects/ExamplesMiddlewareQuery.php
+++ b/tests/Support/Objects/ExamplesMiddlewareQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+class ExamplesMiddlewareQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'examples',
+    ];
+
+    protected $middleware = [
+        ExampleMiddleware::class,
+    ];
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('Example'));
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => [
+                'type' => Type::int(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $data = include __DIR__.'/data.php';
+
+        if (isset($args['index'])) {
+            return [
+                $data[$args['index']],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -90,6 +90,14 @@ return [
         }
     ',
 
+    'exampleMiddleware' => '
+        query examplesMiddleware($index: Int) {
+            examplesMiddleware(index: $index) {
+                test
+            }
+        }
+    ',
+
     'examplePagination' => '
         query Items($take: Int!, $page: Int!) {
             examplesPagination(take: $take, page: $page) {

--- a/tests/Support/Traits/MakeCommandAssertionTrait.php
+++ b/tests/Support/Traits/MakeCommandAssertionTrait.php
@@ -19,7 +19,7 @@ trait MakeCommandAssertionTrait
         string $expectedFilename,
         string $expectedNamespace,
         string $expectedClassDefinition,
-        string $expectedGraphqlName
+        string $expectedGraphqlName = null
     ): void {
         $filesystemMock = $this
             ->getMockBuilder(Filesystem::class)
@@ -41,7 +41,10 @@ trait MakeCommandAssertionTrait
                 $this->callback(function (string $contents) use ($expectedClassDefinition, $expectedGraphqlName, $expectedNamespace): bool {
                     $this->assertRegExp("/namespace $expectedNamespace;/", $contents);
                     $this->assertRegExp("/class $expectedClassDefinition/", $contents);
-                    $this->assertRegExp("/$expectedGraphqlName/", $contents);
+
+                    if ($expectedGraphqlName) {
+                        $this->assertRegExp("/$expectedGraphqlName/", $contents);
+                    }
 
                     return true;
                 })

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,7 @@ use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesConfigAliasQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesFilteredQuery;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesMiddlewareQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesPaginationQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleType;
@@ -52,6 +53,7 @@ class TestCase extends BaseTestCase
                 'examples' => ExamplesQuery::class,
                 'examplesAuthorize' => ExamplesAuthorizeQuery::class,
                 'examplesAuthorizeMessage' => ExamplesAuthorizeMessageQuery::class,
+                'examplesMiddleware' => ExamplesMiddlewareQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
                 'examplesFiltered' => ExamplesFilteredQuery::class,
                 'examplesConfigAlias' => ExamplesConfigAliasQuery::class,

--- a/tests/Unit/Console/MiddlewareMakeCommandTest.php
+++ b/tests/Unit/Console/MiddlewareMakeCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit\Console;
+
+use Rebing\GraphQL\Console\MiddlewareMakeCommand;
+use Rebing\GraphQL\Tests\Support\Traits\MakeCommandAssertionTrait;
+use Rebing\GraphQL\Tests\TestCase;
+
+class MiddlewareMakeCommandTest extends TestCase
+{
+    use MakeCommandAssertionTrait;
+
+    /**
+     * @dataProvider dataForMakeCommand
+     * @param  string  $inputName
+     * @param  string  $expectedFilename
+     * @param  string  $expectedClassDefinition
+     */
+    public function testCommand(
+        string $inputName,
+        string $expectedFilename,
+        string $expectedClassDefinition
+    ): void {
+        $this->assertMakeCommand(
+            'Middleware',
+            MiddlewareMakeCommand::class,
+            $inputName,
+            $expectedFilename,
+            'App\\\\GraphQL\\\\Middleware',
+            $expectedClassDefinition
+        );
+    }
+
+    public function dataForMakeCommand(): array
+    {
+        return [
+            'Example' => [
+                'inputName' => 'Example',
+                'expectedFilename' => 'GraphQL/Middleware/Example.php',
+                'expectedClassDefinition' => 'Example extends Middleware',
+            ],
+            'ExampleMiddleware' => [
+                'inputName' => 'ExampleMiddleware',
+                'expectedFilename' => 'GraphQL/Middleware/ExampleMiddleware.php',
+                'expectedClassDefinition' => 'ExampleMiddleware extends Middleware',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\TestCase;
+
+class MiddlewareTest extends TestCase
+{
+    public function testMiddleware(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 0,
+        ]);
+
+        $this->assertObjectHasAttribute('data', $result);
+
+        $this->assertEquals($result->data, [
+            'examplesMiddleware' => [$this->data[0]],
+        ]);
+    }
+
+    public function testMiddlewareCanMutateArgs(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 4, // there is no index 4
+        ]);
+
+        $this->assertObjectHasAttribute('data', $result);
+
+        $this->assertEquals($result->data, [
+            'examplesMiddleware' => [$this->data[0]], // switched to index 0 in middleware
+        ]);
+    }
+
+    public function testMiddlewareCanMutateFields(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 1,
+        ]);
+
+        $this->assertObjectHasAttribute('data', $result);
+
+        $this->assertEquals($result->data, [
+            'examplesMiddleware' => [['test' => 'ExampleMiddleware changed me!']],
+        ]);
+    }
+
+    public function testMiddlewareCanThrowExceptionsBeforeResolution(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 5,
+        ]);
+
+        $this->assertObjectHasAttribute('errors', $result);
+        $this->assertSame('Index 5 is not allowed', $result->errors[0]->message);
+    }
+
+    public function testMiddlewareCanThrowExceptionsAfterResolution(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 2,
+        ]);
+
+        $this->assertObjectHasAttribute('errors', $result);
+        $this->assertSame('Example 3 is not allowed', $result->errors[0]->message);
+    }
+
+    public function testMiddlewareTerimateHappensAfterResponseIsSent(): void
+    {
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleMiddleware'], [
+            'index' => 6,
+        ]);
+
+        $this->assertObjectHasAttribute('errors', $result);
+        $this->assertSame('Undefined offset: 6', $result->errors[0]->message);
+    }
+}

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -55,7 +55,7 @@ class MiddlewareTest extends TestCase
         ]);
 
         $this->assertObjectHasAttribute('errors', $result);
-        $this->assertSame('Index 5 is not allowed', $result->errors[0]->message);
+        $this->assertSame('Index 5 is not allowed', $result->errors[0]->getMessage());
     }
 
     public function testMiddlewareCanThrowExceptionsAfterResolution(): void
@@ -65,7 +65,7 @@ class MiddlewareTest extends TestCase
         ]);
 
         $this->assertObjectHasAttribute('errors', $result);
-        $this->assertSame('Example 3 is not allowed', $result->errors[0]->message);
+        $this->assertSame('Example 3 is not allowed', $result->errors[0]->getMessage());
     }
 
     public function testMiddlewareTerimateHappensAfterResponseIsSent(): void
@@ -75,6 +75,6 @@ class MiddlewareTest extends TestCase
         ]);
 
         $this->assertObjectHasAttribute('errors', $result);
-        $this->assertSame('Undefined offset: 6', $result->errors[0]->message);
+        $this->assertSame('Undefined offset: 6', $result->errors[0]->getMessage());
     }
 }


### PR DESCRIPTION
## Summary

GraphQL-aware middleware solve a variety of problems, a while ago I needed to be able to Logstash various stats about the queries going through my API (e.g. what args were passed, what fields were requested), and more recently I wanted to move authorization ahead of validation after I learnt about #481. Resolves #591.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`