### PR TITLE
[LUMEN] Fix multiple schemas on query/mutation

### DIFF
--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -29,7 +29,7 @@ class GraphQLController extends Controller
         // If there are multiple route params we can expect that there
         // will be a schema name that has to be built
         $routeParameters = $this->getRouteParameters($request);
-        if (count($routeParameters) > 1) {
+        if (count($routeParameters) > 0) {
             $schema = implode('/', $routeParameters);
         }
 


### PR DESCRIPTION
## Summary
`$schema` arg received in query function is always `null` and if we have only one element in `$routeParameters`, `$schema` remain empty, then the query always hit default schema.

## Type of change
switching condition to fill `$schema`, from `if (count($routeParameters) > 1)` to `if (count($routeParameters) > 0)`

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`

### Links
- Fixed https://github.com/rebing/graphql-laravel/issues/568