### PR TITLE
GraphQL::type modifier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 - Support Laravel 7 [\#597 / exodusanto](https://github.com/rebing/graphql-laravel/pull/597)
 - Add support for custom authorization message [\#578 / Sh1d0w](https://github.com/rebing/graphql-laravel/pull/578)
 - Add support for macros on the GraphQL service/facade [\#592 / stevelacey](https://github.com/rebing/graphql-laravel/pull/592)
+- Add support for modifiers to `GraphQL::type` [\#621 / stevelacey](https://github.com/rebing/graphql-laravel/pull/621)
 ### Fixed
 - Fix the infinite loop as well as sending the correct matching input data to the rule-callback [\#579 / crissi](https://github.com/rebing/graphql-laravel/pull/579)
 - Fix selecting not the correct columns for interface fields [\#607 / illambo](https://github.com/rebing/graphql-laravel/pull/607)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ To work this around:
     - [Interfaces](#interfaces)
       - [Sharing interface fields](#sharing-interface-fields)
     - [Input Object](#input-object)
+    - [Type modifiers](#type-modifiers)
     - [Field and input alias](#field-and-input-alias)
     - [JSON columns](#json-columns)
     - [Field deprecation](#field-deprecation)
@@ -1654,6 +1655,24 @@ class TestMutation extends GraphQLType {
     }
 
 }
+```
+
+### Type modifiers
+
+Type modifiers can be applied by wrapping your chosen type in `Type::nonNull` or `Type::listOf` calls
+or alternatively you can use the shorthand syntax available via `GraphQL::type` to build up more complex
+types.
+
+```php
+GraphQL::type('MyInput!');
+GraphQL::type('[MyInput]');
+GraphQL::type('[MyInput]!');
+GraphQL::type('[MyInput!]!');
+
+GraphQL::type('String!');
+GraphQL::type('[String]');
+GraphQL::type('[String]!');
+GraphQL::type('[String!]!');
 ```
 
 ### Field and input alias


### PR DESCRIPTION
## Summary
Adds support for type modifiers and standard types to `GraphQL::type`.

```php
GraphQL::type('MyInput!');
GraphQL::type('[MyInput]');
GraphQL::type('[MyInput]!');
GraphQL::type('[MyInput!]!');

GraphQL::type('String');
GraphQL::type('String!');
GraphQL::type('[String]');
GraphQL::type('[String]!');
GraphQL::type('[String!]!');
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`