### PR TITLE
use static in select fields to make it easier to extend

### DIFF
--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -165,7 +165,7 @@ abstract class Field
         };
     }
 
-    private function instanciateSelectFields(array $arguments, int $depth = null): SelectFields
+    protected function instanciateSelectFields(array $arguments, int $depth = null): SelectFields
     {
         $ctx = $arguments[2] ?? null;
 


### PR DESCRIPTION
## Summary
use static in select fields to make it easier to extend

## Type of change
- [x ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x ] Existing tests have been adapted and/or new tests have been added
- [x ] Add a CHANGELOG.md entry
- [x ] Update the README.md
- [x ] Code style has been fixed via `composer fix-style`
