### PR TITLE
Freeze the time to trigger date test

### DIFF
--- a/tests/Unit/InstantiableTypesTest/InstantiableTypesTest.php
+++ b/tests/Unit/InstantiableTypesTest/InstantiableTypesTest.php
@@ -9,8 +9,10 @@ use Rebing\GraphQL\Tests\TestCase;
 
 class InstantiableTypesTest extends TestCase
 {
-    public function testSomething(): void
+    public function testDateFunctions(): void
     {
+        Carbon::setTestNow('2020-06-05 12:34:56');
+
         $query = <<<'GRAQPHQL'
 {
     user {
@@ -24,8 +26,8 @@ GRAQPHQL;
 
         $result = $this->graphql($query);
 
-        $dateOfBirth = Carbon::now()->addMonth()->startOfDay();
-        $createdAt = Carbon::now()->startOfDay();
+        $dateOfBirth = Carbon::today()->addMonth();
+        $createdAt = Carbon::today();
 
         $expectedResult = [
             'data' => [


### PR DESCRIPTION
## Summary
Solves https://travis-ci.org/github/rebing/graphql-laravel/jobs/693126257#L579

By freezing the time, you can actually rely on the predictable interval to be calculated (it won't depends on the time the test takes to run, the current hour, etc.)

Then `Carbon::now()->startOfDay()` is `Carbon::today()`

## Type of change

- Unit test fix

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry: not needed: no impact on the package
- [ ] Update the README.md: NA
- [x] Code style has been fixed via `composer fix-style`
