### PR TITLE
Authorize in Queries doesn't get passed a $getSelectFields closure

### DIFF
--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -125,11 +125,6 @@ abstract class Field
 
             $arguments[1] = $this->getArgs($arguments);
 
-            // Authorize
-            if (true != call_user_func_array($authorize, $arguments)) {
-                throw new AuthorizationError($this->getAuthorizationMessage());
-            }
-
             $method = new ReflectionMethod($this, 'resolve');
 
             $additionalParams = array_slice($method->getParameters(), 3);
@@ -157,6 +152,12 @@ abstract class Field
 
                 return app()->make($className);
             }, $additionalParams);
+            
+            
+            // Authorize
+            if (true != call_user_func_array($authorize, $arguments)) {
+                throw new AuthorizationError($this->getAuthorizationMessage());
+            }
 
             return call_user_func_array($resolver, array_merge(
                 [$arguments[0], $arguments[1], $arguments[2]],


### PR DESCRIPTION
## Summary
In the Authorize function inside a query / mutation the $getSelectFields closure is always null. This is because in \Rebing\GraphQL\Support\Field::getResolver $additionalArguments gets populated after the authorize function is already called. The $getSelectFields closure is only populated after its called.

This change moves authorize so thats it run afterwards. This change doesn't seem to affect any of the unit tests etc.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
