### PR TITLE
Fix $getSelectFields in Authorize for Queries and Mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/5.1.1...master)
 --------------
+### Fixed
+- Fixed an issue where $getSelectFields doesn't work in Authorize function for queries and mutations. [\#639 / adamlc](https://github.com/rebing/graphql-laravel/pull/639)
 
 2019-04-23, 5.1.1
 -----------------

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -153,18 +153,17 @@ abstract class Field
                 return app()->make($className);
             }, $additionalParams);
 
-            // Authorize
-            if (true != call_user_func_array($authorize, array_merge(
+            $functionArguments = array_merge(
                 [$arguments[0], $arguments[1], $arguments[2]],
                 $additionalArguments
-            ))) {
+            );
+
+            // Authorize
+            if (true != call_user_func_array($authorize, $functionArguments)) {
                 throw new AuthorizationError($this->getAuthorizationMessage());
             }
 
-            return call_user_func_array($resolver, array_merge(
-                [$arguments[0], $arguments[1], $arguments[2]],
-                $additionalArguments
-            ));
+            return call_user_func_array($resolver, $functionArguments);
         };
     }
 

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -125,11 +125,6 @@ abstract class Field
 
             $arguments[1] = $this->getArgs($arguments);
 
-            // Authorize
-            if (true != call_user_func_array($authorize, $arguments)) {
-                throw new AuthorizationError($this->getAuthorizationMessage());
-            }
-
             $method = new ReflectionMethod($this, 'resolve');
 
             $additionalParams = array_slice($method->getParameters(), 3);
@@ -157,6 +152,14 @@ abstract class Field
 
                 return app()->make($className);
             }, $additionalParams);
+
+            // Authorize
+            if (true != call_user_func_array($authorize, array_merge(
+                [$arguments[0], $arguments[1], $arguments[2]],
+                $additionalArguments
+            ))) {
+                throw new AuthorizationError($this->getAuthorizationMessage());
+            }
 
             return call_user_func_array($resolver, array_merge(
                 [$arguments[0], $arguments[1], $arguments[2]],

--- a/tests/Support/Objects/ExampleFieldSelectFieldsResolve.php
+++ b/tests/Support/Objects/ExampleFieldSelectFieldsResolve.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Field;
+
+class ExampleFieldSelectFieldsResolve extends Field
+{
+    protected $attributes = [
+        'name' => 'example',
+    ];
+
+    public function type(): Type
+    {
+        return Type::listOf(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => [
+                'name' => 'index',
+                'type' => Type::int(),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields): array
+    {
+        return [$getSelectFields()];
+    }
+}

--- a/tests/Unit/FieldAuthorizeTest.php
+++ b/tests/Unit/FieldAuthorizeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Closure;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleFieldSelectFieldsResolve;
+use Rebing\GraphQL\Tests\TestCase;
+
+class FieldAuthorizeTest extends TestCase
+{
+    protected function getFieldClass()
+    {
+        return ExampleFieldSelectFieldsResolve::class;
+    }
+
+    /**
+     * Ensure $getSelectFields is an instance of a closure when calling authorize
+     */
+    public function testSelectFieldsClosure(): void
+    {
+        $class = $this->getFieldClass();
+        $field = $this->getMockBuilder($class)
+            ->setMethods(['authorize'])
+            ->getMock();
+
+        $mockResolveInfo = new ResolveInfo(
+            '',
+            [],
+            new ObjectType(['name' => 'test']),
+            new ObjectType(['name' => 'test']),
+            [],
+            new Schema([]),
+            [],
+            null,
+            null,
+            []
+        );
+
+        $mockSelectFields = new SelectFields(
+            $mockResolveInfo,
+            Type::string(),
+            [],
+            1,
+             null
+        );
+
+        $field->expects($this->once())
+            ->method('authorize')
+            ->with(null, [], [], $mockResolveInfo, function() {})
+            ->willReturn(true);
+
+        $attributes = $field->getAttributes();
+        $selectFieldResult = $attributes['resolve'](null, [], [], $mockResolveInfo, $mockSelectFields);
+
+        $this->assertInstanceOf(SelectFields::class, $selectFieldResult[0]);
+    }
+}


### PR DESCRIPTION
## Summary
In the Authorize function inside a query / mutation the $getSelectFields closure is always null. This is because in \Rebing\GraphQL\Support\Field::getResolver $additionalArguments gets populated after the authorize function is already called. The $getSelectFields closure is only populated after its called.

This change moves authorize so thats it run afterwards. This change doesn't seem to affect any of the unit tests etc.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
