### PR TITLE
Shorten SelectFields constructor using array unpacking

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,7 +16,6 @@ parameters:
         - '/Cannot access property \$parameters on mixed/'
         - '/Parameter #1 \$haystack of function mb_stripos expects string, \(array\)\|string given/'
         - '/Strict comparison using === between null and array will always evaluate to false/'
-        - '/Cannot access offset . on array\|Closure/'
         # \Rebing\GraphQL\Support\SelectFields::handleFields
         - '/Parameter #1 \$function of function call_user_func expects callable\(\): mixed, array\(mixed, mixed\) given/'
         - '/Binary operation "." between string and array\|string\|null results in an error/'

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -48,9 +48,7 @@ class SelectFields
             'fields' => $fieldsAndArguments,
         ];
 
-        $fields = self::getSelectableFieldsAndRelations($queryArgs, $requestedFields, $parentType, null, true, $ctx);
-        $this->select = $fields[0];
-        $this->relations = $fields[1];
+        [$this->select, $this->relations] = self::getSelectableFieldsAndRelations($queryArgs, $requestedFields, $parentType, null, true, $ctx);
     }
 
     /**


### PR DESCRIPTION
## Summary
Syntax proposal: usage of array unpacking

Benefits:
- Avoid intermediate variable
- Avoid magic numbers 0 and 1
- Avoid ambiguous 'fields' name: fields[0] (which make think the first field only goes to select and the second one to relations while it's actually 2 groups of different things that have been retrieved and the unit is not the field)
- Solve a PHPStan error

## Type of change
Misc. change (syntax)
