### PR TITLE
Remove support for Laravel < 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,8 @@ jobs:
   integration:
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
-        laravel: [5.5.*, ^6.0, ^7.0]
-        exclude:
-          - php: 7.1
-            laravel: ^6.0
-          - php: 7.1
-            laravel: ^7.0
-          - php: 7.4
-            laravel: 5.5.*
+        php: [7.2, 7.3, 7.4]
+        laravel: [^6.0, ^7.0]
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-18.04
     env:
@@ -46,9 +39,6 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-composer-
 
       - run: composer update --prefer-dist --no-progress
-
-      - run: composer require --dev orchestra/database:3.5 --prefer-dist --no-suggest
-        if: matrix.laravel == '5.5.*'
 
       - name: Run tests
         run: composer tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 ## Breaking changes
 - Upgrade to webonxy/graphql-php 14.0.0 [\#645 / mfn](https://github.com/rebing/graphql-laravel/pull/645)
+- Remove support for Laravel < 6.0 [\#651 / mfn](https://github.com/rebing/graphql-laravel/pull/651)
+  This also bumps the minimum required version to PHP 7.2
 
 2019-07-02, 5.1.2
 -----------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://poser.pugx.org/rebing/graphql-laravel/license)](https://packagist.org/packages/rebing/graphql-laravel)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/rebing-graphql/shared_invite/enQtNTE5NjQzNDI5MzQ4LTdhNjk0ZGY1N2U1YjE4MGVlYmM2YTc2YjQ0MmIwODY5MWMwZWIwYmY1MWY4NTZjY2Q5MzdmM2Q3NTEyNDYzZjc)
 
-Uses Facebook GraphQL with Laravel 5.5+. It is based on the PHP implementation [here](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](http://facebook.github.io/react/blog/2015/05/01/graphql-introduction.html) on the [React](http://facebook.github.io/react) blog or you can read the [GraphQL specifications](https://facebook.github.io/graphql/). This is a work in progress.
+Uses Facebook GraphQL with Laravel 6.0+. It is based on the PHP implementation [here](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](http://facebook.github.io/react/blog/2015/05/01/graphql-introduction.html) on the [React](http://facebook.github.io/react) blog or you can read the [GraphQL specifications](https://facebook.github.io/graphql/). This is a work in progress.
 
 This package is compatible with Eloquent models or any other data source.
 * Allows creating **queries** and **mutations** as request endpoints
@@ -26,7 +26,7 @@ It offers following features and improvements over the original package by
 
 #### Dependencies:
 
-* [Laravel 5.5+](https://github.com/laravel/laravel) or [Lumen](https://github.com/laravel/lumen)
+* [Laravel 6.0+](https://github.com/laravel/laravel) or [Lumen](https://github.com/laravel/lumen)
 * [GraphQL PHP](https://github.com/webonyx/graphql-php)
 
 
@@ -37,9 +37,9 @@ It offers following features and improvements over the original package by
 composer require rebing/graphql-laravel
 ```
 
-##### Laravel 5.5+
+##### Laravel 6.0+
 
-**1.** Laravel 5.5+ will autodiscover the package, for older versions add the
+**1.** Laravel 6.0+ will autodiscover the package, for older versions add the
 following service provider
 ```php
 Rebing\GraphQL\GraphQLServiceProvider::class,
@@ -100,7 +100,7 @@ To work this around:
   - [Installation](#installation)
       - [Dependencies:](#dependencies)
       - [Installation:](#installation)
-        - [Laravel 5.5+](#laravel-55)
+        - [Laravel 6.0+](#laravel-60)
         - [Lumen (experimental!)](#lumen-experimental)
   - [Usage](#usage)
     - [Schemas](#schemas)

--- a/composer.json
+++ b/composer.json
@@ -33,15 +33,15 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">= 7.1",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+        "php": ">= 7.2",
+        "illuminate/contracts": "6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
         "webonyx/graphql-php": "^14.0, !=14.0.2",
         "ext-json": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|4.0.*|5.0.*",
-        "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0",
+        "orchestra/testbench": "4.0.*|5.0.*",
+        "phpunit/phpunit": "~7.0|~8.0",
         "nunomaduro/larastan": "0.5.0",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1936,16 +1936,6 @@ parameters:
 			path: tests/TestCase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:__call\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/TestCase.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:__call\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/TestCase.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:runCommand\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/TestCase.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,6 @@ parameters:
         - %currentWorkingDirectory%/tests/Support/database/
     ignoreErrors:
         - '/Call to an undefined method Rebing\\GraphQL\\Tests\\TestCaseDatabase::setupSqlAssertionTrait\(\)/'
-        - '/Class Orchestra\\Database\\ConsoleServiceProvider not found/'
         - '/Parameter #3 \$subject of function str_replace expects array\|string, string\|false given/'
         - '/Method Rebing\\GraphQL\\GraphQL::routeNameTransformer\(\) should return string but returns string\|null/'
         - '/Cannot access property \$parameters on mixed/'

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL\Tests;
 
-use Error;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use Illuminate\Console\Command;
-use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
@@ -121,11 +118,6 @@ class TestCase extends BaseTestCase
             GraphQLServiceProvider::class,
         ];
 
-        // Support for Laravel 5.5 testing
-        if (class_exists(ConsoleServiceProvider::class)) {
-            $providers[] = ConsoleServiceProvider::class;
-        }
-
         return $providers;
     }
 
@@ -134,26 +126,6 @@ class TestCase extends BaseTestCase
         return [
             'GraphQL' => GraphQL::class,
         ];
-    }
-
-    /**
-     * Implement for Laravel 5.5 testing with PHPUnit 6.5 which doesn't have
-     * `assertIsArray`.
-     *
-     * @param  string  $name
-     * @param  array  $arguments
-     */
-    public function __call(string $name, array $arguments)
-    {
-        if ($name !== 'assertIsArray') {
-            throw new Error('Call to undefined method '.static::class.'::$name via __call()');
-        }
-
-        static::assertThat(
-            $arguments[0],
-            new IsType(IsType::TYPE_ARRAY),
-            $arguments[1] ?? ''
-        );
     }
 
     /**


### PR DESCRIPTION
## Summary
All < L6 are EOL by the end of August 2020, see https://laravel.com/docs/7.x/releases

L6+ requires PHP 7.2 and PHPUnit 7.5.* thus we can also
bump these.
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
