### PR TITLE
Remove exclusion of specific graphql-php version and fix actual bugs in tests and adapt code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php": ">= 7.2",
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0",
-        "webonyx/graphql-php": "^14.0, !=14.0.2",
+        "webonyx/graphql-php": "^14.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Support/AliasArguments/AliasArguments.php
+++ b/src/Support/AliasArguments/AliasArguments.php
@@ -70,10 +70,15 @@ class AliasArguments
         }
         $pathAndAlias = [];
         foreach ($fields as $name => $arg) {
-            // $arg is either an array DSL notation or an InputObjectField
-            $arg = $arg instanceof InputObjectField ? $arg : (object) $arg;
+            $type = null;
 
-            $type = $arg->type ?? null;
+            // $arg is either an array DSL notation or an InputObjectField
+            if ($arg instanceof InputObjectField) {
+                $type = $arg->getType();
+            } else {
+                $arg = (object) $arg;
+                $type = $arg->type ?? null;
+            }
 
             if (null === $type) {
                 continue;

--- a/src/Support/Rules.php
+++ b/src/Support/Rules.php
@@ -139,7 +139,10 @@ class Rules
             }
 
             if (property_exists($field, 'type') && array_key_exists($name, $resolutionArguments) && is_array($resolutionArguments[$name])) {
-                $rules = $rules + $this->inferRulesFromType($field->type, $key, $resolutionArguments[$name]);
+                $type = $field instanceof InputObjectField
+                    ? $field->getType()
+                    : $field->type;
+                $rules = $rules + $this->inferRulesFromType($type, $key, $resolutionArguments[$name]);
             }
         }
 

--- a/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+++ b/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
@@ -26,7 +26,7 @@ class TestAuthorizationArgsQuery extends Query
     {
         return [
             'id' => [
-                Type::nonNull(Type::ID()),
+                'type' => Type::nonNull(Type::ID()),
             ],
         ];
     }

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
@@ -27,7 +27,7 @@ class PostType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query): HasMany {

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
@@ -30,7 +30,7 @@ class UserType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
@@ -27,7 +27,7 @@ class PostType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
@@ -30,7 +30,7 @@ class UserType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
@@ -22,7 +22,7 @@ class UsersQuery extends Query
     {
         return [
             'flag' => [
-                Type::boolean(),
+                'type' => Type::boolean(),
             ],
             'select' => [
                 'type' => Type::boolean(),

--- a/tests/Unit/AliasAguments/AliasArgumentsTest.php
+++ b/tests/Unit/AliasAguments/AliasArgumentsTest.php
@@ -32,8 +32,23 @@ class AliasArgumentsTest extends TestCase
     public function testMutationAlias(): void
     {
         $query = '
-            mutation ($exampleValidationInputObject: ExampleValidationInputObject, $aList: [ExampleNestedValidationInputObject], $aListNonNull: [ExampleNestedValidationInputObject]!, $a_list_non_null_and_type_nonNull: [ExampleNestedValidationInputObject!]!, $a_list_type_nonNull: [ExampleNestedValidationInputObject!]) {
-                updateExample(test_type_duplicates: null, test: "HELLO", test_with_alias_and_null: null, test_type: $exampleValidationInputObject, a_list: $aList, a_list_non_null: $aListNonNull, a_list_non_null_and_type_nonNull: $a_list_non_null_and_type_nonNull, a_list_type_nonNull: $a_list_type_nonNull) {
+            mutation (
+                $exampleValidationInputObject: ExampleValidationInputObject,
+                $aList: [ExampleNestedValidationInputObject],
+                $aListNonNull: [ExampleNestedValidationInputObject]!,
+                $a_list_non_null_and_type_nonNull: [ExampleNestedValidationInputObject!]!,
+                $a_list_type_nonNull: [ExampleNestedValidationInputObject!]
+            ) {
+                updateExample(
+                    test_type_duplicates: null,
+                    test: "HELLO",
+                    test_with_alias_and_null: null,
+                    test_type: $exampleValidationInputObject,
+                    a_list: $aList,
+                    a_list_non_null: $aListNonNull,
+                    a_list_non_null_and_type_nonNull: $a_list_non_null_and_type_nonNull,
+                    a_list_type_nonNull: $a_list_type_nonNull
+                ) {
                     test
                 }
             }


### PR DESCRIPTION
## Summary
- [x] Let's track the progress of the breaking change from https://github.com/webonyx/graphql-php/pull/684#issuecomment-655274309 with the removal of this exclusion

See https://github.com/webonyx/graphql-php/pull/684#issuecomment-655904755 , all the problems were bugs in the test cases "working by accident", I recommend to read the analysis.

OTOH some adaptions where necessary as `->type` cannot be assumed to be available on lazy loaded types and using the getter `->getType()` is necessary.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
