### PR TITLE
composer.json: indicate PDO sqlite is required for running tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "matt-allan/laravel-code-style": "0.5.0",
-        "phpstan/phpstan": "0.12.8"
+        "phpstan/phpstan": "0.12.8",
+        "ext-pdo_sqlite": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
This is from the conversation over at https://github.com/webonyx/graphql-php/pull/684#issuecomment-655341377

I never questioned PDO or it's sqlite driver not being available.

Also it seems the GHA https://github.com/shivammathur/setup-php provides it out of the box 

But I wonder, is this appropriate/correct to do this way?

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
