### PR TITLE
[TESTS] Add testing lazy types as dedicated predicate to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,8 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4]
         laravel: [^6.0, ^7.0]
-    name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
+        lazy_types: ['false', 'true']
+    name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
     runs-on: ubuntu-18.04
     env:
       COMPOSER_NO_INTERACTION: 1
@@ -39,6 +40,10 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-composer-
 
       - run: composer update --prefer-dist --no-progress
+
+      - name: Enable lazy types conditionally
+        run: echo "::set-env name=TESTS_ENABLE_LAZYLOAD_TYPES::1"
+        if: matrix.lazy_types == 'true'
 
       - name: Run tests
         run: composer tests

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,9 @@
     },
     "scripts": {
         "phpstan": "phpstan analyse --memory-limit=512M",
-        "tests": [
-          "phpunit --colors=always --verbose",
+        "tests": "phpunit --colors=always --verbose",
+        "all-tests": [
+          "TESTS_ENABLE_LAZYLOAD_TYPES=0 phpunit --colors=always --verbose",
           "TESTS_ENABLE_LAZYLOAD_TYPES=1 phpunit --colors=always --verbose"
         ],
         "phpstan-baseline": "phpstan analyse --memory-limit=512M --generate-baseline",

--- a/composer.json
+++ b/composer.json
@@ -61,14 +61,14 @@
     },
     "scripts": {
         "phpstan": "phpstan analyse --memory-limit=512M",
-        "tests": "phpunit --colors=always --verbose",
-        "all-tests": [
-          "TESTS_ENABLE_LAZYLOAD_TYPES=0 phpunit --colors=always --verbose",
-          "TESTS_ENABLE_LAZYLOAD_TYPES=1 phpunit --colors=always --verbose"
-        ],
         "phpstan-baseline": "phpstan analyse --memory-limit=512M --generate-baseline",
         "lint": "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
-        "fix-style": "php-cs-fixer fix"
+        "fix-style": "php-cs-fixer fix",
+        "tests": "phpunit --colors=always --verbose",
+        "tests-all": [
+            "TESTS_ENABLE_LAZYLOAD_TYPES=0 phpunit --colors=always --verbose",
+            "TESTS_ENABLE_LAZYLOAD_TYPES=1 phpunit --colors=always --verbose"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
## Summary
- doesn't (always) stop testing lazy types when the regular suite fails
- give better visibility that we're in fact running tests on them

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
