### PR TITLE
Fix problem with redeclaring the class in phpunit

### DIFF
--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -9,9 +9,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Controller;
 
-class GraphQLController extends Controller
+class GraphQLController
 {
     /** @var Container */
     protected $app;

--- a/src/GraphQLLumenServiceProvider.php
+++ b/src/GraphQLLumenServiceProvider.php
@@ -20,7 +20,7 @@ class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 
     public function register()
     {
-        if (class_exists('Laravel\Lumen\Routing\Controller')) {
+        if (class_exists('Laravel\Lumen\Routing\Controller') && !class_exists('Illuminate\Routing\Controller')) {
             class_alias('Laravel\Lumen\Routing\Controller', 'Illuminate\Routing\Controller');
         }
 

--- a/src/GraphQLLumenServiceProvider.php
+++ b/src/GraphQLLumenServiceProvider.php
@@ -6,6 +6,10 @@ namespace Rebing\GraphQL;
 
 use Rebing\GraphQL\Console\PublishCommand;
 
+if (class_exists('Laravel\Lumen\Routing\Controller')) {
+    class_alias('Laravel\Lumen\Routing\Controller', 'Illuminate\Routing\Controller');
+}
+
 class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 {
     protected function bootPublishes(): void
@@ -20,10 +24,6 @@ class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 
     public function register()
     {
-        if (class_exists('Laravel\Lumen\Routing\Controller') && !class_exists('Illuminate\Routing\Controller')) {
-            class_alias('Laravel\Lumen\Routing\Controller', 'Illuminate\Routing\Controller');
-        }
-
         parent::register();
     }
 

--- a/src/GraphQLLumenServiceProvider.php
+++ b/src/GraphQLLumenServiceProvider.php
@@ -6,10 +6,6 @@ namespace Rebing\GraphQL;
 
 use Rebing\GraphQL\Console\PublishCommand;
 
-if (class_exists('Laravel\Lumen\Routing\Controller')) {
-    class_alias('Laravel\Lumen\Routing\Controller', 'Illuminate\Routing\Controller');
-}
-
 class GraphQLLumenServiceProvider extends GraphQLServiceProvider
 {
     protected function bootPublishes(): void


### PR DESCRIPTION
Suggested change from issue #640 works well.
https://github.com/rebing/graphql-laravel/issues/640

## Summary
When running phpunit tests you will get this error:
```
ErrorException: Cannot declare class Illuminate\Routing\Controller, because the name is already in use

/var/www/vendor/rebing/graphql-laravel/src/GraphQLLumenServiceProvider.php:24
/var/www/vendor/laravel/lumen-framework/src/Application.php:233
/var/www/bootstrap/app.php:100
/var/www/tests/TestCase.php:17
/var/www/vendor/laravel/lumen-framework/src/Testing/TestCase.php:55
/var/www/vendor/laravel/lumen-framework/src/Testing/TestCase.php:72
```
## Type of change
Simply check if the class already exists before creating the alias.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
