### PR TITLE
Fix break with graphql-php 14.2.0

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,6 +131,11 @@ parameters:
 			path: src/Support/AliasArguments/AliasArguments.php
 
 		-
+			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\|stdClass\\:\\:\\$alias\\.$#"
+			count: 1
+			path: src/Support/AliasArguments/AliasArguments.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\ArrayKeyChange\\:\\:modify\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/AliasArguments/ArrayKeyChange.php
@@ -284,6 +289,11 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getInputListObjectValue\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
+			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\|stdClass\\:\\:\\$rules\\.$#"
+			count: 1
+			path: src/Support/Rules.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:\\$select type has no value type specified in iterable type array\\.$#"

--- a/src/Support/AliasArguments/AliasArguments.php
+++ b/src/Support/AliasArguments/AliasArguments.php
@@ -86,8 +86,9 @@ class AliasArguments
 
             $newPrefix = $prefix ? $prefix.'.'.$name : $name;
 
-            if (isset($arg->alias)) {
-                $pathAndAlias[$newPrefix] = $arg->alias;
+            $alias = $arg->config['alias'] ?? $arg->alias ?? null;
+            if ($alias) {
+                $pathAndAlias[$newPrefix] = $alias;
             }
 
             if ($this->isWrappedInList($type)) {

--- a/src/Support/Rules.php
+++ b/src/Support/Rules.php
@@ -134,8 +134,9 @@ class Rules
             $key = $prefix === null ? $name : "{$prefix}.{$name}";
 
             // get any explicitly set rules
-            if (isset($field->rules)) {
-                $rules[$key] = $this->resolveRules($field->rules, $resolutionArguments);
+            $fieldRules = $field->config['rules'] ?? $field->rules ?? null;
+            if ($fieldRules) {
+                $rules[$key] = $this->resolveRules($fieldRules, $resolutionArguments);
             }
 
             if (property_exists($field, 'type') && array_key_exists($name, $resolutionArguments) && is_array($resolutionArguments[$name])) {


### PR DESCRIPTION
## Summary
Prefer accessing custom fields via `->config` over direct property access.

Assuming options are set as public properties isn't working anymore after https://github.com/webonyx/graphql-php/pull/702

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
