### PR TITLE
Generate SyntaxError instead of Exception for empty queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/5.1.3...master)
 --------------
 
+2020-10-05, 5.x
+-----------------
+### Fixed
+- Implemented generation of a SyntaxError instead of an hard Exception for empty single/batch queries [\#680 / plivius](https://github.com/rebing/graphql-laravel/pull/680)
+
 ## Breaking changes
 - Upgrade to webonxy/graphql-php 14.0.0 [\#645 / mfn](https://github.com/rebing/graphql-laravel/pull/645)
 - Remove support for Laravel < 6.0 [\#651 / mfn](https://github.com/rebing/graphql-laravel/pull/651)

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -45,7 +45,10 @@ class GraphQLController extends Controller
 
         // Complete each query in order
         foreach ($inputs as $input) {
-            $completedQueries[] = $this->executeQuery($schema, $input);
+            $completedQueries[] = $this->executeQuery(
+                $schema,
+                ($input['query'] ?? null) ? $input : ['query' => '']
+            );
         }
 
         $data = $isBatch ? $completedQueries : $completedQueries[0];

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -12,12 +12,12 @@ class EmptyQueryTest extends TestCaseDatabase
     use SqlAssertionTrait;
 
     /**
-     * @param $query
+     * @param string $query
      * @testWith    [""]
      *              [" "]
      *              ["#"]
      */
-    public function testEmptyQuery($query): void
+    public function testEmptyQuery(string $query): void
     {
         $this->sqlCounterReset();
 

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database;
+
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class EmptyQueryTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    /**
+     * @param $query
+     * @testWith    [""]
+     *              [" "]
+     *              ["#"]
+     */
+    public function testEmptyQuery($query): void
+    {
+        $this->sqlCounterReset();
+
+        $result = $this->httpGraphql($query);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('Syntax Error: Unexpected <EOF>', $result['errors'][0]['message']);
+        $this->assertSame('graphql', $result['errors'][0]['extensions']['category']);
+    }
+
+}

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -27,5 +27,4 @@ class EmptyQueryTest extends TestCaseDatabase
         $this->assertSame('Syntax Error: Unexpected <EOF>', $result['errors'][0]['message']);
         $this->assertSame('graphql', $result['errors'][0]['extensions']['category']);
     }
-
 }

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -11,7 +11,7 @@ class EmptyQueryTest extends TestCaseDatabase
     /**
      * @dataProvider dataForEmptyQuery
      * @param bool $isBatchRequest
-     * @param array $parameters
+     * @param array<mixed> $parameters
      */
     public function testEmptyQuery(bool $isBatchRequest, array $parameters): void
     {
@@ -34,7 +34,7 @@ class EmptyQueryTest extends TestCaseDatabase
     }
 
     /**
-     * @return array
+     * @return array<mixed>
      */
     public function dataForEmptyQuery(): array
     {


### PR DESCRIPTION
## Summary
When providing a completely empty query, this triggers a hard (typecast) exception in `Rebing\GraphQL\GraphQLController` (either `$input` not being an array on L48 or `$query` being `null` on line L73). This PR facilitates a "graceful fallback" to a SyntaxError.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Amended CHANGELOG.md
- [x] Code style has been fixed via `composer fix-style`
