### PR TITLE
Generate SyntaxError instead of Exception for empty queries [5.x]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/5.1.4...master)
 --------------
 
+2020-10-12, 5.x
+-----------------
+### Fixed
+- Implemented generation of a SyntaxError instead of an hard Exception for empty single/batch queries
+
 2020-09-03, 5.1.4
 -----------------
 Hotfix release to replace 5.1.3

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -45,7 +45,7 @@ class GraphQLController extends Controller
 
         // Complete each query in order
         foreach ($inputs as $input) {
-            $completedQueries[] = $this->executeQuery($schema, $input);
+            $completedQueries[] = $this->executeQuery($schema, $input ?: []);
         }
 
         $data = $isBatch ? $completedQueries : $completedQueries[0];
@@ -58,7 +58,7 @@ class GraphQLController extends Controller
 
     protected function executeQuery(string $schema, array $input): array
     {
-        $query = $input['query'];
+        $query = $input['query'] ?? '';
 
         $paramsKey = config('graphql.params_key', 'variables');
         $params = $input[$paramsKey] ?? null;

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class EmptyQueryTest extends TestCaseDatabase
+{
+    /**
+     * @dataProvider dataForEmptyQuery
+     * @param array<mixed> $parameters
+     * @param bool $isBatchRequest
+     * @param bool $isExpectedCleanResult
+     */
+    public function testEmptyQuery(array $parameters, bool $isBatchRequest, bool $isExpectedCleanResult): void
+    {
+        $response = $this->call('GET', '/graphql', $parameters);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $results = $isBatchRequest ? $response->getData(true) : [$response->getData(true)];
+
+        foreach ($results as $result) {
+            if ($isExpectedCleanResult) {
+                $this->assertArrayNotHasKey('errors', $result);
+            } else {
+                $this->assertCount(1, $result['errors']);
+                $this->assertSame('Syntax Error: Unexpected <EOF>', $result['errors'][0]['message']);
+                $this->assertSame('graphql', $result['errors'][0]['extensions']['category']);
+            }
+        }
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function dataForEmptyQuery(): array
+    {
+        return [
+            // completely empty request
+            [
+                [], false, true,
+            ],
+            // single request with an empty query parameter
+            [
+                ['query' => null], false, false,
+            ],
+            [
+                ['query' => ''], false, false,
+            ],
+            [
+                ['query' => ' '], false, false,
+            ],
+            [
+                ['query' => '#'], false, false,
+            ],
+            // batch request with one completely empty batch, and batches with an empty query parameter
+            [
+                [[], ['query' => null], ['query' => ''], ['query' => ' '], ['query' => '#']], true, false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
Continuation of https://github.com/rebing/graphql-laravel/pull/680, against base `5.x`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Code style has been fixed via `composer fix-style`
