### PR TITLE
[5.x] PHP 8 compatibility

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: composer:v1
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,10 @@ jobs:
             laravel: 5.5.*
           - php: 8.0
             laravel: 5.5.*
+          - php: 8.0
+            laravel: ^6.0
+          - php: 8.0
+            laravel: ^7.0
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,6 @@ jobs:
             laravel: 5.5.*
           - php: 8.0
             laravel: 5.5.*
-          - php: 8.0
-            laravel: ^6.0
-          - php: 8.0
-            laravel: ^7.0
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
             laravel: 5.5.*
           - php: 8.0
             laravel: 5.5.*
+          - php: 8.0
+            laravel: ^6.0
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   integration:
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
         laravel: [5.5.*, ^6.0, ^7.0, ^8.0]
         exclude:
           - php: 7.1
@@ -18,6 +18,8 @@ jobs:
           - php: 7.2
             laravel: ^8.0
           - php: 7.4
+            laravel: 5.5.*
+          - php: 8.0
             laravel: 5.5.*
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-18.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
       - run: composer remove --dev matt-allan/laravel-code-style --no-update
       - run: composer require illuminate/contracts:${{ matrix.laravel }} --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
+      - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
       - run: composer require --dev laravel/legacy-factories --no-update
         if: matrix.laravel == '^8.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/5.1.4...master)
 --------------
 
+### Added
+- Support for PHP 8 [\#686 / mfn](https://github.com/rebing/graphql-laravel/pull/686)
+
 2020-09-03, 5.1.4
 -----------------
 Hotfix release to replace 5.1.3

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*|4.0.*|5.0.*|^6.0",
-        "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0",
+        "phpunit/phpunit": "^5.5|~6.0|~7.0|~8.0|^9",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "matt-allan/laravel-code-style": "0.5.0"

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -85,8 +85,6 @@ class PublishCommand extends Command
      */
     protected function status(string $from, string $to): void
     {
-        $from = str_replace(base_path(), '', realpath($from));
-        $to = str_replace(base_path(), '', realpath($to));
         $this->line("<info>Copied File</info> <comment>[{$from}]</comment> <info>To</info> <comment>[{$to}]</comment>");
     }
 }

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -162,13 +162,15 @@ abstract class Field
             $additionalParams = array_slice($method->getParameters(), 3);
 
             $additionalArguments = array_map(function ($param) use ($arguments, $fieldsAndArguments) {
-                $className = null !== $param->getClass() ? $param->getClass()->getName() : null;
+                $paramType = $param->getType();
 
-                if (null === $className) {
+                if ($paramType->isBuiltin()) {
                     throw new InvalidArgumentException("'{$param->name}' could not be injected");
                 }
 
-                if (Closure::class === $param->getType()->getName()) {
+                $className = $param->getType()->getName();
+
+                if (Closure::class === $className) {
                     return function (int $depth = null) use ($arguments, $fieldsAndArguments): SelectFields {
                         return $this->instanciateSelectFields($arguments, $fieldsAndArguments, $depth);
                     };


### PR DESCRIPTION
## Summary

See also https://github.com/rebing/graphql-laravel/pull/687 for the same directly for the master/6.x branch, but ideally we can make this one working and merge it up.

Unclear: can't make tests work with PHP8/L6 (also a problem of https://github.com/rebing/graphql-laravel/pull/687 )

### TODO
- [x] `BadMethodCallException: Method Illuminate\Http\Response::getData does not exist.`
- [x] `TypeError: GraphQL\Utils\AST::valueFromAST(): Argument #2 ($type) must be of type GraphQL\Type\Definition\InputType, null given, called in /home/runner/work/graphql-laravel/graphql-laravel/vendor/webonyx/graphql-php/src/Executor/Values.php on line 229`

=> both these errors where fixed via https://github.com/rebing/graphql-laravel/pull/689

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
