### PR TITLE
[6.x] PHP 8 compatibility

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: composer:v1
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
         exclude:
           - php: 7.2
             laravel: ^8.0
+          - php: 8.0
+            laravel: ^6.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   integration:
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         lazy_types: ['false', 'true']
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       - run: composer remove --dev matt-allan/laravel-code-style --no-update
       - run: composer require illuminate/contracts:${{ matrix.laravel }} --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
+      - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
       - run: composer remove --dev laravel/legacy-factories --no-update
         if: (matrix.laravel == '^6.0' || matrix.laravel == '^7.0')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
   
 ### Added
 - Support for Laravel 8 [\#672 / mfn](https://github.com/rebing/graphql-laravel/pull/672)
+- Support for PHP 8 [\#687 / mfn](https://github.com/rebing/graphql-laravel/pull/687)
 
 2020-09-03, 5.1.4
 -----------------

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "4.0.*|5.0.*|^6.0",
-        "phpunit/phpunit": "~7.0|~8.0",
+        "phpunit/phpunit": "~7.0|~8.0|^9",
         "nunomaduro/larastan": "0.6.4",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -206,6 +206,11 @@ parameters:
 			path: src/Support/Field.php
 
 		-
+			message: "#^Cannot call method isBuiltin\\(\\) on ReflectionType\\|null\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
 			message: "#^Cannot call method getName\\(\\) on ReflectionType\\|null\\.$#"
 			count: 1
 			path: src/Support/Field.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,13 +10,11 @@ parameters:
         - %currentWorkingDirectory%/tests/Support/database/
     ignoreErrors:
         - '/Call to an undefined method Rebing\\GraphQL\\Tests\\TestCaseDatabase::setupSqlAssertionTrait\(\)/'
-        - '/Parameter #3 \$subject of function str_replace expects array\|string, string\|false given/'
         - '/Method Rebing\\GraphQL\\GraphQL::routeNameTransformer\(\) should return string but returns string\|null/'
         - '/Cannot access property \$parameters on mixed/'
         - '/Strict comparison using === between null and array will always evaluate to false/'
         # \Rebing\GraphQL\Support\SelectFields::handleFields
         - '/Binary operation "." between string and array\|string\|null results in an error/'
-        - '/Parameter #1 \$key of function array_key_exists expects int\|string, string\|false given/'
         - '/Parameter #1 \$function of function call_user_func_array expects callable\(\): mixed, array\(\$this\(Rebing\\GraphQL\\Support\\Type\), string\) given/'
         - '/Call to an undefined method Illuminate\\Testing\\TestResponse::(content|getData|getStatusCode)\(\)/'
         - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -85,8 +85,6 @@ class PublishCommand extends Command
      */
     protected function status(string $from, string $to): void
     {
-        $from = str_replace(base_path(), '', realpath($from));
-        $to = str_replace(base_path(), '', realpath($to));
         $this->line("<info>Copied File</info> <comment>[{$from}]</comment> <info>To</info> <comment>[{$to}]</comment>");
     }
 }

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -162,13 +162,15 @@ abstract class Field
             $additionalParams = array_slice($method->getParameters(), 3);
 
             $additionalArguments = array_map(function ($param) use ($arguments, $fieldsAndArguments) {
-                $className = null !== $param->getClass() ? $param->getClass()->getName() : null;
+                $paramType = $param->getType();
 
-                if (null === $className) {
+                if ($paramType->isBuiltin()) {
                     throw new InvalidArgumentException("'{$param->name}' could not be injected");
                 }
 
-                if (Closure::class === $param->getType()->getName()) {
+                $className = $param->getType()->getName();
+
+                if (Closure::class === $className) {
                     return function (int $depth = null) use ($arguments, $fieldsAndArguments): SelectFields {
                         return $this->instanciateSelectFields($arguments, $fieldsAndArguments, $depth);
                     };


### PR DESCRIPTION
## Summary
Notable changes:
- Can't get Laravel 6 / PHP 8 working
  Due to composer dependency conflicts I can't figure out how to solve.
  I _assume_ L6 (which is supposed to be PHP8 compatible) just works with for now
- removed file path translation in `\Rebing\GraphQL\Console\PublishCommand::status`
  Couldn't figure out a good fix so the tests (yes, it's a problem only for the tests!) would also work in PHP8.
  Consider this temporary until a fix comes along.
- For the integration tests, had to switch back to composer v1
  It's in fact unrelated to this PR but was necessary to get things "green"

See also https://github.com/rebing/graphql-laravel/pull/687 for the same attempt for the 5.x branch

### TODO
- [x] Before finalizing, removing `DROP COMMIT` commits ;)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
