### PR TITLE
Prepare 6.0.0-rc1

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: composer:v1
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG
 =========
 
-[Next release](https://github.com/rebing/graphql-laravel/compare/5.1.3...master)
+[Next release](https://github.com/rebing/graphql-laravel/compare/6.0.0-rc1...master)
 --------------
+
+2020-11-13, 6.0.0-rc1
+---------------------
 
 ## Breaking changes
 - Upgrade to webonxy/graphql-php 14.0.0 [\#645 / mfn](https://github.com/rebing/graphql-laravel/pull/645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
 ---------------------
 
 ## Breaking changes
-- Upgrade to webonxy/graphql-php 14.0.0 [\#645 / mfn](https://github.com/rebing/graphql-laravel/pull/645)
+- Upgrade to webonyx/graphql-php 14.0.0 [\#645 / mfn](https://github.com/rebing/graphql-laravel/pull/645)
 - Remove support for Laravel < 6.0 [\#651 / mfn](https://github.com/rebing/graphql-laravel/pull/651)
   This also bumps the minimum required version to PHP 7.2
   

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,7 +16,6 @@ parameters:
         - '/Strict comparison using === between null and array will always evaluate to false/'
         # \Rebing\GraphQL\Support\SelectFields::handleFields
         - '/Binary operation "." between string and array\|string\|null results in an error/'
-        - '/Parameter #1 \$key of function array_key_exists expects int\|string, string\|false given/'
         - '/Parameter #1 \$function of function call_user_func_array expects callable\(\): mixed, array\(\$this\(Rebing\\GraphQL\\Support\\Type\), string\) given/'
         - '/Call to an undefined method Illuminate\\Testing\\TestResponse::(content|getData|getStatusCode)\(\)/'
         - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'


### PR DESCRIPTION
## Summary
Let's get the ball rolling ⚽ 

- Seems the integration tests don't work with composer:v2 (anymore? 🤷‍♀️), I already saw this in https://github.com/rebing/graphql-laravel/pull/687 and cherry-picked the commit to downgrade them temporarily
- phpstan also needed a small change, removal of ignored error

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
