### PR TITLE
tests: fix definition of some args missing the `type` key

### DIFF
--- a/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
+++ b/tests/Database/AuthorizeArgsTests/TestAuthorizationArgsQuery.php
@@ -26,7 +26,7 @@ class TestAuthorizationArgsQuery extends Query
     {
         return [
             'id' => [
-                Type::nonNull(Type::ID()),
+                'type' => Type::nonNull(Type::ID()),
             ],
         ];
     }

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/PostType.php
@@ -27,7 +27,7 @@ class PostType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query): HasMany {

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/UserType.php
@@ -30,7 +30,7 @@ class UserType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
@@ -27,7 +27,7 @@ class PostType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UserType.php
@@ -30,7 +30,7 @@ class UserType extends GraphQLType
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Post')))),
                 'args' => [
                     'flag' => [
-                        Type::boolean(),
+                        'type' => Type::boolean(),
                     ],
                 ],
                 'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
@@ -22,7 +22,7 @@ class UsersQuery extends Query
     {
         return [
             'flag' => [
-                Type::boolean(),
+                'type' => Type::boolean(),
             ],
             'select' => [
                 'type' => Type::boolean(),


### PR DESCRIPTION
## Summary
See https://github.com/webonyx/graphql-php/pull/684#issuecomment-655904755

This is cherry-picked from https://github.com/rebing/graphql-laravel/pull/652/commits to fix some tests for https://github.com/rebing/graphql-laravel/pull/686

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
