### PR TITLE
[5.x] Fix integration tests not working with composer v2, 2nd attempt

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,12 +18,12 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: composer:v1
+          tools: composer:v2
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it
       - run: composer remove --dev matt-allan/laravel-code-style --no-update
-      - run: composer require illuminate/contracts:7.0 --no-update
+      - run: composer require illuminate/contracts:^8.0 --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
 
       - name: Get composer cache directory


### PR DESCRIPTION
## Summary
The problem in question, from the GHA logs:
```
Your requirements could not be resolved to an installable set of packages.
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires rebing/graphql-laravel * -> satisfiable by rebing/graphql-laravel[dev-mfn-integration-test-composer-v2].
    - rebing/graphql-laravel dev-mfn-integration-test-composer-v2 requires illuminate/contracts 7.0 -> found illuminate/contracts[v7.0.0] but it conflicts with another require.


  Problem 1
    - Root composer.json requires rebing/graphql-laravel * -> satisfiable by rebing/graphql-laravel[dev-mfn-integration-test-composer-v2].
    - rebing/graphql-laravel dev-mfn-integration-test-composer-v2 requires illuminate/contracts 7.0 -> found illuminate/contracts[v7.0.0] but it conflicts with another require.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
