### PR TITLE
[6.x] gha: fix deprecated of set-env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - run: composer update --prefer-dist --no-progress
 
       - name: Enable lazy types conditionally
-        run: echo "::set-env name=TESTS_ENABLE_LAZYLOAD_TYPES::1"
+        run: echo "TESTS_ENABLE_LAZYLOAD_TYPES=1" >> $GITHUB_ENV
         if: matrix.lazy_types == 'true'
 
       - name: Run tests


### PR DESCRIPTION
## Summary
See https://github.com/rebing/graphql-laravel/runs/1410824957#step:12:6

Docs how to fix https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

This only applies to master branch, 5.x used a different approach.

<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
