### PR TITLE
Basic directives support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2221,7 +2221,7 @@ class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
      */
     public static function getInstance(): UpperCaseDirective
     {
-        if (self::$instance == null) self::$instance = new static();
+        if (self::$instance == null) self::$instance = new self();
         return self::$instance;
     }
 

--- a/README.md
+++ b/README.md
@@ -2168,7 +2168,7 @@ Create and place directives in your graphql config file, example and setup your 
             'query' => [],
             'mutation' => [],
             'directive' => [
-                \App\GraphQL\Directives\CapitalizeDirective::newInstance(),
+                \App\GraphQL\Directives\CapitalizeDirective::class,
             ],
             'middleware' => [],
             'method' => ['get', 'post'],
@@ -2198,13 +2198,10 @@ class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
     /** @var string */
     const NAME = 'upper';
 
-    /** @var UpperCaseDirective|null */
-    private static $instance = null;
-
     /**
      * UpperCaseDirective constructor.
      */
-    protected function __construct()
+    public function __construct()
     {
         parent::__construct([
             'name' => static::NAME,
@@ -2214,15 +2211,6 @@ class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
             ],
             'args' => [],
         ]);
-    }
-
-    /**
-     * @return UpperCaseDirective
-     */
-    public static function getInstance(): UpperCaseDirective
-    {
-        if (self::$instance == null) self::$instance = new self();
-        return self::$instance;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpunit/phpunit": "~7.0|~8.0|^9",
         "nunomaduro/larastan": "0.6.10",
         "mockery/mockery": "^1.2",
-        "friendsofphp/php-cs-fixer": "^2.15",
+        "friendsofphp/php-cs-fixer": "2.16.8",
         "matt-allan/laravel-code-style": "0.5.1",
         "ext-pdo_sqlite": "*",
         "laravel/legacy-factories": "^1.0"

--- a/config/config.php
+++ b/config/config.php
@@ -107,7 +107,7 @@ return [
                 // 'example_mutation'  => ExampleMutation::class,
             ],
             'directive' => [
-                // ExampleDirective::getInstance(),
+                // ExampleDirective::class,
             ],
             'middleware' => [],
             'method' => ['get', 'post'],

--- a/config/config.php
+++ b/config/config.php
@@ -106,6 +106,9 @@ return [
             'mutation' => [
                 // 'example_mutation'  => ExampleMutation::class,
             ],
+            'directive' => [
+                //
+            ],
             'middleware' => [],
             'method' => ['get', 'post'],
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -107,7 +107,7 @@ return [
                 // 'example_mutation'  => ExampleMutation::class,
             ],
             'directive' => [
-                //
+                // ExampleDirective::getInstance(),
             ],
             'middleware' => [],
             'method' => ['get', 'post'],
@@ -196,6 +196,7 @@ return [
      * or
      * ```php
      * 'defaultFieldResolver' => [SomeKlass::class, 'someMethod'],
+     * 'defaultFieldResolver' => [\Rebing\GraphQL\Helpers::class, 'defaultFieldResolverWithDirectives'],
      * ```
      */
     'defaultFieldResolver' => null,

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -84,20 +84,11 @@ class GraphQL
             'name' => 'Subscription',
         ]);
 
-        /* TODO: understand its functionality, it's not working at the moment
-        $directive = $this->objectType($schemaDirective, [
-            'name' => 'Directive',
-        ]);
-        */
-
-        // temp workaround
-        $directive = $schemaDirective;
-
         return new Schema([
             'query' => $query,
             'mutation' => ! empty($schemaMutation) ? $mutation : null,
             'subscription' => ! empty($schemaSubscription) ? $subscription : null,
-            'directives' => ! empty($schemaDirective) ? $directive : null,
+            'directives' => ! empty($schemaDirective) ? $schemaDirective : null,
             'types' => function () use ($schema) {
                 $types = [];
                 $schemaTypes = $schema['types'] ?? [];

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -84,11 +84,18 @@ class GraphQL
             'name' => 'Subscription',
         ]);
 
+        $directives = [];
+        foreach ($schemaDirective as $directive) {
+            if (is_string($directive)) {
+                $directives[] = new $directive();
+            }
+        }
+
         return new Schema([
             'query' => $query,
             'mutation' => ! empty($schemaMutation) ? $mutation : null,
             'subscription' => ! empty($schemaSubscription) ? $subscription : null,
-            'directives' => ! empty($schemaDirective) ? $schemaDirective : null,
+            'directives' => ! empty($directives) ? $directives : null,
             'types' => function () use ($schema) {
                 $types = [];
                 $schemaTypes = $schema['types'] ?? [];

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -70,6 +70,7 @@ class GraphQL
         $schemaQuery = $schema['query'] ?? [];
         $schemaMutation = $schema['mutation'] ?? [];
         $schemaSubscription = $schema['subscription'] ?? [];
+        $schemaDirective = $schema['directive'] ?? [];
 
         $query = $this->objectType($schemaQuery, [
             'name' => 'Query',
@@ -83,10 +84,20 @@ class GraphQL
             'name' => 'Subscription',
         ]);
 
+        /* TODO: understand its functionality, it's not working at the moment
+        $directive = $this->objectType($schemaDirective, [
+            'name' => 'Directive',
+        ]);
+        */
+
+        // temp workaround
+        $directive = $schemaDirective;
+
         return new Schema([
             'query' => $query,
             'mutation' => ! empty($schemaMutation) ? $mutation : null,
             'subscription' => ! empty($schemaSubscription) ? $subscription : null,
+            'directives' => ! empty($schemaDirective) ? $directive : null,
             'types' => function () use ($schema) {
                 $types = [];
                 $schemaTypes = $schema['types'] ?? [];

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,10 +4,49 @@ declare(strict_types=1);
 
 namespace Rebing\GraphQL;
 
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\ValueNode;
+use GraphQL\Type\Definition\ResolveInfo;
+
 class Helpers
 {
     public static function isLumen(): bool
     {
         return class_exists('Laravel\Lumen\Application');
+    }
+
+    /**
+     * @param ResolveInfo $info
+     * @param string $name
+     * @return DirectiveNode|null
+     */
+    public static function getDirectiveByName(ResolveInfo $info, string $name)
+    {
+        $fieldNode = $info->fieldNodes[0];
+        /** @var NodeList $directives */
+        $directives = $fieldNode->directives;
+        if ($directives) {
+            /** @var DirectiveNode[] $directives */
+            foreach ($directives as $directive) {
+                if ($directive->name->value === $name) {
+                    return $directive;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param DirectiveNode $directive
+     * @return ValueNode[]
+     */
+    public static function getDirectiveArguments(DirectiveNode $directive)
+    {
+        $args = [];
+        foreach ($directive->arguments as $arg) {
+            $args[$arg->name->value] = $arg->value;
+        }
+
+        return $args;
     }
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rebing\GraphQL;
 
 use GraphQL\Language\AST\DirectiveNode;
-use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ValueNode;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -21,7 +20,7 @@ class Helpers
      * @param string $name
      * @return DirectiveNode|null
      */
-    public static function getDirectiveByName(ResolveInfo $info, string $name)
+    public static function getDirectiveByName(ResolveInfo $info, string $name): ?DirectiveNode
     {
         $fieldNode = $info->fieldNodes[0];
         $directives = $fieldNode->directives;
@@ -40,7 +39,7 @@ class Helpers
      * @param DirectiveNode $directive
      * @return ValueNode[]
      */
-    public static function getDirectiveArguments(DirectiveNode $directive)
+    public static function getDirectiveArguments(DirectiveNode $directive): array
     {
         $args = [];
         foreach ($directive->arguments as $arg) {
@@ -78,12 +77,13 @@ class Helpers
 
         $fieldNode = $info->fieldNodes[0];
         $fieldNodeDirectives = $fieldNode->directives ?? [];
-        if (count($fieldNodeDirectives ?? [])) {
+        if (count($fieldNodeDirectives)) {
             foreach ($fieldNodeDirectives as $directive) {
-                /** @var \Rebing\GraphQL\Support\Directive $d */
                 foreach ($info->schema->getDirectives() as $d) {
                     if ($d->name == $directive->name->value) {
-                        $property = $d->handle($property, static::getDirectiveArguments($directive));
+                        if ($d instanceof \Rebing\GraphQL\Support\Directive) {
+                            $property = $d->handle($property, static::getDirectiveArguments($directive));
+                        }
                     }
                 }
             }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -25,7 +25,7 @@ class Helpers
     {
         $fieldNode = $info->fieldNodes[0];
         $directives = $fieldNode->directives;
-        if ((null !== $directives) && is_array($directives)) {
+        if ((null !== $directives)) {
             foreach ($directives as $directive) {
                 if ($directive->name->value === $name) {
                     return $directive;

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -24,16 +24,16 @@ class Helpers
     public static function getDirectiveByName(ResolveInfo $info, string $name)
     {
         $fieldNode = $info->fieldNodes[0];
-        /** @var NodeList $directives */
         $directives = $fieldNode->directives;
-        if ($directives) {
-            /** @var DirectiveNode[] $directives */
+        if ((null !== $directives) && is_array($directives)) {
             foreach ($directives as $directive) {
                 if ($directive->name->value === $name) {
                     return $directive;
                 }
             }
         }
+
+        return null;
     }
 
     /**
@@ -51,10 +51,10 @@ class Helpers
     }
 
     /**
-     * @param $objectValue
-     * @param $args
-     * @param $context
-     * @param  ResolveInfo  $info
+     * @param mixed $objectValue
+     * @param mixed[] $args
+     * @param mixed|null $context
+     * @param ResolveInfo $info
      * @return mixed|null
      */
     public static function defaultFieldResolverWithDirectives($objectValue, $args, $context, \GraphQL\Type\Definition\ResolveInfo $info)
@@ -77,8 +77,9 @@ class Helpers
         }
 
         $fieldNode = $info->fieldNodes[0];
-        if (property_exists($fieldNode, 'directives') && count($fieldNode->directives)) {
-            foreach ($fieldNode->directives as $directive) {
+        $fieldNodeDirectives = $fieldNode->directives ?? [];
+        if (count($fieldNodeDirectives ?? [])) {
+            foreach ($fieldNodeDirectives as $directive) {
                 /** @var \Rebing\GraphQL\Support\Directive $d */
                 foreach ($info->schema->getDirectives() as $d) {
                     if ($d->name == $directive->name->value) {

--- a/src/Support/Directive.php
+++ b/src/Support/Directive.php
@@ -13,7 +13,7 @@ abstract class Directive extends \GraphQL\Type\Definition\Directive
 
     /**
      * @param mixed $value
-     * @param array $args
+     * @param array<mixed> $args
      * @return mixed
      */
     abstract public function handle($value, array $args = []);

--- a/src/Support/Directive.php
+++ b/src/Support/Directive.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support;
+
+abstract class Directive extends \GraphQL\Type\Definition\Directive
+{
+    /**
+     * @return mixed
+     */
+    abstract public static function getInstance();
+
+    /**
+     * @param mixed $value
+     * @param array $args
+     * @return mixed
+     */
+    abstract public function handle($value, array $args = []);
+}

--- a/src/Support/Directive.php
+++ b/src/Support/Directive.php
@@ -7,13 +7,8 @@ namespace Rebing\GraphQL\Support;
 abstract class Directive extends \GraphQL\Type\Definition\Directive
 {
     /**
-     * @return mixed
-     */
-    abstract public static function getInstance();
-
-    /**
      * @param mixed $value
-     * @param array<mixed> $args
+     * @param mixed[] $args
      * @return mixed
      */
     abstract public function handle($value, array $args = []);

--- a/tests/Support/Directives/LowerCaseDirective.php
+++ b/tests/Support/Directives/LowerCaseDirective.php
@@ -14,13 +14,10 @@ class LowerCaseDirective extends \Rebing\GraphQL\Support\Directive
     /** @var string */
     const NAME = 'lower';
 
-    /** @var LowerCaseDirective|null */
-    private static $instance = null;
-
     /**
-     * UpperCaseDirective constructor.
+     * LowerCaseDirective constructor.
      */
-    protected function __construct()
+    public function __construct()
     {
         parent::__construct([
             'name' => static::NAME,
@@ -30,18 +27,6 @@ class LowerCaseDirective extends \Rebing\GraphQL\Support\Directive
             ],
             'args' => [],
         ]);
-    }
-
-    /**
-     * @return LowerCaseDirective
-     */
-    public static function getInstance(): self
-    {
-        if (self::$instance == null) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
     }
 
     /**

--- a/tests/Support/Directives/LowerCaseDirective.php
+++ b/tests/Support/Directives/LowerCaseDirective.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Directives;
+
+use GraphQL\Language\DirectiveLocation;
+
+/**
+ * Class LowerCaseDirective.
+ */
+class LowerCaseDirective extends \Rebing\GraphQL\Support\Directive
+{
+    /** @var string */
+    const NAME = 'lower';
+
+    /** @var LowerCaseDirective|null */
+    private static $instance = null;
+
+    /**
+     * UpperCaseDirective constructor.
+     */
+    protected function __construct()
+    {
+        parent::__construct([
+            'name' => static::NAME,
+            'description' => 'The lower directive.',
+            'locations' => [
+                DirectiveLocation::FIELD,
+            ],
+            'args' => [],
+        ]);
+    }
+
+    /**
+     * @return LowerCaseDirective
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance == null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * @param mixed $value
+     * @param  array<mixed>  $args
+     * @return string|null
+     */
+    public function handle($value, array $args = []): ?string
+    {
+        if (! empty($value)) {
+            $value = strtolower($value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Support/Directives/UpperCaseDirective.php
+++ b/tests/Support/Directives/UpperCaseDirective.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Directives;
+
+use GraphQL\Language\DirectiveLocation;
+
+/**
+ * Class UpperCaseDirective.
+ */
+class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
+{
+    /** @var string */
+    const NAME = 'upper';
+
+    /** @var UpperCaseDirective|null */
+    private static $instance = null;
+
+    /**
+     * UpperCaseDirective constructor.
+     */
+    protected function __construct()
+    {
+        parent::__construct([
+            'name' => static::NAME,
+            'description' => 'The upper directive.',
+            'locations' => [
+                DirectiveLocation::FIELD,
+            ],
+            'args' => [],
+        ]);
+    }
+
+    /**
+     * @return UpperCaseDirective
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance == null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * @param mixed $value
+     * @param  array<mixed>  $args
+     * @return string|null
+     */
+    public function handle($value, array $args = []): ?string
+    {
+        if (! empty($value)) {
+            $value = strtoupper($value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Support/Directives/UpperCaseDirective.php
+++ b/tests/Support/Directives/UpperCaseDirective.php
@@ -14,13 +14,10 @@ class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
     /** @var string */
     const NAME = 'upper';
 
-    /** @var UpperCaseDirective|null */
-    private static $instance = null;
-
     /**
      * UpperCaseDirective constructor.
      */
-    protected function __construct()
+    public function __construct()
     {
         parent::__construct([
             'name' => static::NAME,
@@ -30,18 +27,6 @@ class UpperCaseDirective extends \Rebing\GraphQL\Support\Directive
             ],
             'args' => [],
         ]);
-    }
-
-    /**
-     * @return UpperCaseDirective
-     */
-    public static function getInstance(): self
-    {
-        if (self::$instance == null) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
     }
 
     /**

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -114,4 +114,20 @@ return [
         }
     ',
 
+    'examplesWithDirective' => '
+        query ExamplesWithDirective {
+            examples {
+                test @upper
+            }
+        }
+    ',
+
+    'examplesWithConsecutiveDirectives' => '
+        query ExamplesWithConsecutiveDirectives {
+            examples {
+                test @upper @lower
+            }
+        }
+    ',
+
 ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,8 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Directives\LowerCaseDirective;
+use Rebing\GraphQL\Tests\Support\Directives\UpperCaseDirective;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
@@ -60,6 +62,10 @@ class TestCase extends BaseTestCase
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class,
+            ],
+            'directive' => [
+                UpperCaseDirective::getInstance(),
+                LowerCaseDirective::getInstance(),
             ],
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -64,8 +64,8 @@ class TestCase extends BaseTestCase
                 'updateExample' => UpdateExampleMutation::class,
             ],
             'directive' => [
-                UpperCaseDirective::getInstance(),
-                LowerCaseDirective::getInstance(),
+                UpperCaseDirective::class,
+                LowerCaseDirective::class,
             ],
         ]);
 

--- a/tests/Unit/DirectiveTest.php
+++ b/tests/Unit/DirectiveTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class DirectiveTest extends TestCase
+{
+    /**
+     * Test simple directive.
+     */
+    public function testSimpleDirective(): void
+    {
+        config(['graphql.defaultFieldResolver' => [\Rebing\GraphQL\Helpers::class, 'defaultFieldResolverWithDirectives']]);
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithDirective']),
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->json();
+
+        $this->assertArrayHasKey('data', $content);
+
+        $this->assertEquals([
+            'examples' => array_map(function ($n) {
+                return ['test' => strtoupper($n['test'])];
+            }, $this->data),
+        ], $content['data']);
+    }
+
+    /**
+     * Test simple directive.
+     */
+    public function testConsecutiveDirectives(): void
+    {
+        config(['graphql.defaultFieldResolver' => [\Rebing\GraphQL\Helpers::class, 'defaultFieldResolverWithDirectives']]);
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithConsecutiveDirectives']),
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->json();
+
+        $this->assertArrayHasKey('data', $content);
+
+        $this->assertEquals([
+            'examples' => array_map(function ($n) {
+                return ['test' => strtolower(strtoupper($n['test']))];
+            }, $this->data),
+        ], $content['data']);
+    }
+}


### PR DESCRIPTION
## Summary
Attempted integration of directives support, see [changes](https://github.com/rebing/graphql-laravel/pull/703/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2156) in readme for use case.

#### TODO
 - [ ] Directive location:
   * Request definitions:
      + [ ] query -> seems accessible via ResolveInfo  operation->directives
      + [ ] mutation -> seems accessible via ResolveInfo  operation->directives
      + [ ] subscription -> seems accessible via ResolveInfo  operation->directives
      + [x] field
      + [ ] fragment_definition
      + [ ] fragment_spread
      + [ ] inline_fragment
      + [ ] variable_definition
   * Type system definitions:
      + [ ] schema
      + [ ] scalar
      + [ ] object
      + [ ] field_definition
      + [ ] argument_definition
      + [ ] interface
      + [ ] union
      + [ ] enum
      + [ ] enum_value
      + [ ] input_object
      + [ ] input_field_definition 
 - [ ] Discuss if treating GraphQL directives as middleware or (better) pipeline (see [interesting article](https://blog.logrocket.com/treating-graphql-directives-as-middleware/)) maybe in [default field resolver](https://github.com/rebing/graphql-laravel#default-field-resolver)
 - [ ] Understand possible adaptation of [type-modifiers](https://github.com/rebing/graphql-laravel#type-modifiers)
 - [ ] Tests
 - [ ] Unlock friendsofphp/php-cs-fixer composer dependency

#### DEV NOTES
 - https://www.apollographql.com/docs/apollo-server/schema/creating-directives/
 - underlying layer seems "unready" webonyx/graphql-php#748 webonyx/graphql-php#299
 - webonyx example custom directive - https://github.com/webonyx/graphql-php/issues/308#issuecomment-431197515
 - check implementation https://github.com/diasfs/graphql-php-resolvers
 - https://spec.graphql.org/June2018/#sec-Type-System.Directives

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
