### PR TITLE
Support class based schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/6.1.0...master)
 --------------
 
+### Added
+- Support for class based schemas [\#706 / jasonvarga](https://github.com/rebing/graphql-laravel/pull/706)
+
 2020-11-30, 6.1.0
 -----------------
 Same as 6.1.0-rc1!

--- a/README.md
+++ b/README.md
@@ -180,6 +180,39 @@ in addition to the global middleware. For example:
 ],
 ```
 
+#### Schema classes
+
+You may alternatively define the configuration of a schema in a class that implements `ConfigConvertible`.
+
+In your config, you can reference the name of the class, rather than an array.
+
+```php
+'schemas' => [
+    'default' => DefaultSchema::class
+]
+```
+
+```php
+namespace App\GraphQL\Schemas;
+
+use Rebing\GraphQL\Support\Contracts\ConfigConvertible;
+
+class DefaultSchema implements ConfigConvertible
+{
+    public function toConfig(): array
+    {
+        return [
+            'query' => [
+                ExampleQuery::class,
+            ],
+            'mutation' => [
+                ExampleMutation::class,
+            ]
+        ]
+    }
+}
+```
+
 ### Creating a query
 
 First you need to create a type. The Eloquent Model is only required, if specifying relations.

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -21,6 +21,7 @@ use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
 use Rebing\GraphQL\Exception\SchemaNotFound;
 use Rebing\GraphQL\Exception\TypeNotFound;
+use Rebing\GraphQL\Support\Contracts\ConfigConvertible;
 use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 use Rebing\GraphQL\Support\PaginationType;
 
@@ -65,6 +66,10 @@ class GraphQL
 
         if ($schema instanceof Schema) {
             return $schema;
+        }
+
+        if (is_string($schema) && ($instance = app()->make($schema)) instanceof ConfigConvertible) {
+            $schema = $instance->toConfig();
         }
 
         $schemaQuery = $schema['query'] ?? [];

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -32,7 +32,7 @@ class GraphQL
     /** @var Container */
     protected $app;
 
-    /** @var array<array|Schema> */
+    /** @var array<array|string|Schema> */
     protected $schemas = [];
 
     /**
@@ -66,10 +66,6 @@ class GraphQL
 
         if ($schema instanceof Schema) {
             return $schema;
-        }
-
-        if (is_string($schema) && ($instance = app()->make($schema)) instanceof ConfigConvertible) {
-            $schema = $instance->toConfig();
         }
 
         $schemaQuery = $schema['query'] ?? [];
@@ -512,6 +508,15 @@ class GraphQL
             throw new SchemaNotFound('Type '.$schemaName.' not found.');
         }
 
-        return is_array($schema) ? $schema : $this->schemas[$schemaName];
+        $schema = is_array($schema) ? $schema : $this->schemas[$schemaName];
+
+        if (! is_string($schema)) {
+            return $schema;
+        }
+
+        /** @var ConfigConvertible $instance */
+        $instance = app()->make($schema);
+
+        return $instance->toConfig();
     }
 }

--- a/src/Support/Contracts/ConfigConvertible.php
+++ b/src/Support/Contracts/ConfigConvertible.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support\Contracts;
+
+interface ConfigConvertible
+{
+    public function toConfig(): array;
+}

--- a/src/Support/Contracts/ConfigConvertible.php
+++ b/src/Support/Contracts/ConfigConvertible.php
@@ -6,5 +6,8 @@ namespace Rebing\GraphQL\Support\Contracts;
 
 interface ConfigConvertible
 {
+    /**
+     * @return array<array>
+     */
     public function toConfig(): array;
 }

--- a/tests/Support/Objects/ExampleSchema.php
+++ b/tests/Support/Objects/ExampleSchema.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Rebing\GraphQL\Support\Contracts\ConfigConvertible;
+
+class ExampleSchema implements ConfigConvertible
+{
+    public function toConfig(): array
+    {
+        return [
+            'query' => [
+                'examplesCustom' => ExamplesQuery::class,
+            ],
+            'mutation' => [
+                'updateExampleCustom' => UpdateExampleMutation::class,
+            ],
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesConfigAliasQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesFilteredQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesMiddlewareQuery;
@@ -71,6 +72,9 @@ class TestCase extends BaseTestCase
                 'updateExampleCustom' => UpdateExampleMutation::class,
             ],
         ]);
+
+        $app['config']->set('graphql.schemas.class_based', ExampleSchema::class);
+        $app['config']->set('graphql.schemas.invalid_class_based', 'ThisClassDoesntExist');
 
         $app['config']->set('graphql.types', [
             'Example' => ExampleType::class,

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -10,6 +10,7 @@ use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Traits\Macroable;
 use Rebing\GraphQL\Error\ValidationError;
 use Rebing\GraphQL\Exception\SchemaNotFound;
@@ -70,6 +71,19 @@ class GraphQLTest extends TestCase
     }
 
     /**
+     * Test schema with name referencing a class.
+     */
+    public function testSchemaWithNameReferencingClass(): void
+    {
+        $schema = GraphQL::schema('class_based');
+
+        $this->assertGraphQLSchema($schema);
+        $this->assertGraphQLSchemaHasQuery($schema, 'examplesCustom');
+        $this->assertGraphQLSchemaHasMutation($schema, 'updateExampleCustom');
+        $this->assertArrayHasKey('Example', $schema->getTypeMap());
+    }
+
+    /**
      * Test schema custom.
      */
     public function testSchemaWithArray(): void
@@ -99,6 +113,16 @@ class GraphQLTest extends TestCase
     {
         $this->expectException(SchemaNotFound::class);
         GraphQL::schema('wrong');
+    }
+
+    /**
+     * Test schema with invalid class name.
+     */
+    public function testSchemaWithInvalidClassName(): void
+    {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target class [ThisClassDoesntExist] does not exist.');
+        GraphQL::schema('invalid_class_based');
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR adds support for defining a class based schema.

Rather than defining the entire schema directly in the config file, like this:

```php
'schemas' => [
    'default' => [
        'query' => [
            QueryOne::class,
            QueryTwo::class
        ]
    ]
]
```

You'll be able to define it by specifying a class name:

```php
'schemas' => [
  'default' => \App\GraphQL\MySchema::class
]
```

This class should implement the new `ConfigConvertible` contract which will convert to an array you'd have previously used in the config file.

```php
use Rebing\GraphQL\Support\Contracts\ConfigConvertible;

class MySchema implements ConfigConvertible
{
    public function toConfig(): array
    {
        return [
            'query' => [
                QueryOne::class,
                QueryTwo::class
            ]
        ];
    }
}
```

The reason this would be useful for us (Statamic, a Laravel CMS package) is because we intend to be able to have an entire schema that users can put into their config. We don't want them to have to manually define the config.

Also, we intend to allow third parties to inject their own query classes into our schema. The schema class above is a bit simplified. Ours might look more like this:

```php
class Schema implements ConfigConvertible
{
    private static $customQueries = [];

    public function toConfig(): array
    {
        return [
            'query' => array_merge([
                NativeQueryOne::class,
                NativeQueryTwo::class
            ], static::$customQueries);
        ];
    }

    public static function addQuery($class)
    {
        static::$customQueries[] = $class;
    }
}
```

I'm not quite sure how you feel about the naming of things here though. I used `ConfigConvertible` and `toConfig()` because I saw a `TypeConvertible` interface with `toType()`.

The only _technically_ breaking change here is that if you already used a string, you'd previously get a GraphQL error like `cannot query field "some_query"` and now you'd get a `BindingResolutionException`. But your app wouldn't have been working in the first place so I don't think it really matters.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
