### PR TITLE
support simple pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/7.0.0...master)
 --------------
 
+### Added
+- Support Laravels simple pagination [\#715 / lamtranb](https://github.com/rebing/graphql-laravel/pull/715)
+
 2021-04-03, 7.0.0
 -----------------
 ## Breaking changes

--- a/README.md
+++ b/README.md
@@ -1564,7 +1564,7 @@ class PostsQuery extends Query
 {
     public function type(): Type
     {
-        return GraphQL::simplePaginate('posts');
+        return Type::nonNull(GraphQL::simplePaginate('posts'));
     }
 
     // ...

--- a/README.md
+++ b/README.md
@@ -1549,7 +1549,7 @@ Query `posts(limit:10,page:1){data{id},total,per_page}` might return
 Note that you need to add in the extra 'data' object when you request paginated resources as the returned data gives you
 the paginated resources in a data object at the same level as the returned pagination metadata.
 
-Simple Pagination will be used, if a query or mutation returns a `SimplePaginationType`.
+[Simple Pagination](https://laravel.com/docs/pagination#simple-pagination) will be used, if a query or mutation returns a `SimplePaginationType`.
 
 ```php
 namespace App\GraphQL\Queries;

--- a/README.md
+++ b/README.md
@@ -1549,6 +1549,37 @@ Query `posts(limit:10,page:1){data{id},total,per_page}` might return
 Note that you need to add in the extra 'data' object when you request paginated resources as the returned data gives you
 the paginated resources in a data object at the same level as the returned pagination metadata.
 
+Simple Pagination will be used, if a query or mutation returns a `SimplePaginationType`.
+
+```php
+namespace App\GraphQL\Queries;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+class PostsQuery extends Query
+{
+    public function type(): Type
+    {
+        return GraphQL::simplePaginate('posts');
+    }
+
+    // ...
+
+    public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
+    {
+        $fields = $getSelectFields();
+
+        return Post::with($fields->getRelations())
+            ->select($fields->getSelect())
+            ->simplePaginate($args['limit'], ['*'], 'page', $args['page']);
+    }
+}
+```
+
 ### Batching
 
 You can send multiple queries (or mutations) at once by grouping them together. Therefore, instead of creating two HTTP requests:

--- a/config/config.php
+++ b/config/config.php
@@ -170,6 +170,12 @@ return [
     'pagination_type' => \Rebing\GraphQL\Support\PaginationType::class,
 
     /*
+     * You can define your own simple pagination type.
+     * Reference \Rebing\GraphQL\Support\SimplePaginationType::class
+     */
+    'simple_pagination_type' => \Rebing\GraphQL\Support\SimplePaginationType::class,
+
+    /*
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */
     'graphiql' => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -421,6 +421,11 @@ parameters:
 			path: src/Support/SelectFields.php
 
 		-
+			message: "#^Anonymous function never returns null so it can be removed from the return typehint\\.$#"
+			count: 2
+			path: src/Support/SimplePaginationType.php
+
+		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Support\\\\Type\\:\\:\\$attributes has no typehint specified\\.$#"
 			count: 1
 			path: src/Support/Type.php

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -23,6 +23,7 @@ use Rebing\GraphQL\Exception\SchemaNotFound;
 use Rebing\GraphQL\Exception\TypeNotFound;
 use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 use Rebing\GraphQL\Support\PaginationType;
+use Rebing\GraphQL\Support\SimplePaginationType;
 
 class GraphQL
 {
@@ -380,6 +381,18 @@ class GraphQL
 
         if (! isset($this->typesInstances[$name])) {
             $paginationType = config('graphql.pagination_type', PaginationType::class);
+            $this->wrapType($typeName, $name, $paginationType);
+        }
+
+        return $this->typesInstances[$name];
+    }
+
+    public function simplePaginate(string $typeName, string $customName = null): Type
+    {
+        $name = $customName ?: $typeName.'SimplePagination';
+
+        if (! isset($this->typesInstances[$name])) {
+            $paginationType = config('graphql.simple_pagination_type', SimplePaginationType::class);
             $this->wrapType($typeName, $name, $paginationType);
         }
 

--- a/src/Support/Facades/GraphQL.php
+++ b/src/Support/Facades/GraphQL.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static ExecutionResult queryAndReturnResult(string $query, ?array $params = [], array $opts = [])
  * @method static Type type(string $name, bool $fresh = false)
  * @method static Type paginate(string $typeName, string $customName = null)
+ * @method static Type simplePaginate(string $typeName, string $customName = null)
  * @method static array<string,object|string> getTypes()
  * @method static Schema schema(Schema|array|string $schema = null)
  * @method static array getSchemas()

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -177,7 +177,8 @@ class SelectFields
                 $queryable = static::isQueryable($fieldObject->config);
 
                 // Pagination
-                if (is_a($parentType, config('graphql.pagination_type', PaginationType::class))) {
+                if (is_a($parentType, config('graphql.pagination_type', PaginationType::class))
+                    || is_a($parentType, config('graphql.simple_pagination_type', SimplePaginationType::class))) {
                     /* @var GraphqlType $fieldType */
                     $fieldType = $fieldObject->config['type'];
                     static::handleFields(

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Support;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+
+class SimplePaginationType extends ObjectType
+{
+    public function __construct(string $typeName, string $customName = null)
+    {
+        $name = $customName ?: $typeName.'SimplePagination';
+
+        $config = [
+            'name'   => $name,
+            'fields' => $this->getPaginationFields($typeName),
+        ];
+
+        $underlyingType = GraphQL::type($typeName);
+        if (isset($underlyingType->config['model'])) {
+            $config['model'] = $underlyingType->config['model'];
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
+     * @param string $typeName
+     *
+     * @return array<string, array<string,mixed>>
+     */
+    protected function getPaginationFields(string $typeName): array
+    {
+        return [
+            'data'           => [
+                'type'        => GraphQLType::listOf(GraphQL::type($typeName)),
+                'description' => 'List of items on the current page',
+                'resolve'     => function (Paginator $data): Collection {
+                    return $data->getCollection();
+                },
+            ],
+            'per_page'       => [
+                'type'        => GraphQLType::nonNull(GraphQLType::int()),
+                'description' => 'Number of items returned per page',
+                'resolve'     => function (Paginator $data): int {
+                    return $data->perPage();
+                },
+                'selectable'  => false,
+            ],
+            'current_page'   => [
+                'type'        => GraphQLType::nonNull(GraphQLType::int()),
+                'description' => 'Current page of the cursor',
+                'resolve'     => function (Paginator $data): int {
+                    return $data->currentPage();
+                },
+                'selectable'  => false,
+            ],
+            'from'           => [
+                'type'        => GraphQLType::int(),
+                'description' => 'Number of the first item returned',
+                'resolve'     => function (Paginator $data): int {
+                    return $data->firstItem();
+                },
+                'selectable'  => false,
+            ],
+            'to'             => [
+                'type'        => GraphQLType::int(),
+                'description' => 'Number of the last item returned',
+                'resolve'     => function (Paginator $data): int {
+                    return $data->lastItem();
+                },
+                'selectable'  => false,
+            ],
+            'has_more_pages' => [
+                'type'        => GraphQLType::nonNull(GraphQLType::boolean()),
+                'description' => 'Determines if cursor has more pages after the current page',
+                'resolve'     => function (Paginator $data): bool {
+                    return $data->hasMorePages();
+                },
+                'selectable'  => false,
+            ],
+        ];
+    }
+}

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -38,7 +38,7 @@ class SimplePaginationType extends ObjectType
     {
         return [
             'data'           => [
-                'type'        => GraphQLType::nonNull(GraphQLType::listOf(GraphQL::type($typeName))),
+                'type'        => GraphQLType::listOf(GraphQL::type($typeName)),
                 'description' => 'List of items on the current page',
                 'resolve'     => function (Paginator $data): Collection {
                     return $data->getCollection();

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -71,7 +71,7 @@ class SimplePaginationType extends ObjectType
             'to'             => [
                 'type'        => GraphQLType::int(),
                 'description' => 'Number of the last item returned',
-                'resolve'     => function (Paginator $data): int {
+                'resolve'     => function (Paginator $data): ?int {
                     return $data->lastItem();
                 },
                 'selectable'  => false,

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -38,7 +38,7 @@ class SimplePaginationType extends ObjectType
     {
         return [
             'data'           => [
-                'type'        => Type::nonNull(GraphQLType::listOf(GraphQL::type($typeName))),
+                'type'        => GraphQLType::listOf(GraphQL::type($typeName)),
                 'description' => 'List of items on the current page',
                 'resolve'     => function (Paginator $data): Collection {
                     return $data->getCollection();

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -38,7 +38,7 @@ class SimplePaginationType extends ObjectType
     {
         return [
             'data'           => [
-                'type'        => GraphQLType::listOf(GraphQL::type($typeName)),
+                'type'        => Type::nonNull(GraphQLType::listOf(GraphQL::type($typeName))),
                 'description' => 'List of items on the current page',
                 'resolve'     => function (Paginator $data): Collection {
                     return $data->getCollection();

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -38,7 +38,7 @@ class SimplePaginationType extends ObjectType
     {
         return [
             'data'           => [
-                'type'        => GraphQLType::listOf(GraphQL::type($typeName)),
+                'type'        => GraphQLType::nonNull(GraphQLType::listOf(GraphQL::type($typeName))),
                 'description' => 'List of items on the current page',
                 'resolve'     => function (Paginator $data): Collection {
                     return $data->getCollection();

--- a/src/Support/SimplePaginationType.php
+++ b/src/Support/SimplePaginationType.php
@@ -63,7 +63,7 @@ class SimplePaginationType extends ObjectType
             'from'           => [
                 'type'        => GraphQLType::int(),
                 'description' => 'Number of the first item returned',
-                'resolve'     => function (Paginator $data): int {
+                'resolve'     => function (Paginator $data): ?int {
                     return $data->firstItem();
                 },
                 'selectable'  => false,

--- a/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeySimplePaginationQuery.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeySimplePaginationQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\PrimaryKeyTests;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Pagination\Paginator;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class PrimaryKeySimplePaginationQuery extends Query
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $attributes = [
+        'name' => 'primaryKeySimplePaginationQuery',
+    ];
+
+    /**
+     * @return Type
+     */
+    public function type(): Type
+    {
+        return GraphQL::simplePaginate('Post');
+    }
+
+    /**
+     * @param mixed       $root
+     * @param mixed       $args
+     * @param mixed       $ctx
+     * @param ResolveInfo $info
+     * @param Closure     $getSelectFields
+     *
+     * @return Paginator
+     */
+    public function resolve($root, $args, $ctx, ResolveInfo $info, Closure $getSelectFields)
+    {
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields();
+
+        return Post
+            ::with($selectFields->getRelations())
+            ->select($selectFields->getSelect())
+            ->simplePaginate(1);
+    }
+}

--- a/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
@@ -148,6 +148,51 @@ SQL
         $this->assertEquals($expectedResult, $result);
     }
 
+    public function testSimplePaginationReturnEmptyList(): void
+    {
+        $query = <<<'GRAQPHQL'
+{
+  primaryKeySimplePaginationQuery {
+    current_page
+    data {
+      title
+      comments {
+        title
+      }
+    }
+    from
+    has_more_pages
+    per_page
+    to
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($query);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "posts"."title", "posts"."id" from "posts" limit 2 offset 0;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'primaryKeySimplePaginationQuery' => [
+                    'current_page'   => 1,
+                    'data'           => [],
+                    'from'           => null,
+                    'has_more_pages' => false,
+                    'per_page'       => 1,
+                    'to'             => null,
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\PrimaryKeyTests;
+
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\Support\Traits\SqlAssertionTrait;
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class SimplePaginationTest extends TestCaseDatabase
+{
+    use SqlAssertionTrait;
+
+    public function testSimplePagination(): void
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create([
+            'title' => 'post 1',
+        ]);
+        factory(Comment::class)->create([
+            'title'   => 'post 1 comment 1',
+            'post_id' => $post->id,
+        ]);
+        /** @var Post $post */
+        $post = factory(Post::class)->create([
+            'title' => 'post 2',
+        ]);
+        factory(Comment::class)->create([
+            'title'   => 'post 2 comment 1',
+            'post_id' => $post->id,
+        ]);
+
+        $query = <<<'GRAQPHQL'
+{
+  primaryKeySimplePaginationQuery {
+    current_page
+    data {
+      title
+      comments {
+        title
+      }
+    }
+    from
+    has_more_pages
+    per_page
+    to
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($query);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "posts"."title", "posts"."id" from "posts" limit 2 offset 0;
+select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?, ?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'primaryKeySimplePaginationQuery' => [
+                    'current_page'   => 1,
+                    'data'           => [
+                        [
+                            'title'    => 'post 1',
+                            'comments' => [
+                                [
+                                    'title' => 'post 1 comment 1',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'from'           => 1,
+                    'has_more_pages' => true,
+                    'per_page'       => 1,
+                    'to'             => 1,
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testSimplePaginationHasNoMorePage(): void
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create([
+            'title' => 'post 1',
+        ]);
+        factory(Comment::class)->create([
+            'title'   => 'post 1 comment 1',
+            'post_id' => $post->id,
+        ]);
+        $query = <<<'GRAQPHQL'
+{
+  primaryKeySimplePaginationQuery {
+    current_page
+    data {
+      title
+      comments {
+        title
+      }
+    }
+    from
+    has_more_pages
+    per_page
+    to
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $result = $this->graphql($query);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "posts"."title", "posts"."id" from "posts" limit 2 offset 0;
+select "comments"."title", "comments"."post_id", "comments"."id" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'primaryKeySimplePaginationQuery' => [
+                    'current_page'   => 1,
+                    'data'           => [
+                        [
+                            'title'    => 'post 1',
+                            'comments' => [
+                                [
+                                    'title' => 'post 1 comment 1',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'from'           => 1,
+                    'has_more_pages' => false,
+                    'per_page'       => 1,
+                    'to'             => 1,
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                PrimaryKeyQuery::class,
+                PrimaryKeySimplePaginationQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.types', [
+            CommentType::class,
+            PostType::class,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
---
Hello, as #709 questioned, I think we should support simplePagination.
As Laravel doc mentioned here: https://laravel.com/docs/8.x/pagination#simple-pagination
> However, if you do not plan to show the total number of pages in your application's UI then the record count query is unnecessary.

If we have a large table then this will be a problem.

Type of change:
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

Checklist:
- [x] Existing tests have been adapted and new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
