### PR TITLE
[CHORES] Attend to phpstan, tests and other things currently failing

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,6 @@ jobs:
 
       # Remove unnecessary dependencies not needed in this context
       - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
-      - run: composer remove --dev matt-allan/laravel-code-style --no-update
 
       - name: Get composer cache directory
         id: composercache

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,7 +5,15 @@ on:
   push:
   schedule:
     # Run Monday morning at 3 o'clock
-    - cron: 0 3 * * 0
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │ ┌───────────── month (1 - 12)
+    #       │ │ │ │ ┌───────────── day of the week (0 - 6)
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    - cron: 0 3 * * 1
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,15 @@ on:
   push:
   schedule:
     # Run Monday morning at 3 o'clock
-    - cron: 0 3 * * 0
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │ ┌───────────── month (1 - 12)
+    #       │ │ │ │ ┌───────────── day of the week (0 - 6)
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    - cron: 0 3 * * 1
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,7 +35,6 @@ jobs:
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it
-      - run: composer remove --dev matt-allan/laravel-code-style --no-update
       - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
       - run: composer require illuminate/contracts:^8.0 --no-update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,15 @@ on:
   push:
   schedule:
     # Run Monday morning at 3 o'clock
-    - cron: 0 3 * * 0
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │ ┌───────────── month (1 - 12)
+    #       │ │ │ │ ┌───────────── day of the week (0 - 6)
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    - cron: 0 3 * * 1
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   integration:
     strategy:
+      fail-fast: false
       matrix:
         php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,6 @@ jobs:
           extensions: pdo_sqlite
 
       # Due to version incompatibility with older Laravels we test, we remove it
-      - run: composer remove --dev matt-allan/laravel-code-style --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
       - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
       - run: composer remove --dev laravel/legacy-factories --no-update

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,20 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
+use PhpCsFixer\Config;
+
 require __DIR__ . '/vendor/autoload.php';
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
-return (new MattAllan\LaravelCodeStyle\Config())
+return (new Config())
         ->setFinder($finder)
         ->setRules([
-            '@Laravel' => true,
-            '@Laravel:risky' => true,
-            // Project specific
-            'array_indentation' => true,
-            'declare_strict_types' => true,
-            'is_null' => true,
-            'modernize_types_casting' => true,
-            'method_argument_space' => [
-                'on_multiline' => 'ensure_fully_multiline',
-            ],
-            'psr4' => false, // Doesn't play well with migrations
+            '@PSR12' => true,
         ])
         ->setRiskyAllowed(true);

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "nunomaduro/larastan": "0.6.10",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "matt-allan/laravel-code-style": "0.5.1",
         "ext-pdo_sqlite": "*",
         "laravel/legacy-factories": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "require-dev": {
         "orchestra/testbench": "4.0.*|5.0.*|^6.0",
         "phpunit/phpunit": "~7.0|~8.0|^9",
-        "nunomaduro/larastan": "0.6.10",
+        "nunomaduro/larastan": "0.7.0",
         "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "ext-pdo_sqlite": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1801,51 +1801,6 @@ parameters:
 			path: tests/Support/Queries/ReturnScalarQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\EnumMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/EnumMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InputMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/InputMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InterfaceMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/InterfaceMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MiddlewareMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/MiddlewareMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MutationMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/MutationMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\QueryMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/QueryMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\ScalarMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/ScalarMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\TypeMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/TypeMakeCommandTest.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\UnionMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/Console/UnionMakeCommandTest.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: tests/Support/Types/MyCustomScalarString.php
@@ -1989,6 +1944,51 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
 			count: 1
 			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\EnumMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/EnumMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InputMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/InputMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InterfaceMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/InterfaceMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MiddlewareMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/MiddlewareMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MutationMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/MutationMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\QueryMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/QueryMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\ScalarMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/ScalarMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\TypeMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/TypeMakeCommandTest.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\UnionMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/Console/UnionMakeCommandTest.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:\\$attributes has no typehint specified\\.$#"
@@ -2169,6 +2169,11 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\ValidationAuthorizationTests\\\\ValidationAndAuthorizationMutation\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Unit/ValidationOfFieldArguments/ValidationOfFieldArgumentsTest.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:\\$attributes has no typehint specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1801,19 +1801,9 @@ parameters:
 			path: tests/Support/Queries/ReturnScalarQuery.php
 
 		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/EnumMakeCommandTest.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\EnumMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/EnumMakeCommandTest.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/InputMakeCommandTest.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InputMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -1821,19 +1811,9 @@ parameters:
 			path: tests/Unit/Console/InputMakeCommandTest.php
 
 		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/InterfaceMakeCommandTest.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\InterfaceMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/InterfaceMakeCommandTest.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/MiddlewareMakeCommandTest.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MiddlewareMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -1841,19 +1821,9 @@ parameters:
 			path: tests/Unit/Console/MiddlewareMakeCommandTest.php
 
 		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/MutationMakeCommandTest.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\MutationMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/MutationMakeCommandTest.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/QueryMakeCommandTest.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\QueryMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -1861,29 +1831,14 @@ parameters:
 			path: tests/Unit/Console/QueryMakeCommandTest.php
 
 		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/ScalarMakeCommandTest.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\ScalarMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/ScalarMakeCommandTest.php
 
 		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/TypeMakeCommandTest.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\TypeMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Unit/Console/TypeMakeCommandTest.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/UnionMakeCommandTest.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\Console\\\\UnionMakeCommandTest\\:\\:dataForMakeCommand\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -2034,16 +1989,6 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasAguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
 			count: 1
 			path: tests/Unit/AliasAguments/Stubs/UpdateExampleMutation.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 2
-			path: tests/Unit/Console/FieldMakeCommandTest.php
-
-		-
-			message: "#^Unable to resolve the template type CallbackInput in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:callback\\(\\)$#"
-			count: 4
-			path: tests/Unit/Console/PublishCommandTest.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:\\$attributes has no typehint specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,6 +281,11 @@ parameters:
 			path: src/Support/ResolveInfoFieldsAndArguments.php
 
 		-
+			message: "#^Property GraphQL\\\\Language\\\\AST\\\\FieldNode\\:\\:\\$arguments \\(GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\ArgumentNode\\>\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: src/Support/ResolveInfoFieldsAndArguments.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Support/ResolveInfoFieldsAndArguments.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1476,11 +1476,6 @@ parameters:
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) return type has no value type specified in iterable type Illuminate\\\\Pagination\\\\LengthAwarePaginator\\.$#"
-			count: 1
-			path: tests/Support/Objects/ExamplesPaginationQuery.php
-
-		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:\\$attributes has no typehint specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesQuery.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,7 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src/
         - %currentWorkingDirectory%/tests/
-    excludes_analyse:
+    excludePaths:
         - %currentWorkingDirectory%/tests/Support/database/
     ignoreErrors:
         - '/Call to an undefined method Rebing\\GraphQL\\Tests\\TestCaseDatabase::setupSqlAssertionTrait\(\)/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,9 @@ parameters:
         - tests/
     excludePaths:
         - tests/Support/database/
+    inferPrivatePropertyTypeFromConstructor: true
+    checkUninitializedProperties: true
+    checkModelProperties: true
     ignoreErrors:
         - '/Call to an undefined method Rebing\\GraphQL\\Tests\\TestCaseDatabase::setupSqlAssertionTrait\(\)/'
         - '/Method Rebing\\GraphQL\\GraphQL::routeNameTransformer\(\) should return string but returns string\|null/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - ./vendor/nunomaduro/larastan/extension.neon
     - ./phpstan-baseline.neon
+    - ./vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
     level: max
     paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,10 +4,10 @@ includes:
 parameters:
     level: max
     paths:
-        - %currentWorkingDirectory%/src/
-        - %currentWorkingDirectory%/tests/
+        - src/
+        - tests/
     excludePaths:
-        - %currentWorkingDirectory%/tests/Support/database/
+        - tests/Support/database/
     ignoreErrors:
         - '/Call to an undefined method Rebing\\GraphQL\\Tests\\TestCaseDatabase::setupSqlAssertionTrait\(\)/'
         - '/Method Rebing\\GraphQL\\GraphQL::routeNameTransformer\(\) should return string but returns string\|null/'

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -148,6 +148,7 @@ abstract class Field
                     $result = $resolver($root, ...array_slice($arguments, 1));
 
                     foreach ($middleware as $name) {
+                        /** @var Middleware $instance */
                         $instance = app()->make($name);
 
                         if (method_exists($instance, 'terminate')) {

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -358,7 +358,7 @@ class SelectFields
 
     /**
      * @param  array  $select
-     * @param  mixed  $relation
+     * @param  Relation  $relation
      * @param  string|null  $parentTable
      * @param  array  $field
      */

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -30,7 +30,7 @@ class SelectFields
     /** @var array */
     protected $relations = [];
 
-    const ALWAYS_RELATION_KEY = 'ALWAYS_RELATION_KEY';
+    public const ALWAYS_RELATION_KEY = 'ALWAYS_RELATION_KEY';
 
     /**
      * @param  GraphqlType  $parentType

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -12,7 +12,9 @@ use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\WrappingType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -370,6 +372,7 @@ class SelectFields
         } elseif (method_exists($relation, 'getQualifiedForeignPivotKeyName')) {
             $foreignKey = $relation->getQualifiedForeignPivotKeyName();
         } else {
+            /** @var BelongsTo|HasManyThrough|HasOneOrMany $relation */
             $foreignKey = $relation->getQualifiedForeignKeyName();
         }
         $foreignKey = $parentTable ? ($parentTable.'.'.preg_replace(

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -50,7 +50,10 @@ class SelectFields
             'fields' => $fieldsAndArguments,
         ];
 
-        [$this->select, $this->relations] = self::getSelectableFieldsAndRelations($queryArgs, $requestedFields, $parentType, null, true, $ctx);
+        /** @var array<int,array> $result */
+        $result = self::getSelectableFieldsAndRelations($queryArgs, $requestedFields, $parentType, null, true, $ctx);
+
+        [$this->select, $this->relations] = $result;
     }
 
     /**

--- a/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
+++ b/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
@@ -108,12 +108,12 @@ SQL
                 'post_id' => $post->id,
             ]);
 
-        $postLike = new Like;
+        $postLike = new Like();
         $postLike->likable()->associate($post);
         $postLike->user()->associate($user);
         $postLike->save();
 
-        $commentLike = new Like;
+        $commentLike = new Like();
         $commentLike->likable()->associate($comment);
         $commentLike->user()->associate($user);
         $commentLike->save();

--- a/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
+++ b/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
@@ -142,23 +142,13 @@ GRAPHQL;
 
         $result = $this->graphql($graphql);
 
-        if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(
-                <<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
 select * from "posts" where "posts"."id" in (?);
 SQL
-            );
-        } else {
-            $this->assertSqlQueries(
-                <<<'SQL'
-select "users"."id" from "users";
-select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
-select * from "posts" where "posts"."id" in (?);
-SQL
-            );
-        }
+        );
 
         $expectedResult = [
             'data' => [
@@ -221,23 +211,13 @@ GRAPHQL;
 
         $result = $this->graphql($graphql);
 
-        if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(
-                <<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
 select * from "posts" where "posts"."id" in (?);
 SQL
-            );
-        } else {
-            $this->assertSqlQueries(
-                <<<'SQL'
-select "users"."id" from "users";
-select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?);
-select * from "posts" where "posts"."id" in (?);
-SQL
-            );
-        }
+        );
 
         $expectedResult = [
             'data' => [
@@ -420,25 +400,14 @@ GRAPHQL;
 
         $result = $this->graphql($graphql);
 
-        if (Application::VERSION < '5.6') {
-            $this->assertSqlQueries(
-                <<<'SQL'
+        $this->assertSqlQueries(
+            <<<'SQL'
 select "users"."id" from "users";
 select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
 select * from "comments" where "comments"."id" in (?);
 select "likes"."id", "likes"."likable_id", "likes"."likable_type" from "likes" where "likes"."likable_id" in (?) and "likes"."likable_type" = ? and 1=1;
 SQL
-            );
-        } else {
-            $this->assertSqlQueries(
-                <<<'SQL'
-select "users"."id" from "users";
-select "likes"."likable_id", "likes"."likable_type", "likes"."user_id", "likes"."id" from "likes" where "likes"."user_id" in (?, ?);
-select * from "comments" where "comments"."id" in (?);
-select "likes"."id", "likes"."likable_id", "likes"."likable_type" from "likes" where "likes"."likable_id" in (?) and "likes"."likable_type" = ? and 1=1;
-SQL
-            );
-        }
+        );
 
         $expectedResult = [
             'data' => [

--- a/tests/Support/Traits/MakeCommandAssertionTrait.php
+++ b/tests/Support/Traits/MakeCommandAssertionTrait.php
@@ -34,16 +34,16 @@ trait MakeCommandAssertionTrait
             ->method('put')
             ->with(
                 $this->callback(function (string $path) use ($expectedFilename): bool {
-                    $this->assertRegExp("|laravel[/\\\\]app/$expectedFilename|", $path);
+                    $this->assertMatchesRegularExpression("|laravel[/\\\\]app/$expectedFilename|", $path);
 
                     return true;
                 }),
                 $this->callback(function (string $contents) use ($expectedClassDefinition, $expectedGraphqlName, $expectedNamespace): bool {
-                    $this->assertRegExp("/namespace $expectedNamespace;/", $contents);
-                    $this->assertRegExp("/class $expectedClassDefinition/", $contents);
+                    $this->assertMatchesRegularExpression("/namespace $expectedNamespace;/", $contents);
+                    $this->assertMatchesRegularExpression("/class $expectedClassDefinition/", $contents);
 
                     if ($expectedGraphqlName) {
-                        $this->assertRegExp("/$expectedGraphqlName/", $contents);
+                        $this->assertMatchesRegularExpression("/$expectedGraphqlName/", $contents);
                     }
 
                     return true;
@@ -58,6 +58,6 @@ trait MakeCommandAssertionTrait
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertRegExp("/$graphqlKind created successfully/", $tester->getDisplay());
+        $this->assertMatchesRegularExpression("/$graphqlKind created successfully/", $tester->getDisplay());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
@@ -249,5 +250,13 @@ class TestCase extends BaseTestCase
                 return $line;
             }, $trace, array_keys($trace))
         );
+    }
+
+    /**
+     * Remove this method once we're PHPUnit 9+ only.
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        static::assertThat($string, new RegularExpression($pattern), $message);
     }
 }

--- a/tests/Unit/Console/FieldMakeCommandTest.php
+++ b/tests/Unit/Console/FieldMakeCommandTest.php
@@ -25,13 +25,13 @@ class FieldMakeCommandTest extends TestCase
             ->method('put')
             ->with(
                 $this->callback(function (string $path): bool {
-                    $this->assertRegExp('|laravel[/\\\\]app/GraphQL/Fields/ExampleField.php|', $path);
+                    $this->assertMatchesRegularExpression('|laravel[/\\\\]app/GraphQL/Fields/ExampleField.php|', $path);
 
                     return true;
                 }),
                 $this->callback(function (string $contents): bool {
-                    $this->assertRegExp('/class ExampleField extends Field/', $contents);
-                    $this->assertRegExp("/'name' => 'ExampleField',/", $contents);
+                    $this->assertMatchesRegularExpression('/class ExampleField extends Field/', $contents);
+                    $this->assertMatchesRegularExpression("/'name' => 'ExampleField',/", $contents);
 
                     return true;
                 })
@@ -45,6 +45,6 @@ class FieldMakeCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertRegExp('/Field created successfully/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/Field created successfully/', $tester->getDisplay());
     }
 }

--- a/tests/Unit/Console/PublishCommandTest.php
+++ b/tests/Unit/Console/PublishCommandTest.php
@@ -25,12 +25,12 @@ class PublishCommandTest extends TestCase
             ->method('copy')
             ->with(
                 $this->callback(function (string $from): bool {
-                    $this->assertRegExp('|/config/config.php|', $from, '1st call to copy, $from');
+                    $this->assertMatchesRegularExpression('|/config/config.php|', $from, '1st call to copy, $from');
 
                     return true;
                 }),
                 $this->callback(function (string $to): bool {
-                    $this->assertRegExp('|laravel[/\\\\]config/graphql.php|', $to, '1st call to copy, $to');
+                    $this->assertMatchesRegularExpression('|laravel[/\\\\]config/graphql.php|', $to, '1st call to copy, $to');
 
                     return true;
                 })
@@ -40,12 +40,12 @@ class PublishCommandTest extends TestCase
             ->method('copy')
             ->with(
                 $this->callback(function (string $from): bool {
-                    $this->assertRegExp('|/resources/views/graphiql.php|', $from, '2nd call to copy, $from');
+                    $this->assertMatchesRegularExpression('|/resources/views/graphiql.php|', $from, '2nd call to copy, $from');
 
                     return true;
                 }),
                 $this->callback(function (string $to): bool {
-                    $this->assertRegExp(
+                    $this->assertMatchesRegularExpression(
                         '|laravel[/\\\\]resources/views/vendor/graphql/graphiql.php|',
                         $to,
                         '2nd call to copy, $to'
@@ -61,8 +61,8 @@ class PublishCommandTest extends TestCase
         $tester = $this->runCommand($command);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertRegExp('|Copied File.*[/\\\\]config[/\\\\]config.php.* To|', $tester->getDisplay());
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression('|Copied File.*[/\\\\]config[/\\\\]config.php.* To|', $tester->getDisplay());
+        $this->assertMatchesRegularExpression(
             '|Copied File.*[/\\\\]resources[/\\\\]views[/\\\\]graphiql.php.* To|',
             $tester->getDisplay()
         );

--- a/tests/Unit/Console/PublishCommandTest.php
+++ b/tests/Unit/Console/PublishCommandTest.php
@@ -21,38 +21,45 @@ class PublishCommandTest extends TestCase
             ])
             ->getMock();
         $filesystemMock
-            ->expects($this->at(2))
+            ->expects($this->exactly(2))
             ->method('copy')
-            ->with(
-                $this->callback(function (string $from): bool {
-                    $this->assertMatchesRegularExpression('|/config/config.php|', $from, '1st call to copy, $from');
+            ->withConsecutive(
+                [
+                    $this->callback(function (string $from): bool {
+                        $this->assertMatchesRegularExpression('|/config/config.php|', $from, '1st call to copy, $from');
 
-                    return true;
-                }),
-                $this->callback(function (string $to): bool {
-                    $this->assertMatchesRegularExpression('|laravel[/\\\\]config/graphql.php|', $to, '1st call to copy, $to');
+                        return true;
+                    }),
+                    $this->callback(function (string $to): bool {
+                        $this->assertMatchesRegularExpression(
+                            '|laravel[/\\\\]config/graphql.php|',
+                            $to,
+                            '1st call to copy, $to'
+                        );
 
-                    return true;
-                })
-            );
-        $filesystemMock
-            ->expects($this->at(5))
-            ->method('copy')
-            ->with(
-                $this->callback(function (string $from): bool {
-                    $this->assertMatchesRegularExpression('|/resources/views/graphiql.php|', $from, '2nd call to copy, $from');
+                        return true;
+                    }),
+                ],
+                [
+                    $this->callback(function (string $from): bool {
+                        $this->assertMatchesRegularExpression(
+                            '|/resources/views/graphiql.php|',
+                            $from,
+                            '2nd call to copy, $from'
+                        );
 
-                    return true;
-                }),
-                $this->callback(function (string $to): bool {
-                    $this->assertMatchesRegularExpression(
-                        '|laravel[/\\\\]resources/views/vendor/graphql/graphiql.php|',
-                        $to,
-                        '2nd call to copy, $to'
-                    );
+                        return true;
+                    }),
+                    $this->callback(function (string $to): bool {
+                        $this->assertMatchesRegularExpression(
+                            '|laravel[/\\\\]resources/views/vendor/graphql/graphiql.php|',
+                            $to,
+                            '2nd call to copy, $to'
+                        );
 
-                    return true;
-                })
+                        return true;
+                    }),
+                ]
             );
         $this->instance(Filesystem::class, $filesystemMock);
 

--- a/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
+++ b/tests/Unit/EngineErrorInResolverTests/EngineErrorInResolverTest.php
@@ -18,7 +18,7 @@ class EngineErrorInResolverTest extends TestCase
         ]);
 
         // Using a regex here because in some cases the message gets prefixed with "Type error:"
-        $this->assertRegExp('/Simulating a TypeError/', $result['errors'][0]['debugMessage']);
+        $this->assertMatchesRegularExpression('/Simulating a TypeError/', $result['errors'][0]['debugMessage']);
     }
 
     protected function resolveApplicationExceptionHandler($app)
@@ -31,7 +31,7 @@ class EngineErrorInResolverTest extends TestCase
             ->with(Mockery::on(
                 function (Throwable $error) {
                     // Using a regex here because in some cases the message gets prefixed with "Type error:"
-                    $this->assertRegExp('/Simulating a TypeError/', $error->getMessage());
+                    $this->assertMatchesRegularExpression('/Simulating a TypeError/', $error->getMessage());
 
                     return true;
                 }

--- a/tests/Unit/InstantiableTypesTest/UserType.php
+++ b/tests/Unit/InstantiableTypesTest/UserType.php
@@ -14,13 +14,13 @@ class UserType extends GraphQLType
         'description' => 'User type',
     ];
 
-    public function fields() : array
+    public function fields(): array
     {
         return [
             'id' => [
                 'type' => Type::id(),
             ],
-            'dateOfBirth' => new FormattableDate,
+            'dateOfBirth' => new FormattableDate(),
             'createdAt' => new FormattableDate([
                 'alias' => 'created_at',
             ]),

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -75,6 +75,6 @@ class MiddlewareTest extends TestCase
         ]);
 
         $this->assertObjectHasAttribute('errors', $result);
-        $this->assertRegExp('/^Undefined .* 6$/', $result->errors[0]->getMessage());
+        $this->assertMatchesRegularExpression('/^Undefined .* 6$/', $result->errors[0]->getMessage());
     }
 }

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -354,7 +354,7 @@ class MutationTest extends FieldTest
     {
         $this->expectException(ValidationError::class);
 
-        $field = new UpdateExampleMutationForRuleTesting;
+        $field = new UpdateExampleMutationForRuleTesting();
         $attributes = $field->getAttributes();
 
         $attributes['resolve'](null, [

--- a/tests/Unit/WithTypeTests/PostType.php
+++ b/tests/Unit/WithTypeTests/PostType.php
@@ -14,7 +14,7 @@ class PostType extends GraphQLType
         'description' => 'Post type',
     ];
 
-    public function fields() : array
+    public function fields(): array
     {
         return [
             'post_id' => [

--- a/tests/Unit/WithTypeTests/SimpleMessageType.php
+++ b/tests/Unit/WithTypeTests/SimpleMessageType.php
@@ -14,7 +14,7 @@ class SimpleMessageType extends GraphQLType
         'description' => 'A type of a simple message',
     ];
 
-    public function fields() : array
+    public function fields(): array
     {
         return [
             'message' => [


### PR DESCRIPTION
## Summary
- Fix newly reported phpstan issues, adapt baseline
- tests related
  - Removed outdated application version checks in tests
  - add a custom `assertMatchesRegularExpression` which provides it for our older PHPUnit versions and gets us rid of the deprecation warning for now
  - Replace deprecated `at()` matcher using `withConsecutive`
  - workaround change in orchestra/testbench-core which changes validation messages (due to a change in Laraval)
    => see also https://github.com/orchestral/testbench-core/commit/6c9c77b2e978890cb6a2712251ddab5eb1b79049
- Github Actions related
  - disable fail-fast: our matrix is so varied, it helps to run them all always
  - fix scheduled tests being run on Monday (and not Sunday)
- Code style related:
  - Get rid of matt-allan/laravel-code-style and pure php-cs-fixer with `@PSR12`
    This package always created subtle dependencies constraints on _our_ Laravel dependencies because it itself does depend on illuminate/support.
    Also: the Laravel code style is not formalize specified (except their use of StyleCI), there's no reason to stick to it anyway -> we'll just go with PSR-12 and might add more rules later if we feel like it
- phpstan related
  - Bump nunomaduro/larastan to 0.7.0
  - Refine some use and add new checks

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
