### PR TITLE
Fix class based schemas within routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/6.3.0...master)
 --------------
 
+### Fixed
+- Middleware and methods can be used in class based schemas. [\#724 / jasonvarga](https://github.com/rebing/graphql-laravel/pull/724)
+
 2021-03-12, 6.3.0
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ CHANGELOG
 --------------
 
 ### Fixed
-- Middleware and methods can be used in class based schemas. [\#724 / jasonvarga](https://github.com/rebing/graphql-laravel/pull/724)
+- Middleware and methods can be used in class based schemas. [\#724 / jasonvarga](https://github.com/rebing/graphql-laravel/pull/724)\
+  This is a follow-up fix for [Support for class based schemas](https://github.com/rebing/graphql-laravel/pull/706)
 
 2021-03-31, 6.4.0
 -----------------

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -58,6 +58,7 @@ parameters:
         - '/Parameter #1 \$name of method Rebing\\GraphQL\\Support\\Type\:\:getFieldResolver\(\) expects string, int\|string given/'
         # tests/Unit/EndpointTest.php
         - '/Parameter #1 \$wrappedType of static method GraphQL\\Type\\Definition\\Type::nonNull\(\) expects \(callable\(\): mixed\)\|GraphQL\\Type\\Definition\\NullableType, GraphQL\\Type\\Definition\\Type given/'
+        - '/Parameter #1 \$array of static method Illuminate\\Support\\Arr::get\(\) expects array\|ArrayAccess/'
         # Mass ignore the raw array property access used in many tests for now
         # See also https://github.com/nunomaduro/larastan/issues/611
         -

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -546,7 +546,7 @@ class GraphQL
         }
 
         /** @var ConfigConvertible $instance */
-        $instance = new $schema();
+        $instance = app()->make($schema);
 
         return $instance->toConfig();
     }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -514,7 +514,7 @@ class GraphQL
     }
 
     /**
-     * @return array<array>
+     * @return array<array|Schema>
      */
     public static function getNormalizedSchemasConfiguration(): array
     {
@@ -528,13 +528,17 @@ class GraphQL
     }
 
     /**
-     * @param  mixed  $schema
-     * @return array<array>
+     * @param  Schema|array<array>|string|null  $schema
+     * @return Schema|array<array>
      */
-    protected static function getNormalizedSchemaConfiguration($schema): array
+    protected static function getNormalizedSchemaConfiguration($schema)
     {
-        if (! is_string($schema)) {
+        if (is_array($schema) || $schema instanceof Schema) {
             return $schema;
+        }
+
+        if (is_null($schema)) {
+            return [];
         }
 
         if (! class_exists($schema)) {

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -500,7 +500,7 @@ class GraphQL
      * @param  array|string|null  $schema
      * @return array|Schema
      */
-    public function getSchemaConfiguration($schema)
+    protected function getSchemaConfiguration($schema)
     {
         $schemaName = is_string($schema) ? $schema : config('graphql.default_schema', 'default');
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -531,7 +531,7 @@ class GraphQL
      * @param  Schema|array<array>|string|null  $schema
      * @return Schema|array<array>
      */
-    protected static function getNormalizedSchemaConfiguration($schema)
+    public static function getNormalizedSchemaConfiguration($schema)
     {
         if (is_array($schema) || $schema instanceof Schema) {
             return $schema;

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -513,7 +513,10 @@ class GraphQL
         return static::getNormalizedSchemaConfiguration($schema);
     }
 
-    public static function getNormalizedSchemasConfiguration()
+    /**
+     * @return array<array>
+     */
+    public static function getNormalizedSchemasConfiguration(): array
     {
         return array_filter(array_map(function ($schema) {
             try {
@@ -524,7 +527,11 @@ class GraphQL
         }, config('graphql.schemas')));
     }
 
-    protected static function getNormalizedSchemaConfiguration($schema)
+    /**
+     * @param  mixed  $schema
+     * @return array<array>
+     */
+    protected static function getNormalizedSchemaConfiguration($schema): array
     {
         if (! is_string($schema)) {
             return $schema;

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -500,7 +500,7 @@ class GraphQL
      * @param  array|string|null  $schema
      * @return array|Schema
      */
-    protected function getSchemaConfiguration($schema)
+    public function getSchemaConfiguration($schema)
     {
         $schemaName = is_string($schema) ? $schema : config('graphql.default_schema', 'default');
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -514,7 +514,7 @@ class GraphQL
     }
 
     /**
-     * @return array<array|Schema>
+     * @return array<string, array|Schema>
      */
     public static function getNormalizedSchemasConfiguration(): array
     {

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -510,12 +510,32 @@ class GraphQL
 
         $schema = is_array($schema) ? $schema : $this->schemas[$schemaName];
 
+        return static::getNormalizedSchemaConfiguration($schema);
+    }
+
+    public static function getNormalizedSchemasConfiguration()
+    {
+        return array_filter(array_map(function ($schema) {
+            try {
+                return static::getNormalizedSchemaConfiguration($schema);
+            } catch (SchemaNotFound $e) {
+                return null;
+            }
+        }, config('graphql.schemas')));
+    }
+
+    protected static function getNormalizedSchemaConfiguration($schema)
+    {
         if (! is_string($schema)) {
             return $schema;
         }
 
+        if (! class_exists($schema)) {
+            throw new SchemaNotFound('Schema class '.$schema.' not found.');
+        }
+
         /** @var ConfigConvertible $instance */
-        $instance = app()->make($schema);
+        $instance = new $schema();
 
         return $instance->toConfig();
     }

--- a/tests/Support/Objects/ExampleSchema.php
+++ b/tests/Support/Objects/ExampleSchema.php
@@ -17,6 +17,9 @@ class ExampleSchema implements ConfigConvertible
             'mutation' => [
                 'updateExampleCustom' => UpdateExampleMutation::class,
             ],
+            'middleware' => [
+                ExampleMiddleware::class,
+            ]
         ];
     }
 }

--- a/tests/Support/Objects/ExampleSchemaWithMethod.php
+++ b/tests/Support/Objects/ExampleSchemaWithMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+class ExampleSchemaWithMethod extends ExampleSchema
+{
+    public function toConfig(): array
+    {
+        return array_merge(parent::toConfig(), ['method' => ['post']]);
+    }
+}

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -120,8 +120,8 @@ class GraphQLTest extends TestCase
      */
     public function testSchemaWithInvalidClassName(): void
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target class [ThisClassDoesntExist] does not exist.');
+        $this->expectException(SchemaNotFound::class);
+        $this->expectExceptionMessage('Schema class ThisClassDoesntExist not found.');
         GraphQL::schema('invalid_class_based');
     }
 

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Unit;
+
+use GraphQL\Utils\BuildSchema;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
+use Rebing\GraphQL\Tests\TestCase;
+
+class RoutesTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('graphql', [
+
+            'prefix' => 'graphql_test',
+
+            'graphiql' => [
+                'display' => false,
+            ],
+
+            'schemas' => [
+                'default' => [
+                    'middleware' => [ExampleMiddleware::class]
+                ],
+                'custom' => [
+                    'middleware' => [ExampleMiddleware::class]
+                ],
+                'with_methods' => [
+                    'method' => ['post'],
+                    'middleware' => [ExampleMiddleware::class]
+                ],
+                'class_based' => ExampleSchema::class,
+                'shorthand' => BuildSchema::build('
+                    schema {
+                        query: ShorthandExample
+                    }
+
+                    type ShorthandExample {
+                        echo(message: String!): String!
+                    }
+                '),
+            ]
+
+        ]);
+    }
+
+    public function testRoutes(): void
+    {
+        $expected = [
+            'graphql.query' => [
+                'methods' => ['GET', 'HEAD'],
+                'uri' => 'graphql_test',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.query.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.default' => [
+                'methods' => ['GET', 'HEAD'],
+                'uri' => 'graphql_test/{default}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.default.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{default}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.custom' => [
+                'methods' => ['GET', 'HEAD'],
+                'uri' => 'graphql_test/{custom}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.custom.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{custom}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.with_methods.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{with_methods}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.class_based' => [
+                'methods' => ['GET', 'HEAD'],
+                'uri' => 'graphql_test/{class_based}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.class_based.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{class_based}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.shorthand' => [
+                'methods' => ['GET', 'HEAD'],
+                'uri' => 'graphql_test/{shorthand}',
+                'middleware' => [],
+            ],
+            'graphql.shorthand.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{shorthand}',
+                'middleware' => [],
+            ],
+        ];
+
+        $this->assertEquals($expected, Collection::make(
+            app('router')->getRoutes()->getRoutesByName()
+        )->map(function (Route $route) {
+            return [
+                'methods' => $route->methods(),
+                'uri' => $route->uri(),
+                'middleware' => $route->middleware(),
+            ];
+        })->all());
+    }
+}

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchemaWithMethod;
 use Rebing\GraphQL\Tests\TestCase;
 
 class RoutesTest extends TestCase
@@ -35,6 +36,7 @@ class RoutesTest extends TestCase
                     'middleware' => [ExampleMiddleware::class]
                 ],
                 'class_based' => ExampleSchema::class,
+                'class_based_with_methods' => ExampleSchemaWithMethod::class,
                 'shorthand' => BuildSchema::build('
                     schema {
                         query: ShorthandExample
@@ -95,6 +97,11 @@ class RoutesTest extends TestCase
             'graphql.class_based.post' => [
                 'methods' => ['POST'],
                 'uri' => 'graphql_test/{class_based}',
+                'middleware' => [ExampleMiddleware::class],
+            ],
+            'graphql.class_based_with_methods.post' => [
+                'methods' => ['POST'],
+                'uri' => 'graphql_test/{class_based_with_methods}',
                 'middleware' => [ExampleMiddleware::class],
             ],
             'graphql.shorthand' => [


### PR DESCRIPTION
## Summary

In #706 I added support for you to be able to generate a schema config by supplying a class name.
That worked when querying, but I've just noticed it doesn't work when generating the routes. 

i.e. `middleware` and `method` wouldn't be respected.

In `routes.php`, the routes are created by simply reading the config and looping over the schemas. If a class name is used, it needed to be converted to the array.

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
