### PR TITLE
Pass query/mutation context into the field privacy detection for better access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/6.3.0...master)
 --------------
 
+## Breaking changes
+- Signtature of `\Rebing\GraphQL\Support\Privacy::validate` changed, now it accepts both query/mutation arguments and the query/mutation context.
+  Update your existing privacy policies this way:
+  ```diff
+  -public function validate(array $queryArgs): bool
+  +public function validate(array $queryArgs, $queryContext = null): bool
+  ```
+
+### Added
+- Ability to pass query/mutation context to the field privacy handler (both closure and class) [\#727 / torunar](https://github.com/rebing/graphql-laravel/pull/727)
+
 2021-03-12, 6.3.0
 -----------------
 
@@ -39,7 +50,7 @@ Same as 6.1.0-rc1!
   Be sure to read up on breaking changes in graphql-php => https://github.com/webonyx/graphql-php/releases/tag/v14.0.0
 - Remove support for Laravel < 6.0 [\#651 / mfn](https://github.com/rebing/graphql-laravel/pull/651)
   This also bumps the minimum required version to PHP 7.2
-  
+
 ### Added
 - Support for Laravel 8 [\#672 / mfn](https://github.com/rebing/graphql-laravel/pull/672)
 

--- a/README.md
+++ b/README.md
@@ -1073,7 +1073,7 @@ use Rebing\GraphQL\Support\Privacy;
 
 class MePrivacy extends Privacy
 {
-    public function validate(array $queryArgs, $queryContext): bool
+    public function validate(array $queryArgs, $queryContext = null): bool
     {
         return $args['id'] == Auth::id();
     }

--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ class UserType extends GraphQLType
             'email' => [
                 'type'          => Type::string(),
                 'description'   => 'The email of user',
-                'privacy'       => function(array $args): bool {
+                'privacy'       => function(array $args, $ctx): bool {
                     return $args['id'] == Auth::id();
                 }
             ]
@@ -1073,7 +1073,7 @@ use Rebing\GraphQL\Support\Privacy;
 
 class MePrivacy extends Privacy
 {
-    public function validate(array $queryArgs): bool
+    public function validate(array $queryArgs, $queryContext): bool
     {
         return $args['id'] == Auth::id();
     }

--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ class MePrivacy extends Privacy
 {
     public function validate(array $queryArgs, $queryContext = null): bool
     {
-        return $args['id'] == Auth::id();
+        return $queryArgs['id'] == Auth::id();
     }
 }
 ```

--- a/example/Privacy/MePrivacy.php
+++ b/example/Privacy/MePrivacy.php
@@ -7,8 +7,8 @@ use Rebing\GraphQL\Support\Privacy;
 
 class MePrivacy extends Privacy
 {
-    public function validate(array $args): bool
+    public function validate(array $queryArgs, $queryContext = null): bool
     {
-        return $args['id'] == Auth::id();
+        return $queryArgs['id'] == Auth::id();
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1191,6 +1191,26 @@ parameters:
 			path: tests/Support/Objects/CustomExampleType.php
 
 		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:\\$attributes has no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/CustomExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/CustomExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/CustomExamplesQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/CustomExamplesQuery.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ErrorFormatter\\:\\:formatError\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Support/Objects/ErrorFormatter.php
@@ -1474,26 +1494,6 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesQuery.php
-
-		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:\\$attributes has no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/CustomExamplesQuery.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/CustomExamplesQuery.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/CustomExamplesQuery.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/CustomExamplesQuery.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:\\$attributes has no typehint specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -266,11 +266,6 @@ parameters:
 			path: src/Support/PaginationType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Privacy\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/Privacy.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getFieldsAndArgumentsSelection\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/ResolveInfoFieldsAndArguments.php
@@ -367,11 +362,6 @@ parameters:
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:validateField\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/SelectFields.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func expects callable\\(\\)\\: mixed, array\\(\\*NEVER\\*, 'fire'\\) given\\.$#"
 			count: 1
 			path: src/Support/SelectFields.php
 
@@ -1169,21 +1159,6 @@ parameters:
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PostType\\:\\:\\$attributes has no typehint specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateFieldTests/PostType.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyAllowed\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyAllowed.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyArgs\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyArgs.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\PrivacyDenied\\:\\:validate\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Database/SelectFields/ValidateFieldTests/PrivacyDenied.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:\\$attributes has no typehint specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -266,6 +266,11 @@ parameters:
 			path: src/Support/PaginationType.php
 
 		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Privacy\\:\\:fire\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: src/Support/Privacy.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\ResolveInfoFieldsAndArguments\\:\\:getFieldsAndArgumentsSelection\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/ResolveInfoFieldsAndArguments.php
@@ -357,11 +362,6 @@ parameters:
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:addFieldToSelect\\(\\) has parameter \\$select with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Support/SelectFields.php
-
-		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\SelectFields\\:\\:validateField\\(\\) has parameter \\$queryArgs with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/SelectFields.php
 

--- a/src/Support/Privacy.php
+++ b/src/Support/Privacy.php
@@ -8,13 +8,18 @@ abstract class Privacy
 {
     public function fire(): bool
     {
-        return $this->validate(func_get_args()[0]);
+        $queryArgs = func_get_arg(0);
+        $queryContext = func_get_arg(1);
+
+        return $this->validate($queryArgs, $queryContext);
     }
 
     /**
-     * @param  array  $queryArgs  Arguments given with the query/mutation
+     * @param array $queryArgs    Arguments given with the query/mutation
+     * @param mixed $queryContext Context of the query/mutation
+     *
      * @return bool Return `true` to allow access to the field in question,
      *   `false otherwise
      */
-    abstract public function validate(array $queryArgs): bool;
+    abstract public function validate(array $queryArgs, $queryContext = null): bool;
 }

--- a/src/Support/Privacy.php
+++ b/src/Support/Privacy.php
@@ -6,12 +6,9 @@ namespace Rebing\GraphQL\Support;
 
 abstract class Privacy
 {
-    public function fire(): bool
+    public function fire(...$args): bool
     {
-        $queryArgs = func_get_arg(0);
-        $queryContext = func_get_arg(1);
-
-        return $this->validate($queryArgs, $queryContext);
+        return $this->validate(...$args);
     }
 
     /**

--- a/src/Support/Privacy.php
+++ b/src/Support/Privacy.php
@@ -15,8 +15,8 @@ abstract class Privacy
     }
 
     /**
-     * @param array $queryArgs    Arguments given with the query/mutation
-     * @param mixed $queryContext Context of the query/mutation
+     * @param array<string, mixed> $queryArgs    Arguments given with the query/mutation
+     * @param mixed                $queryContext Context of the query/mutation
      *
      * @return bool Return `true` to allow access to the field in question,
      *   `false otherwise

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -173,7 +173,7 @@ class SelectFields
             }
 
             // First check if the field is even accessible
-            $canSelect = static::validateField($fieldObject, $queryArgs);
+            $canSelect = static::validateField($fieldObject, $queryArgs, $ctx);
             if ($canSelect === true) {
                 // Add a query, if it exists
                 $customQuery = $fieldObject->config['query'] ?? null;
@@ -300,13 +300,15 @@ class SelectFields
     /**
      * Check the privacy status, if it's given.
      *
-     * @param  FieldDefinition  $fieldObject
-     * @param  array  $queryArgs  Arguments given with the query/mutation
+     * @param FieldDefinition $fieldObject Validated field
+     * @param array           $queryArgs   Arguments given with the query/mutation
+     * @param mixed           $ctx         Query/mutation context
+     *
      * @return bool|null `true`  if selectable
      *                   `false` if not selectable, but allowed
      *                   `null`  if not allowed
      */
-    protected static function validateField(FieldDefinition $fieldObject, array $queryArgs): ?bool
+    protected static function validateField(FieldDefinition $fieldObject, array $queryArgs, $ctx): ?bool
     {
         $selectable = true;
 
@@ -321,7 +323,7 @@ class SelectFields
             switch ($privacyClass) {
                 // If privacy given as a closure
                 case is_callable($privacyClass):
-                    if (false === call_user_func($privacyClass, $queryArgs)) {
+                    if (false === call_user_func($privacyClass, $queryArgs, $ctx)) {
                         $selectable = null;
                     }
 
@@ -330,7 +332,7 @@ class SelectFields
                 // If Privacy class given
                 case is_string($privacyClass):
                     $instance = app($privacyClass);
-                    if (false === call_user_func([$instance, 'fire'], $queryArgs)) {
+                    if (false === call_user_func([$instance, 'fire'], $queryArgs, $ctx)) {
                         $selectable = null;
                     }
 

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -300,9 +300,9 @@ class SelectFields
     /**
      * Check the privacy status, if it's given.
      *
-     * @param FieldDefinition $fieldObject Validated field
-     * @param array           $queryArgs   Arguments given with the query/mutation
-     * @param mixed           $ctx         Query/mutation context
+     * @param FieldDefinition       $fieldObject Validated field
+     * @param array<string, mixed>  $queryArgs   Arguments given with the query/mutation
+     * @param mixed                 $ctx         Query/mutation context
      *
      * @return bool|null `true`  if selectable
      *                   `false` if not selectable, but allowed

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -331,6 +331,7 @@ class SelectFields
 
                 // If Privacy class given
                 case is_string($privacyClass):
+                    /** @var \Rebing\GraphQL\Support\Privacy $instance */
                     $instance = app($privacyClass);
                     if (false === call_user_func([$instance, 'fire'], $queryArgs, $ctx)) {
                         $selectable = null;

--- a/tests/Database/SelectFields/ValidateFieldTests/PostType.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/PostType.php
@@ -104,6 +104,24 @@ class PostType extends GraphQLType
                 'type' => Type::string(),
                 'privacy' => true,
             ],
+            'title_privacy_closure_query_context' => [
+                'alias' => 'title',
+                'type' => Type::string(),
+                'privacy' => static function (array $queryArgs, $queryContext): bool {
+                    $expectedQueryContext = [
+                        'arg_from_context_true' => true,
+                        'arg_from_context_false' => false,
+                    ];
+                    Assert::assertSame($expectedQueryContext, $queryContext);
+
+                    return true;
+                },
+            ],
+            'title_privacy_class_query_context' => [
+                'alias' => 'title',
+                'type' => Type::string(),
+                'privacy' => PrivacyQueryContext::class,
+            ],
         ];
     }
 }

--- a/tests/Database/SelectFields/ValidateFieldTests/PrivacyAllowed.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/PrivacyAllowed.php
@@ -9,11 +9,9 @@ use Rebing\GraphQL\Support\Privacy;
 class PrivacyAllowed extends Privacy
 {
     /**
-     * @param  array  $queryArgs  Arguments given with the query/mutation
-     * @return bool Return `true` to allow access to the field in question,
-     *   `false otherwise
+     * @inheritDoc
      */
-    public function validate(array $queryArgs): bool
+    public function validate(array $queryArgs, $queryContext = null): bool
     {
         return true;
     }

--- a/tests/Database/SelectFields/ValidateFieldTests/PrivacyDenied.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/PrivacyDenied.php
@@ -9,11 +9,9 @@ use Rebing\GraphQL\Support\Privacy;
 class PrivacyDenied extends Privacy
 {
     /**
-     * @param  array  $queryArgs Arguments given with the query/mutation
-     * @return bool Return `true` to allow access to the field in question,
-     *   `false otherwise
+     * @inheritDoc
      */
-    public function validate(array $queryArgs): bool
+    public function validate(array $queryArgs, $queryContext = null): bool
     {
         return false;
     }

--- a/tests/Database/SelectFields/ValidateFieldTests/PrivacyQueryContext.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/PrivacyQueryContext.php
@@ -7,17 +7,18 @@ namespace Rebing\GraphQL\Tests\Database\SelectFields\ValidateFieldTests;
 use PHPUnit\Framework\Assert;
 use Rebing\GraphQL\Support\Privacy;
 
-class PrivacyArgs extends Privacy
+class PrivacyQueryContext extends Privacy
 {
     /**
      * @inheritDoc
      */
     public function validate(array $queryArgs, $queryContext = null): bool
     {
-        $expectedQueryArgs = [
-            'arg_from_query' => true,
+        $expectedQueryContext = [
+            'arg_from_context_true' => true,
+            'arg_from_context_false' => false,
         ];
-        Assert::assertSame($expectedQueryArgs, $queryArgs);
+        Assert::assertSame($expectedQueryContext, $queryContext);
 
         return true;
     }

--- a/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
@@ -526,4 +526,103 @@ GRAQPHQL;
             PostType::class,
         ]);
     }
+
+    /**
+     * Note: actual assertion happens in \Rebing\GraphQL\Tests\Database\SelectFields\ValidateFieldTests\PostType::fields
+     * within the closure for the field `title_privacy_closure_context`.
+     */
+    public function testPrivacyClosureReceivesContext(): void
+    {
+        factory(Post::class)
+            ->create([
+                'title' => 'post title',
+            ]);
+
+        $query = <<<'GRAQPHQL'
+{
+  validateFields {
+    title_privacy_closure_query_context
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $options = [
+            'opts' => [
+                'context' => [
+                    'arg_from_context_true' => true,
+                    'arg_from_context_false' => false,
+                ]
+            ]
+        ];
+
+        $result = $this->graphql($query, $options);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "posts"."title", "posts"."id" from "posts";
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'validateFields' => [
+                    [
+                        'title_privacy_closure_query_context' => 'post title',
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Note: actual assertion happens in \Rebing\GraphQL\Tests\Database\SelectFields\ValidateFieldTests\PrivacyQueryContext::validate.
+     */
+    public function testPrivacyClassReceivesQueryContext(): void
+    {
+        factory(Post::class)
+            ->create([
+                'title' => 'post title',
+            ]);
+
+        $query = <<<'GRAQPHQL'
+{
+  validateFields {
+    title_privacy_class_query_context
+  }
+}
+GRAQPHQL;
+
+        $this->sqlCounterReset();
+
+        $options = [
+            'opts' => [
+                'context' => [
+                    'arg_from_context_true' => true,
+                    'arg_from_context_false' => false,
+                ]
+            ]
+        ];
+
+        $result = $this->graphql($query, $options);
+
+        $this->assertSqlQueries(
+            <<<'SQL'
+select "posts"."title", "posts"."id" from "posts";
+SQL
+        );
+
+        $expectedResult = [
+            'data' => [
+                'validateFields' => [
+                    [
+                        'title_privacy_class_query_context' => 'post title',
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -169,14 +169,17 @@ class TestCase extends BaseTestCase
      *   Supports the following options:
      *   - `expectErrors` (default: false): if no errors are expected but present, let's the test fail
      *   - `variables` (default: null): GraphQL variables for the query
+     *   - `opts` (default: []): GraphQL options for the query (context, schema, operationName, rootValue)
+     *
      * @return array GraphQL result
      */
     protected function graphql(string $query, array $options = []): array
     {
         $expectErrors = $options['expectErrors'] ?? false;
         $variables = $options['variables'] ?? null;
+        $opts = $options['opts'] ?? [];
 
-        $result = GraphQL::query($query, $variables);
+        $result = GraphQL::query($query, $variables, $opts);
 
         $assertMessage = null;
 

--- a/tests/Unit/TypesInSchemas/TypesTest.php
+++ b/tests/Unit/TypesInSchemas/TypesTest.php
@@ -132,7 +132,9 @@ GRAPHQL;
 GRAPHQL;
 
         $actual = $this->graphql($query, [
-            'schema' => 'custom',
+            'opts' => [
+                'schema' => 'custom',
+            ],
         ]);
 
         $expected = [
@@ -165,7 +167,9 @@ GRAPHQL;
 GRAPHQL;
 
         $actual = $this->graphql($query, [
-            'schema' => 'custom',
+            'opts' => [
+                'schema' => 'custom',
+            ],
         ]);
 
         $expected = [
@@ -223,7 +227,9 @@ GRAPHQL;
 }
 GRAPHQL;
         $actual = $this->graphql($query, [
-            'schema' => 'custom',
+            'opts' => [
+                'schema' => 'custom',
+            ],
         ]);
         $expected = [
             'data' => [


### PR DESCRIPTION
## Summary

Currently `privacy` in the field specification can access only the query/mutation arguments.
This creates difficulties in the applications where access to the specific field is based on the current query/mutation context, and the context itself is the robust object which contains user, site area (back office / client area), etc.

This results in quirky workarounds like registering context globally in the app and accessing it via facades.
This PR is fixes this issue by passing query/mutation context to the privacy handlers, so this:
```php
'privacy' => static function (array $args) {
    $ctx = app(Context::class);
    return $ctx->isAdministrator();
},
```
becomes this:
```php
'privacy' => static function (array $args, $ctx) {
    return $ctx->isAdministrator();
},
```

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
