### PR TITLE
Drop support for configuration the name of the variable for the variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/7.0.1...master)
 --------------
 
+## Breaking changes
+- Removed support for `params_key` [\# / mfn]()\
+  It's not possible anymore to configure the name of the variable by which to
+  expect the variables for the GraphQL query to be passed and it's now always
+  `variables` as per https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#request-parameters
+
 2021-04-03, 7.0.1
 -----------------
 ### Added

--- a/README.md
+++ b/README.md
@@ -1275,10 +1275,6 @@ When you query the GraphQL endpoint, you can pass a JSON encoded `variables` par
 http://homestead.app/graphql?query=query+FetchUserByID($id:Int){user(id:$id){id,email}}&params={"id":123}
 ```
 
-Notice that your client side framework might use another parameter name than `variables`.
-You can customize the parameter name to anything your client is using by adjusting
-the `params_key` in the `graphql.php` configuration file.
-
 ### Custom field
 
 You can also define a field as a class if you want to reuse it in multiple types.

--- a/config/config.php
+++ b/config/config.php
@@ -147,9 +147,6 @@ return [
      */
     'errors_handler' => [\Rebing\GraphQL\GraphQL::class, 'handleErrors'],
 
-    // You can set the key, which will be used to retrieve the dynamic variables
-    'params_key' => 'variables',
-
     /*
      * Options to limit the query complexity and depth. See the doc
      * @ https://webonyx.github.io/graphql-php/security

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -60,8 +60,7 @@ class GraphQLController extends Controller
     {
         $query = $input['query'] ?? '';
 
-        $paramsKey = config('graphql.params_key', 'variables');
-        $params = $input[$paramsKey] ?? null;
+        $params = $input['variables'] ?? null;
         if (is_string($params)) {
             $params = json_decode($params, true);
         }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -30,8 +30,6 @@ class ConfigTest extends TestCase
                 'mutation' => 'mutation/{graphql_schema?}',
             ],
 
-            'params_key' => 'params',
-
             'default_schema' => 'custom',
 
             'schemas' => [
@@ -122,26 +120,6 @@ class ConfigTest extends TestCase
         $this->assertArrayHasKey('default', $schemas);
         $this->assertArrayHasKey('custom', $schemas);
         $this->assertArrayHasKey('shorthand', $schemas);
-    }
-
-    public function testVariablesInputName(): void
-    {
-        $response = $this->call('GET', '/graphql_test/query/default', [
-            'query' => $this->queries['examplesWithVariables'],
-            'params' => [
-                'index' => 0,
-            ],
-        ]);
-
-        $this->assertEquals($response->getStatusCode(), 200);
-
-        $content = $response->getData(true);
-        $this->assertArrayHasKey('data', $content);
-        $this->assertEquals($content['data'], [
-            'examples' => [
-                $this->data[0],
-            ],
-        ]);
     }
 
     public function testSecurity(): void


### PR DESCRIPTION
## Summary

As per https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#request-parameters
it's not always `variables.`

This is further also required to switch to [laravel-graphql-utils](https://github.com/rebing/graphql-laravel/issues/663)

**Status:** merge if either the desire for https://github.com/rebing/graphql-laravel/pull/668 gets stronger or the https://github.com/graphql/graphql-over-http spec with the clear definition how it should be named is released.
---
Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
