### PR TITLE
Allow disabling batched requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/7.1.0...master)
 --------------
 
+### Added
+- Allow disabling batched requests [\#738 / mfn](https://github.com/rebing/graphql-laravel/pull/738)
+
 2021-04-08, 7.1.0
 -----------------
 ### Added

--- a/README.md
+++ b/README.md
@@ -1820,6 +1820,8 @@ There are tools that help with this and can handle the batching for you, e.g. [A
 > - No limitations on the number of queries/mutations  
 >   Currently there's no way to limit this.
 
+Support for batching can be disabled by setting the config `batching` to `false`.
+
 ### Scalar types
 
 GraphQL comes with built-in scalar types for string, int, boolean, etc. It's possible to create custom scalar types to special purpose fields.

--- a/config/config.php
+++ b/config/config.php
@@ -54,6 +54,11 @@ return [
     // parameter.
     'default_schema' => 'default',
 
+    // Whether to support GraphQL batching or not.
+    // See e.g. https://www.apollographql.com/blog/batching-client-graphql-queries-a685f5bcd41b/
+    // for pro and con
+    'batching' => true,
+
     // The schemas for query and/or mutation. It expects an array of schemas to provide
     // both the 'query' fields and the 'mutation' fields.
     //

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -157,6 +157,48 @@ class EndpointTest extends TestCase
         ]);
     }
 
+    public function testBatchedQueriesButBatchingDisabled(): void
+    {
+        config(['graphql.batching' => false]);
+
+        $response = $this->call('GET', '/graphql', [
+            [
+                'query' => $this->queries['examplesWithVariables'],
+                'variables' => [
+                    'index' => 0,
+                ],
+            ],
+            [
+                'query' => $this->queries['examplesWithVariables'],
+                'variables' => [
+                    'index' => 0,
+                ],
+            ],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $actual = $response->getData(true);
+
+        $expected = [
+            [
+                'errors' => [
+                    [
+                        'message' => 'Batch request received but batching is not supported',
+                    ],
+                ],
+            ],
+            [
+                'errors' => [
+                    [
+                        'message' => 'Batch request received but batching is not supported',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($expected, $actual);
+    }
+
     public function testGetGraphqiQL(): void
     {
         $response = $this->call('GET', '/graphiql');


### PR DESCRIPTION
## Summary

- See https://www.apollographql.com/blog/batching-client-graphql-queries-a685f5bcd41b/ for pro/con
- Stays enabled by default but can be disabled if desired
- will return a GraphQL batch compatible error response
  i.e. each batch will return the same error, however not more than 100 such errors are returned

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
