### PR TITLE
apq: parse query ahead of caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ CHANGELOG
     new: `public function query(string $query, ?array $variables = [], array $opts = []): array`
   - old: `public function queryAndReturnResult(string $query, ?array $params = [], array $opts = []): ExecutionResult`
     new: `public function queryAndReturnResult(string $query, ?array $variables = [], array $opts = []): ExecutionResult`
+- As part of APQ parsed query support [\#740 / mfn](https://github.com/rebing/graphql-laravel/pull/740):
+  - In `\Rebing\GraphQL\GraphQLController`, the following signature changed:
+    - old: `protected function handleAutomaticPersistQueries(string $schemaName, OperationParams $operation): string`
+      new: `protected function handleAutomaticPersistQueries(string $schemaName, OperationParams $operation): array`
+  - In `\Rebing\GraphQL\GraphQL`, the following signature changed:
+    - old: `public function query(string $query, ?array $variables = [], array $opts = []): array`
+      new: `public function query($query, ?array $variables = [], array $opts = []): array`
+    - old: `public function queryAndReturnResult(string $query, ?array $variables = [], array $opts = []): ExecutionResult`
+      new: `public function queryAndReturnResult($query, ?array $variables = [], array $opts = []): ExecutionResult`
+
+### Added
+- Automatic Persisted Queries (APQ) now cache the parsed query [\#740 / mfn](https://github.com/rebing/graphql-laravel/pull/740)\
+  This avoids having to re-parse the same queries over and over again.
 
 2021-04-10, 7.2.0
 -----------------

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To work this around:
     - [Field deprecation](#field-deprecation)
     - [Default field resolver](#default-field-resolver)
     - [Macros](#macros)
-    - [Basic Automatic Persisted Queries support](#basic-automatic-persisted-queries-support) 
+    - [Automatic Persisted Queries support](#automatic-persisted-queries-support) 
   - [Guides](#guides)
     - [Upgrading from v1 to v2](#upgrading-from-v1-to-v2)
     - [Migrating from Folklore](#migrating-from-folklore)
@@ -2395,7 +2395,7 @@ class AppServiceProvider extends ServiceProvider
 
 The `macro` function accepts a name as its first argument, and a `Closure` as its second.
 
-### Basic Automatic Persisted Queries support
+### Automatic Persisted Queries support
 
 Automatic Persisted Queries (APQ) improve network performance by sending smaller requests, with zero build-time configuration.
 
@@ -2405,8 +2405,11 @@ A persisted query is an ID or hash that can be generated on the client sent to t
 This smaller signature reduces bandwidth utilization and speeds up client loading times.
 Persisted queries pair especially with GET requests, enabling the browser cache and integration with a CDN.
 
-Behind the scenes, APQ uses Laravels cache for storing / retrieving queries.
+Behind the scenes, APQ uses Laravels cache for storing / retrieving the queries.
+They are parsed by GraphQL before storing, so re-parsing them again is not necessary.
 Please see the various options there for which cache, prefix, TTL, etc. to use.
+
+> Note: it is advised to clear the cache after a deployment to accomodate for changes in your schema!
 
 For more information see: 
  - [Apollo - Automatic persisted queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) 
@@ -2419,11 +2422,6 @@ For more information see:
 > 
 > In such case either disable the middleware or trim the query on the client
 > before hashing.
-
-#### Why "basic support" ?
-
-Currently, only the GraphQL query string representation will be cached and still
-needs to be re-parsed after retrieving form the cache.
 
 #### Notes
  - The error descriptions are aligned with [apollo-server](https://github.com/apollographql/apollo-server).

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -10,6 +10,7 @@ use GraphQL\Error\Error;
 use GraphQL\Error\FormattedError;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL as GraphQLBase;
+use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -108,19 +109,21 @@ class GraphQL
     }
 
     /**
+     * @param string|DocumentNode $query
      * @param array<string,mixed>|null $variables Optional GraphQL input variables for your query/mutation
      * @param array<string,mixed> $opts Additional options, like 'schema', 'context' or 'operationName'
      */
-    public function query(string $query, ?array $variables = [], array $opts = []): array
+    public function query($query, ?array $variables = [], array $opts = []): array
     {
         return $this->queryAndReturnResult($query, $variables, $opts)->toArray();
     }
 
     /**
+     * @param string|DocumentNode $query
      * @param array<string,mixed>|null $variables Optional GraphQL input variables for your query/mutation
      * @param array<string,mixed> $opts Additional options, like 'schema', 'context' or 'operationName'
      */
-    public function queryAndReturnResult(string $query, ?array $variables = [], array $opts = []): ExecutionResult
+    public function queryAndReturnResult($query, ?array $variables = [], array $opts = []): ExecutionResult
     {
         $context = $opts['context'] ?? null;
         $schemaName = $opts['schema'] ?? null;

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -105,7 +105,7 @@ class GraphQLController extends Controller
                 'query' => $query,
                 'parsedQuery' => $parsedQuery,
             ] = $this->handleAutomaticPersistQueries($schemaName, $params);
-        } catch (AutomaticPersistedQueriesError $e) {
+        } catch (AutomaticPersistedQueriesError | Error $e) {
             return $graphql
                 ->decorateExecutionResult(new ExecutionResult(null, [$e]))
                 ->toArray($debug);

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -7,6 +7,7 @@ use Exception;
 use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error;
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Language\Parser;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
@@ -98,7 +99,12 @@ class GraphQLController extends Controller
         }
 
         try {
-            $query = $this->handleAutomaticPersistQueries($schemaName, $params);
+            // In case of an APQ cache hit, parsedQuery contains the AST of the provided query
+            // and is subsequently used to speed up the execution.
+            [
+                'query' => $query,
+                'parsedQuery' => $parsedQuery,
+            ] = $this->handleAutomaticPersistQueries($schemaName, $params);
         } catch (AutomaticPersistedQueriesError $e) {
             return $graphql
                 ->decorateExecutionResult(new ExecutionResult(null, [$e]))
@@ -106,7 +112,7 @@ class GraphQLController extends Controller
         }
 
         return $graphql->query(
-            $query,
+            $parsedQuery ?? $query,
             $params->variables,
             [
                 'context' => $this->queryContext($query, $params->variables, $schemaName),
@@ -128,10 +134,16 @@ class GraphQLController extends Controller
     /**
      * Note: it's expected this is called even when APQ is disabled to adhere
      *       to the negotiation protocol.
+     * @return array{query:string,parsedQuery:?\GraphQL\Language\AST\DocumentNode}
      */
-    protected function handleAutomaticPersistQueries(string $schemaName, OperationParams $operation): string
+    protected function handleAutomaticPersistQueries(string $schemaName, OperationParams $operation): array
     {
         $query = $operation->query;
+
+        $datum = [
+            'query' => $query,
+            'parsedQuery' => null,
+        ];
 
         $apqEnabled = config('graphql.apq.enable', false);
 
@@ -144,14 +156,14 @@ class GraphQLController extends Controller
 
         // APQ disabled? Nothing to be done
         if (!$apqEnabled) {
-            return $query;
+            return $datum;
         }
 
         // No hash? Nothing to be done
         $hash = $persistedQuery['sha256Hash'] ?? null;
 
         if (null === $hash) {
-            return $query;
+            return $datum;
         }
 
         $apqCacheDriver = config('graphql.apq.cache_driver');
@@ -165,10 +177,13 @@ class GraphQLController extends Controller
             if ($hash !== hash('sha256', $query)) {
                 throw AutomaticPersistedQueriesError::invalidHash();
             }
-            $ttl = config('graphql.apq.cache_ttl', 300);
-            $cache->driver($apqCacheDriver)->set($apqCacheIdentifier, $query, $ttl);
 
-            return $query;
+            $datum['parsedQuery'] = Parser::parse($query);
+
+            $ttl = config('graphql.apq.cache_ttl', 300);
+            $cache->driver($apqCacheDriver)->set($apqCacheIdentifier, $datum, $ttl);
+
+            return $datum;
         }
 
         // retrieve from cache

--- a/tests/Unit/AutomatedPersistedQueriesTest.php
+++ b/tests/Unit/AutomatedPersistedQueriesTest.php
@@ -447,4 +447,41 @@ class AutomatedPersistedQueriesTest extends TestCase
         ];
         self::assertEquals($expected, $content);
     }
+
+    public function testPersistedQueryParseError(): void
+    {
+        $query = '{ parse(error) }';
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $query,
+            'extensions' => [
+                'persistedQuery' => [
+                    'version' => 1,
+                    'sha256Hash' => hash('sha256', $query),
+                ],
+            ],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->json();
+
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'Syntax Error: Expected :, found )',
+                    'extensions' => [
+                        'category' => 'graphql',
+                    ],
+                    'locations' => [
+                        [
+                            'line' => 1,
+                            'column' => 14,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($expected, $content);
+    }
 }


### PR DESCRIPTION
## Summary
Once a query is retrieved from the cache, it's not necessary to parse it
again.

This builds upon https://github.com/rebing/graphql-laravel/pull/701

The reason for keeping the original source query is to still allow calling `queryContext()` with it (otherwise there would indeed not be much reason to keep it).


### Notes
- ~Lumen integration tests are broken, but this is unrelated and already happens since https://github.com/rebing/graphql-laravel/commit/53248e2cfa5c3de78562f7f5b5513c13933c8dc0~ fixed with https://github.com/rebing/graphql-laravel/commit/85a7e885107af47edff2cf753d1e1bd0457df30c

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
