### PR TITLE
Format Laravels `ValidationException` the same way as a `ValidationError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ CHANGELOG
 - Automatic Persisted Queries (APQ) now cache the parsed query [\#740 / mfn](https://github.com/rebing/graphql-laravel/pull/740)\
   This avoids having to re-parse the same queries over and over again.
 - Add ability to detect unused GraphQL variables [\#660 / mfn](https://github.com/rebing/graphql-laravel/pull/660)
+- Laravels `ValidationException` is now formatted the same way as a `ValidationError` [\#748 / mfn](https://github.com/rebing/graphql-laravel/pull/748)
 
 2021-04-10, 7.2.0
 -----------------

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Schema;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\ValidationException;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
 use Rebing\GraphQL\Exception\SchemaNotFound;
@@ -424,8 +425,18 @@ class GraphQL
 
         $previous = $e->getPrevious();
 
-        if ($previous && $previous instanceof ValidationError) {
-            $error['extensions']['validation'] = $previous->getValidatorMessages();
+        if ($previous) {
+            if ($previous instanceof ValidationException) {
+                $error['message'] = 'validation';
+                $error['extensions'] = [
+                    'category' => 'validation',
+                    'validation' => $previous->validator->errors()->getMessages(),
+                ];
+            }
+
+            if ($previous instanceof ValidationError) {
+                $error['extensions']['validation'] = $previous->getValidatorMessages();
+            }
         }
 
         return $error;

--- a/tests/Unit/ValidationException/ThrowsValidationExceptionQuery.php
+++ b/tests/Unit/ValidationException/ThrowsValidationExceptionQuery.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ValidationException;
+
+use GraphQL\Type\Definition\Type;
+use Illuminate\Support\Facades\Validator;
+use Rebing\GraphQL\Support\Query;
+
+class ThrowsValidationExceptionQuery extends Query
+{
+    /** @var array<string,string> */
+    protected $attributes = [
+        'name' => 'throwsValidationException',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::boolean());
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     */
+    public function resolve($root, $args): bool
+    {
+        Validator
+            ::make(
+                $args,
+                [
+                    'field' => 'required',
+                ]
+            )
+            ->validate();
+
+        return true;
+    }
+}

--- a/tests/Unit/ValidationException/ValidationExceptionTest.php
+++ b/tests/Unit/ValidationException/ValidationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ValidationException;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class ValidationExceptionTest extends TestCase
+{
+    public function testLaravelValidationException(): void
+    {
+        $query = <<<'GRAQPHQL'
+query {
+    throwsValidationException
+}
+GRAQPHQL;
+
+        $result = $this->graphql($query, [
+            'expectErrors' => true,
+        ]);
+
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'validation',
+                    'extensions' => [
+                        'category' => 'validation',
+                        'validation' => [
+                            'field' => [
+                                    'The field field is required.',
+                                ],
+                        ],
+                    ],
+                    'locations' => [
+                        [
+                            'line' => 2,
+                            'column' => 5,
+                        ],
+                    ],
+                    'path' => [
+                        'throwsValidationException',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($expected, $result);
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                ThrowsValidationExceptionQuery::class,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
This way it's as easy as just letting the validator throw from any resolver and doesn't require the provided `ValidationError` thrown from the internal validation.

See also https://github.com/rebing/graphql-laravel/issues/716#issuecomment-821461178

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
