### PR TITLE
Remove deprecated inputObject/enumObjet properties in favour of classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 --------------
 
 ## Breaking changes
+- Remove deprecated `\Rebing\GraphQL\Support\Type::$inputObject` and `\Rebing\GraphQL\Support\Type::$enumObject` properties [\#752 / mfn](https://github.com/rebing/graphql-laravel/pull/752)\
+  Instead in your code, extend `\Rebing\GraphQL\Support\InputType` and `\Rebing\GraphQL\Support\EnumType` directly 
 - Support for Lumen has been removed
 - Integrate laragraph/utils RequestParser [\#739 / mfn](https://github.com/rebing/graphql-laravel/pull/739)
   - batched queries will only work with `POST` requests

--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -3,9 +3,7 @@
 declare(strict_types = 1);
 namespace Rebing\GraphQL\Support;
 
-use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FieldDefinition;
-use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphqlType;
 use Illuminate\Support\Str;
@@ -17,20 +15,6 @@ use Rebing\GraphQL\Support\Contracts\TypeConvertible;
 abstract class Type implements TypeConvertible
 {
     protected $attributes = [];
-    /**
-     * Set to `true` in your type when it should reflect an InputObject.
-     * @var bool
-     * @deprecated Use InputType instead
-     * @see InputType
-     */
-    protected $inputObject = false;
-    /**
-     * Set to `true` in your type when it should reflect an Enum.
-     * @var bool
-     * @deprecated Use EnumType instead
-     * @see EnumType
-     */
-    protected $enumObject = false;
 
     public function attributes(): array
     {
@@ -138,14 +122,6 @@ abstract class Type implements TypeConvertible
 
     public function toType(): GraphqlType
     {
-        if ($this->inputObject) {
-            return new InputObjectType($this->toArray());
-        }
-
-        if ($this->enumObject) {
-            return new EnumType($this->toArray());
-        }
-
         return new ObjectType($this->toArray());
     }
 


### PR DESCRIPTION
## Summary
The replacement is to extend `EnumType` and `InputType` directly and
not rely on these properties.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
