### PR TITLE
Remove \Rebing\GraphQL\GraphQLController::$app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ CHANGELOG
 --------------
 
 ## Breaking changes
+- Remove the `\Rebing\GraphQL\GraphQLController::$app`  property [\#755 / mfn](https://github.com/rebing/graphql-laravel/pull/755)\
+  Injecting the application container early is incompatible when running within
+  an application server like laravel/octane, as it's not guaranteed that the
+  container received contains all the bindings. If you relied on this property
+  when extending the classes, invoke the container directly via
+  `Container::getInstance()`.
+  
 - Remove deprecated `\Rebing\GraphQL\Support\Type::$inputObject` and `\Rebing\GraphQL\Support\Type::$enumObject` properties [\#752 / mfn](https://github.com/rebing/graphql-laravel/pull/752)\
   Instead in your code, extend `\Rebing\GraphQL\Support\InputType` and `\Rebing\GraphQL\Support\EnumType` directly 
 - Support for Lumen has been removed

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -21,20 +21,12 @@ use Rebing\GraphQL\Error\AutomaticPersistedQueriesError;
 
 class GraphQLController extends Controller
 {
-    /** @var Container */
-    protected $app;
-
-    public function __construct(Container $app)
-    {
-        $this->app = $app;
-    }
-
     public function query(Request $request, string $schema = null): JsonResponse
     {
         $schemaName = $schema;
 
         /** @var RequestParser $parser */
-        $parser = $this->app->make(RequestParser::class);
+        $parser = Container::getInstance()->make(RequestParser::class);
         $operations = $parser->parseRequest($request);
 
         // If there are multiple route params we can expect that there
@@ -79,10 +71,10 @@ class GraphQLController extends Controller
             : DebugFlag::NONE;
 
         /** @var GraphQL $graphql */
-        $graphql = $this->app->make('graphql');
+        $graphql = Container::getInstance()->make('graphql');
 
         /** @var Helper $helper */
-        $helper = $this->app->make(Helper::class);
+        $helper = Container::getInstance()->make(Helper::class);
         $errors = $helper->validateOperationParams($params);
 
         if ($errors) {
@@ -125,7 +117,7 @@ class GraphQLController extends Controller
     protected function queryContext(string $query, ?array $variables, string $schemaName)
     {
         try {
-            return $this->app->make('auth')->user();
+            return Container::getInstance()->make('auth')->user();
         } catch (Exception $e) {
             return null;
         }
@@ -170,7 +162,7 @@ class GraphQLController extends Controller
         $apqCachePrefix = config('graphql.apq.cache_prefix');
         $apqCacheIdentifier = "$apqCachePrefix:$schemaName:$hash";
 
-        $cache = $this->app->make('cache');
+        $cache = Container::getInstance()->make('cache');
 
         // store in cache
         if ($query) {


### PR DESCRIPTION
## Summary
Add access the container directly via `Container::getInstance()`.

Injecting the application container into the controller can cause
problems with application servers like https://github.com/laravel/octane/. It's not
guaranteed that all bindings are already available (e.g. `'graphql'`)
and thus a fresh instance must be fetched.

Reference: https://github.com/laravel/octane/#container-injection



---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
