### PR TITLE
[BREAKING CHANGE 🚨] Rewrite and simplify routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ CHANGELOG
 --------------
 
 ## Breaking changes
+- Routing has been rewritten and simplified [\#757 / mfn](https://github.com/rebing/graphql-laravel/pull/757)
+  - All routing related configuration is now within the top level `route`
+    configuration key
+  - The following configuration options have been removed:
+    - `graphql.routes`\
+      It's therefore also not possible anymore to register different routes for
+      queries and mutations within a schema. Each schema gets only one route
+      (except for the default schema, which is registered for the global prefix
+      route as well as under its name).\
+      If necessary, this can be emulated with different schemas and multi-level
+      paths
+  - The following configuration options have been moved/renamed:
+    - `graphql.prefix` => `graphql.route.prefix`
+    - `graphql.controllers` => `graphql.route.controller`\
+      Further, providing a controller action for `query` or `mutation` is not
+      supported anymore.
+    - `graphql.middlware` => `graphql.route.middleware`
+    - `graphql.route_group_attributes` => `graphql.route.group_attributes`
+  - The actual routes defined have changed:
+    - No more separate routes for the HTTP methods
+    - 1 route for each schema + 1 route for the group prefix (default schema)
+    - If GraphiQL is enabled: 1 route graphiql route for each schema + 1 for the
+      graphiql group prefix (default schema)
+  - It's now possible to prevent the registering of any routes by making the top
+    level `route` an empty array or null
+  - `\Rebing\GraphQL\GraphQL::routeNameTransformer` has been removed
+  - It's not possible to register schemas with a `-` in their name
+
 - Remove the `\Rebing\GraphQL\GraphQLController::$app`  property [\#755 / mfn](https://github.com/rebing/graphql-laravel/pull/755)\
   Injecting the application container early is incompatible when running within
   an application server like laravel/octane, as it's not guaranteed that the

--- a/README.md
+++ b/README.md
@@ -2596,22 +2596,20 @@ and set it to `true`.
 
 ## Configuration options
 
-- `prefix`\
-  The route prefix to your GraphQL endpoint without the leading `/`.\
-  The default makes the API available via `/graphql`
-- `routes`\
-  The route itself. The default `{graphql_schema?}` is a place holder which gets
-  dynamically resolved whether you request a specific or the default schema
-  - Default schema: `/graphql`
-  - Specific schema: `/gaphql/specificschema`
-- `controllers`\
-  Allows overriding the default controller class, in case you want to extend or
-  replace the existing one.
-- `middleware`\
-  Global GraphQL middleware applying in case no schema-specific middleware was
-  provided
-- `route_group_attributes`\
-  Additional route group attributes
+- `route`\
+  Holds all the configuration for the route group. Each schema will be available
+  via its name as a dedicated route.
+  - `prefix`\
+    The route prefix to your GraphQL endpoint without the leading `/`.\
+    The default makes the API available via `/graphql`
+  - `controller`\
+    Allows overriding the default controller class, in case you want to extend or
+    replace the existing one.
+  - `middleware`\
+    Global GraphQL middleware applying in case no schema-specific middleware was
+    provided
+  - `group_attributes`\
+    Additional route group attributes
 - `default_schema`\
   The name of the default schema used, when none is provided via the route
 - `batching`\

--- a/config/config.php
+++ b/config/config.php
@@ -3,55 +3,28 @@
 declare(strict_types = 1);
 
 return [
-    // The prefix for routes
-    'prefix' => 'graphql',
+    'route' => [
+        // The prefix for routes; do NOT use a leading slash!
+        'prefix' => 'graphql',
 
-    // The routes to make GraphQL request. Either a string that will apply
-    // to both query and mutation or an array containing the key 'query' and/or
-    // 'mutation' with the according Route
-    //
-    // Example:
-    //
-    // Same route for both query and mutation
-    //
-    // 'routes' => 'path/to/query/{graphql_schema?}',
-    //
-    // or define each route
-    //
-    // 'routes' => [
-    //     'query' => 'query/{graphql_schema?}',
-    //     'mutation' => 'mutation/{graphql_schema?}',
-    // ]
-    //
-    'routes' => '{graphql_schema?}',
+        // The controller/method to use in GraphQL request.
+        'controller' => \Rebing\GraphQL\GraphQLController::class . '@query',
 
-    // The controller to use in GraphQL request. Either a string that will apply
-    // to both query and mutation or an array containing the key 'query' and/or
-    // 'mutation' with the according Controller and method
-    //
-    // Example:
-    //
-    // 'controllers' => [
-    //     'query' => '\Rebing\GraphQL\GraphQLController@query',
-    //     'mutation' => '\Rebing\GraphQL\GraphQLController@mutation'
-    // ]
-    //
-    'controllers' => \Rebing\GraphQL\GraphQLController::class . '@query',
+        // Any middleware for the graphql route group
+        // This middleware will apply to all schemas
+        'middleware' => [],
 
-    // Any middleware for the graphql route group
-    'middleware' => [],
+        // Additional route group attributes
+        //
+        // Example:
+        //
+        // 'group_attributes' => ['guard' => 'api']
+        //
+        'group_attributes' => [],
+    ],
 
-    // Additional route group attributes
-    //
-    // Example:
-    //
-    // 'route_group_attributes' => ['guard' => 'api']
-    //
-    'route_group_attributes' => [],
-
-    // The name of the default schema used when no argument is provided
-    // to GraphQL::schema() or when the route is used without the graphql_schema
-    // parameter.
+    // The name of the default schema
+    // Used when the route group is directly accessed
     'default_schema' => 'default',
 
     'batching' => [
@@ -68,12 +41,11 @@ return [
     //
     // Example:
     //
-    //  'schema' => 'default',
-    //
     //  'schemas' => [
     //      'default' => [
+    //          'controller' => MyController::class . '@method',
     //          'query' => [
-    //              'users' => App\GraphQL\Query\UsersQuery::class
+    //              App\GraphQL\Query\UsersQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -81,7 +53,7 @@ return [
     //      ],
     //      'user' => [
     //          'query' => [
-    //              'profile' => App\GraphQL\Query\ProfileQuery::class
+    //              App\GraphQL\Query\ProfileQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -90,7 +62,7 @@ return [
     //      ],
     //      'user/me' => [
     //          'query' => [
-    //              'profile' => App\GraphQL\Query\MyProfileQuery::class
+    //              App\GraphQL\Query\MyProfileQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -107,6 +79,7 @@ return [
             'mutation' => [
                 // ExampleMutation::class,
             ],
+            // The types only available in this schema
             'types' => [
                 // ExampleType::class,
             ],
@@ -115,8 +88,8 @@ return [
         ],
     ],
 
-    // The types available in the application. You can then access it from the
-    // facade like this: GraphQL::type('user')
+    // The global types available to all schemas.
+    // You can then access it from the facade like this: GraphQL::type('user')
     //
     // Example:
     //
@@ -180,7 +153,7 @@ return [
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */
     'graphiql' => [
-        'prefix' => '/graphiql',
+        'prefix' => 'graphiql', // Do NOT use a leading slash
         'controller' => \Rebing\GraphQL\GraphQLController::class . '@graphiql',
         'middleware' => [],
         'view' => 'graphql::graphiql',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/GraphQL.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:routeNameTransformer\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/GraphQL.php
-
-		-
 			message: "#^Method Rebing\\\\GraphQL\\\\GraphQL\\:\\:schema\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/GraphQL.php
@@ -494,16 +489,6 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Support/UploadType.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$queryTypesMap has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/routes.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed, mixed\\)\\: bool\\)\\|null, Closure\\(array, string\\)\\: bool\\|null given\\.$#"
-			count: 1
-			path: src/routes.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLContext\\:\\:\\$data has no typehint specified\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,7 +14,6 @@ parameters:
     checkUninitializedProperties: true
     checkModelProperties: true
     ignoreErrors:
-        - '/Cannot access property \$parameters on mixed/'
         - '/Call to an undefined method Illuminate\\Testing\\TestResponse::(content|getData|getStatusCode)\(\)/'
         - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'
         # tests/Unit/GraphQLTest.php
@@ -27,7 +26,6 @@ parameters:
         - '/Parameter #1 \$name of method Rebing\\GraphQL\\Support\\Type\:\:getFieldResolver\(\) expects string, int\|string given/'
         # tests/Unit/EndpointTest.php
         - '/Parameter #1 \$wrappedType of static method GraphQL\\Type\\Definition\\Type::nonNull\(\) expects \(callable\(\): mixed\)\|GraphQL\\Type\\Definition\\NullableType, GraphQL\\Type\\Definition\\Type given/'
-        - '/Parameter #1 \$array of static method Illuminate\\Support\\Arr::get\(\) expects array\|ArrayAccess/'
         # Mass ignore the raw array property access used in many tests for now
         # See also https://github.com/nunomaduro/larastan/issues/611
         -

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -479,28 +479,6 @@ class GraphQL
     }
 
     /**
-     * Check if the schema expects a nest URI name and return the formatted version
-     * Eg. 'user/me'
-     * will open the query path /graphql/user/me.
-     */
-    public static function routeNameTransformer(string $name, string $schemaParameterPattern, string $queryRoute): string
-    {
-        $multiLevelPath = explode('/', $name);
-        $routeName = null;
-
-        if (count($multiLevelPath) > 1) {
-            foreach ($multiLevelPath as $multiName) {
-                $routeName = !$routeName ? null : $routeName . '/';
-                $routeName =
-                    $routeName
-                    . preg_replace($schemaParameterPattern, '{' . $multiName . '}', $queryRoute);
-            }
-        }
-
-        return $routeName ?: preg_replace($schemaParameterPattern, '{' . $name . '}', $queryRoute);
-    }
-
-    /**
      * @param array|string|null $schema
      * @return array|Schema
      */

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -37,9 +37,7 @@ class GraphQLServiceProvider extends ServiceProvider
      */
     protected function bootRouter(): void
     {
-        if (config('graphql.routes')) {
-            include __DIR__ . '/routes.php';
-        }
+        $this->loadRoutesFrom(__DIR__ . '/routes.php');
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -2,131 +2,88 @@
 
 declare(strict_types = 1);
 
-use Illuminate\Support\Arr;
+use Illuminate\Routing\Router;
+use Rebing\GraphQL\GraphQL;
 use Rebing\GraphQL\GraphQLController;
 
-$router = app('router');
-$schemaParameterPattern = '/\{\s*graphql\_schema\s*\?\s*\}/';
+$routeConfig = config('graphql.route');
 
-$router->group(array_merge([
-    'prefix' => config('graphql.prefix'),
-    'middleware' => config('graphql.middleware', []),
-], config('graphql.route_group_attributes', [])), function ($router) use ($schemaParameterPattern): void {
-    /** @var \Illuminate\Routing\Router $router */
+if ($routeConfig) {
+    /** @var Router $router */
+    $router = app('router');
 
-    // Routes and controllers
-    $routes = config('graphql.routes');
-    $controllers = config('graphql.controllers', GraphQLController::class . '@query');
-
-    $queryTypesMap = [
-        'query' => [],
-        'mutation' => [],
-    ];
-
-    /** @var array $queryTypesMap */
-    $queryTypesMap = array_combine(
-        array_keys($queryTypesMap),
-        array_map(function (string $type) use ($routes, $controllers, $queryTypesMap) {
-            $row = $queryTypesMap[$type];
-            $row['route'] = is_array($routes) ? Arr::get($routes, $type) : $routes;
-            $row['controller'] = is_array($controllers) ? Arr::get($controllers, $type) : $controllers;
-
-            return $row;
-        }, array_keys($queryTypesMap))
+    $routeGroupAttributes = array_merge(
+        [
+            'prefix' => $routeConfig['prefix'] ?? 'graphql',
+            'middleware' => $routeConfig['middleware'] ?? [],
+        ],
+        $routeConfig['group_attributes'] ?? []
     );
 
-    // Specific query type routes
-    $queryTypesMapWithRoutes = array_filter($queryTypesMap, function (array $row, string $type) use ($queryTypesMap) {
-        if ('mutation' === $type && $queryTypesMap['mutation']['route'] === $queryTypesMap['query']['route']) {
-            return;
-        }
+    $router->group(
+        $routeGroupAttributes,
+        function (Router $router) use ($routeConfig): void {
+            $schemas = GraphQL::getNormalizedSchemasConfiguration();
+            $defaultSchema = config('graphql.default_schema', 'default');
 
-        return null !== $row['route'];
-    }, ARRAY_FILTER_USE_BOTH);
+            foreach ($schemas as $schemaName => $schemaConfig) {
+                // A schemaConfig can in fact be a \GraphQL\Type\Schema object
+                // in which case no further information can be extracted from it
+                if (is_object($schemaConfig)) {
+                    $schemaConfig = [];
+                }
 
-    if ($queryTypesMapWithRoutes) {
-        $schemaConfig = Rebing\GraphQL\GraphQL::getNormalizedSchemasConfiguration();
+                $actions = array_filter([
+                    'uses' => $schemaConfig['controller'] ?? $routeConfig['controller'] ?? GraphQLController::class . '@query',
+                    'middleware' => $schemaConfig['middleware'] ?? $routeConfig['middleware'] ?? null,
+                ]);
 
-        $defaultConfig = Arr::get($schemaConfig, config('graphql.default_schema'), []);
-        $defaultMiddleware = $defaultConfig['middleware'] ?? [];
-        $defaultMethod = $defaultConfig['method'] ?? ['get', 'post'];
+                // Add route for each schema…
+                $router->addRoute(
+                    ['GET', 'POST'],
+                    $schemaName,
+                    $actions + ['as' => "graphql.$schemaName"]
+                );
 
-        foreach ($queryTypesMapWithRoutes as $type => $info) {
-            if (preg_match($schemaParameterPattern, $info['route'])) {
-                foreach ($defaultMethod as $method) {
-                    $routeName = "graphql.$type";
-
-                    if ('get' !== $method) {
-                        $routeName .= ".$method";
-                    }
-                    $router->{$method}(
-                        preg_replace($schemaParameterPattern, '', $info['route']),
-                        [
-                            'uses' => $info['controller'],
-                            'middleware' => $defaultMiddleware,
-                            'as' => $routeName,
-                        ]
+                // … and the default schema against the group itself
+                if ($schemaName === $defaultSchema) {
+                    $router->addRoute(
+                        ['GET', 'POST'],
+                        '',
+                        $actions + ['as' => 'graphql']
                     );
                 }
-
-                foreach ($schemaConfig as $name => $schema) {
-                    foreach (Arr::get($schema, 'method', ['get', 'post']) as $method) {
-                        $routeName = "graphql.$name";
-
-                        if ('get' !== $method) {
-                            $routeName .= ".$method";
-                        }
-                        $route = $router->{$method}(
-                            Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, $info['route']),
-                            [
-                                'uses' => $info['controller'],
-                                'middleware' => Arr::get($schema, 'middleware', []),
-                                'as' => $routeName,
-                            ]
-                        );
-
-                        $route->where($name, $name);
-                    }
-                }
-            } else {
-                $router->get($info['route'], [
-                    'uses' => $info['controller'],
-                    'as' => "graphql.$type",
-                ]);
-                $router->post($info['route'], [
-                    'uses' => $info['controller'],
-                    'as' => "graphql.$type.post",
-                ]);
             }
         }
-    }
-});
+    );
+}
 
 if (config('graphql.graphiql.display', true)) {
-    $router->group([
-        'prefix' => config('graphql.graphiql.prefix', 'graphiql'),
-        'middleware' => config('graphql.graphiql.middleware', []),
-    ], function ($router) use ($schemaParameterPattern): void {
-        /** @var \Illuminate\Routing\Router $router */
-        $graphiqlController = config('graphql.graphiql.controller', GraphQLController::class . '@graphiql');
+    /** @var Router $router */
+    $router = app('router');
+    $graphiqlConfig = config('graphql.graphiql');
 
-        $graphiqlAction = ['uses' => $graphiqlController];
+    $router->group(
+        [
+            'prefix' => $graphiqlConfig['prefix'] ?? 'graphiql',
+            'middleware' => $graphiqlConfig['middleware'] ?? [],
+        ],
+        function (Router $router) use ($graphiqlConfig): void {
+            $actions = [
+                'uses' => $graphiqlConfig['controller'] ?? GraphQLController::class . '@graphiql',
+            ];
 
-        foreach (config('graphql.schemas') as $name => $schema) {
-            $route = $router->get(
-                Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, '{graphql_schema?}'),
-                $graphiqlAction + ['as' => "graphql.graphiql.$name"]
-            );
-            $route->where($name, $name);
+            // A graphiql route for each schema…
+            /** @var string $schemaName */
+            foreach (array_keys(config('graphql.schemas')) as $schemaName) {
+                $router->get(
+                    $schemaName,
+                    $actions + ['as' => "graphql.graphiql.$schemaName"]
+                );
+            }
 
-            $route = $router->post(
-                Rebing\GraphQL\GraphQL::routeNameTransformer($name, $schemaParameterPattern, '{graphql_schema?}'),
-                $graphiqlAction + ['as' => "graphql.graphiql.$name.post"]
-            );
-            $route->where($name, $name);
+            // … and one for the default schema against the group itself
+            $router->get('/', $actions + ['as' => 'graphql.graphiql']);
         }
-
-        $router->get('/', $graphiqlAction + ['as' => 'graphql.graphiql']);
-        $router->post('/', $graphiqlAction + ['as' => 'graphql.graphiql.post']);
-    });
+    );
 }

--- a/tests/Database/AuthorizeArgsTests/AuthorizeArgsTest.php
+++ b/tests/Database/AuthorizeArgsTests/AuthorizeArgsTest.php
@@ -11,8 +11,6 @@ class AuthorizeArgsTest extends TestCaseDatabase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('graphql.controllers', GraphQLController::class . '@query');
-
         $app['config']->set('graphql.schemas.default', [
             'query' => [
                 TestAuthorizationArgsQuery::class,

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
@@ -17,7 +17,7 @@ class NestedRelationLoadingTest extends TestCaseDatabase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('graphql.controllers', GraphQLController::class . '@query');
+        $app['config']->set('graphql.route.controller', GraphQLController::class . '@query');
 
         $app['config']->set('graphql.schemas.default', [
             'query' => [

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -21,13 +21,6 @@ class ConfigTest extends TestCase
     protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('graphql', [
-            'prefix' => 'graphql_test',
-
-            'routes' => [
-                'query' => 'query/{graphql_schema?}',
-                'mutation' => 'mutation/{graphql_schema?}',
-            ],
-
             'default_schema' => 'custom',
 
             'schemas' => [
@@ -70,30 +63,6 @@ class ConfigTest extends TestCase
                 'query_max_depth' => 10,
             ],
         ]);
-    }
-
-    public function testRouteQuery(): void
-    {
-        $response = $this->call('GET', '/graphql_test/query', [
-            'query' => $this->queries['examplesCustom'],
-        ]);
-
-        self::assertEquals(200, $response->getStatusCode());
-
-        $content = $response->getData(true);
-        self::assertArrayHasKey('data', $content);
-    }
-
-    public function testRouteMutation(): void
-    {
-        $response = $this->call('POST', '/graphql_test/mutation', [
-            'query' => $this->queries['updateExampleCustom'],
-        ]);
-
-        self::assertEquals(200, $response->getStatusCode());
-
-        $content = $response->getData(true);
-        self::assertArrayHasKey('data', $content);
     }
 
     public function testTypes(): void

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -226,4 +226,15 @@ class EndpointTest extends TestCase
         $response->assertSee('return fetch(\'/graphql\', {', false);
         $response->assertSee("'x-csrf-token': xcsrfToken || ''", false);
     }
+
+    public function testGetGraphiQLCustomSchema(): void
+    {
+        $response = $this->call('GET', '/graphiql/custom');
+
+        // Are we seeing the right template?
+        $response->assertSee('This GraphiQL example illustrates how to use some of GraphiQL\'s props', false);
+        // The argument to fetch is extracted from the configuration
+        $response->assertSee('return fetch(\'/graphql/custom\', {', false);
+        $response->assertSee("'x-csrf-token': xcsrfToken || ''", false);
+    }
 }

--- a/tests/Unit/NoRoutesRegisteredTest.php
+++ b/tests/Unit/NoRoutesRegisteredTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit;
+
+use GraphQL\Utils\BuildSchema;
+use Illuminate\Routing\Router;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchemaWithMethod;
+use Rebing\GraphQL\Tests\TestCase;
+
+class NoRoutesRegisteredTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('graphql', [
+            'route' => [],
+            'graphiql' => [
+                'display' => false,
+            ],
+
+            'schemas' => [
+                'default' => [
+                    'middleware' => [ExampleMiddleware::class],
+                ],
+                'custom' => [
+                    'middleware' => [ExampleMiddleware::class],
+                ],
+                'with_methods' => [
+                    'method' => ['post'],
+                    'middleware' => [ExampleMiddleware::class],
+                ],
+                'class_based' => ExampleSchema::class,
+                'class_based_with_methods' => ExampleSchemaWithMethod::class,
+                'shorthand' => BuildSchema::build('
+                    schema {
+                        query: ShorthandExample
+                    }
+
+                    type ShorthandExample {
+                        echo(message: String!): String!
+                    }
+                '),
+            ],
+        ]);
+    }
+
+    public function testNoRoutesAreRegistered(): void
+    {
+        /** @var Router $router */
+        $router = app('router');
+
+        self::assertCount(0, $router->getRoutes()->getRoutes());
+    }
+}

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -16,7 +16,9 @@ class RoutesTest extends TestCase
     protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('graphql', [
-            'prefix' => 'graphql_test',
+            'route' => [
+                'prefix' => 'graphql_test',
+            ],
 
             'graphiql' => [
                 'display' => false,
@@ -51,69 +53,84 @@ class RoutesTest extends TestCase
     public function testRoutes(): void
     {
         $expected = [
-            'graphql.query' => [
-                'methods' => ['GET', 'HEAD'],
+            'graphql' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
                 'uri' => 'graphql_test',
-                'middleware' => [ExampleMiddleware::class],
-            ],
-            'graphql.query.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test',
-                'middleware' => [ExampleMiddleware::class],
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
             'graphql.default' => [
-                'methods' => ['GET', 'HEAD'],
-                'uri' => 'graphql_test/{default}',
-                'middleware' => [ExampleMiddleware::class],
-            ],
-            'graphql.default.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{default}',
-                'middleware' => [ExampleMiddleware::class],
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/default',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
             'graphql.custom' => [
-                'methods' => ['GET', 'HEAD'],
-                'uri' => 'graphql_test/{custom}',
-                'middleware' => [ExampleMiddleware::class],
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/custom',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
-            'graphql.custom.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{custom}',
-                'middleware' => [ExampleMiddleware::class],
-            ],
-            'graphql.with_methods.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{with_methods}',
-                'middleware' => [ExampleMiddleware::class],
+            'graphql.with_methods' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/with_methods',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
             'graphql.class_based' => [
-                'methods' => ['GET', 'HEAD'],
-                'uri' => 'graphql_test/{class_based}',
-                'middleware' => [ExampleMiddleware::class],
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/class_based',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
-            'graphql.class_based.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{class_based}',
-                'middleware' => [ExampleMiddleware::class],
-            ],
-            'graphql.class_based_with_methods.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{class_based_with_methods}',
-                'middleware' => [ExampleMiddleware::class],
+            'graphql.class_based_with_methods' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/class_based_with_methods',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
             ],
             'graphql.shorthand' => [
-                'methods' => ['GET', 'HEAD'],
-                'uri' => 'graphql_test/{shorthand}',
-                'middleware' => [],
-            ],
-            'graphql.shorthand.post' => [
-                'methods' => ['POST'],
-                'uri' => 'graphql_test/{shorthand}',
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/shorthand',
                 'middleware' => [],
             ],
         ];
 
-        self::assertEquals($expected, Collection::make(
+        $actual = Collection::make(
             app('router')->getRoutes()->getRoutesByName()
         )->map(function (Route $route) {
             return [
@@ -121,6 +138,8 @@ class RoutesTest extends TestCase
                 'uri' => $route->uri(),
                 'middleware' => $route->middleware(),
             ];
-        })->all());
+        })->all();
+
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/SchemaHyphenInPathTest.php
+++ b/tests/Unit/SchemaHyphenInPathTest.php
@@ -5,7 +5,6 @@ namespace Rebing\GraphQL\Tests\Unit;
 
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
 use Rebing\GraphQL\Tests\TestCase;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SchemaHyphenInPathTest extends TestCase
 {
@@ -33,8 +32,6 @@ GRAPHQL;
         $response = $this->call('GET', '/graphql/with-hyphen', [
             'query' => $graphql,
         ]);
-
-        $this->expectException(NotFoundHttpException::class);
 
         $result = $response->json();
 


### PR DESCRIPTION
## Summary
- rewrote the routing code from scratch: the group routing is kept but
  the setup for each schema is vastly simplified
- moved all routing related configuration into the `route` top level
  configuration key
- register only one route per schema (and not one per method)
  - plus one for the default schema on the route group prefix
  - same for graphiql
- remove support for different routes for schema query
  and schema mutations.
- to keep supporting multi-level schemas, e.g. schemas looking like
  `multi/level`, we don't capture the schema name from the group but
  resolve it in the controller from the request.
  The problem is that `/` are not possible to be caught that way.
  OTOH it simplified the route parameter logic in `query()`
  (i.e. it was removed)

For the longest time, the whole routing code was a real eyesore. This library is a bit unique in that it supports multiple schemas which not all do, but I don't think we need to be able to have potential "route for queries in a schema" and a different route for "mutations in a schema"; each which could target different controller actions.

Fun fact: this Fixes https://github.com/rebing/graphql-laravel/issues/465 (although this was not intentional, it's a side effect of removing the complexity).

To handle such different behaviour one could:
- use multi-level routes
- use the resolver middleware

## The breaking changes
- config options have been shuffled around in an incompatible way
- different routes for `query` and `mutation` within a schema not explicitly supported anymore
- the internal route names have changed: if you're using them in your application, it's not `graphql.query` anymore but just `graphql` or `graphql.your_non_default_schema`

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
