### PR TITLE
Enable lazyload_types by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ CHANGELOG
 - Add ability to detect unused GraphQL variables [\#660 / mfn](https://github.com/rebing/graphql-laravel/pull/660)
 - Laravels `ValidationException` is now formatted the same way as a `ValidationError` [\#748 / mfn](https://github.com/rebing/graphql-laravel/pull/748)
 
+### Changed
+- Lazy loading types has been enabled by default [\#758 / mfn](https://github.com/rebing/graphql-laravel/pull/758)
+
 2021-04-10, 7.2.0
 -----------------
 ### Added

--- a/README.md
+++ b/README.md
@@ -2616,7 +2616,7 @@ and set it to `true`.
   - 'enable'\
     Whether to support GraphQL batching or not
 - `lazyload_types`\
-  The types will be loaded on demand. Recommended being enabled as it improves
+  The types will be loaded on demand. Enabled by default as it improves
   performance. Cannot be used with type aliasing.
 - `error_formatter`\
   This callable will be passed the Error object for each errors GraphQL catch.
@@ -2747,8 +2747,8 @@ The following is not a bullet-proof list but should serve as a guide. It's not a
 
 Lazy loading of types is a way of improving the start up performance.
 
-If you are declaring types using aliases it is not supported.
-If that is not the case, you can enable it with `lazyload_types` set to `true`.
+If you are declaring types using aliases, this is not supported and you need to
+set `lazyload_types` set to `false`.
 
 #### Example of aliasing **not** supported by lazy loading
 

--- a/config/config.php
+++ b/config/config.php
@@ -106,7 +106,7 @@ return [
     // The types will be loaded on demand. Default is to load all types on each request
     // Can increase performance on schemes with many types
     // Presupposes the config type key to match the type class name property
-    'lazyload_types' => false,
+    'lazyload_types' => true,
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -103,7 +103,7 @@ class GraphQL
 
                 return $types;
             },
-            'typeLoader' => config('graphql.lazyload_types', false)
+            'typeLoader' => config('graphql.lazyload_types', true)
                 ? function ($name) {
                     return $this->type($name);
                 }
@@ -207,7 +207,7 @@ class GraphQL
         if (!isset($this->types[$name])) {
             $error = "Type $name not found.";
 
-            if (config('graphql.lazyload_types', false)) {
+            if (config('graphql.lazyload_types', true)) {
                 $error .= "\nCheck that the config array key for the type matches the name attribute in the type's class.\nIt is required when 'lazyload_types' is enabled";
             }
 

--- a/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
@@ -16,8 +16,6 @@ class PrimaryKeyTest extends TestCaseDatabase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('graphql.lazyload_types', false);
-
         $app['config']->set('graphql.schemas.default', [
             'query' => [
                 PrimaryKeyQuery::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,8 +42,8 @@ class TestCase extends BaseTestCase
 
     protected function getEnvironmentSetUp($app): void
     {
-        if ('1' === env('TESTS_ENABLE_LAZYLOAD_TYPES')) {
-            $app['config']->set('graphql.lazyload_types', true);
+        if ('0' === env('TESTS_ENABLE_LAZYLOAD_TYPES')) {
+            $app['config']->set('graphql.lazyload_types', false);
         }
 
         $app['config']->set('graphql.schemas.default', [

--- a/tests/Unit/TypesInSchemas/TypesTest.php
+++ b/tests/Unit/TypesInSchemas/TypesTest.php
@@ -12,8 +12,8 @@ class TypesTest extends TestCase
         // Note: deliberately not calling parent to start with a clean config
 
         // To still properly support dual tests, we thus have to add this
-        if ('1' === env('TESTS_ENABLE_LAZYLOAD_TYPES')) {
-            $app['config']->set('graphql.lazyload_types', true);
+        if ('0' === env('TESTS_ENABLE_LAZYLOAD_TYPES')) {
+            $app['config']->set('graphql.lazyload_types', false);
         }
     }
 


### PR DESCRIPTION
## Summary
I think it's time to suggest this as default.

There's no BC impact expected for proper existing installations as they
will just use whatever their `lazyload_types` value is.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
