### PR TITLE
Fix example classes in config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -45,7 +45,7 @@ return [
     //      'default' => [
     //          'controller' => MyController::class . '@method',
     //          'query' => [
-    //              App\GraphQL\Query\UsersQuery::class,
+    //              App\GraphQL\Queries\UsersQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -53,7 +53,7 @@ return [
     //      ],
     //      'user' => [
     //          'query' => [
-    //              App\GraphQL\Query\ProfileQuery::class,
+    //              App\GraphQL\Queries\ProfileQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -62,7 +62,7 @@ return [
     //      ],
     //      'user/me' => [
     //          'query' => [
-    //              App\GraphQL\Query\MyProfileQuery::class,
+    //              App\GraphQL\Queries\MyProfileQuery::class,
     //          ],
     //          'mutation' => [
     //
@@ -94,7 +94,7 @@ return [
     // Example:
     //
     // 'types' => [
-    //     App\GraphQL\Type\UserType::class
+    //     App\GraphQL\Types\UserType::class
     // ]
     //
     'types' => [


### PR DESCRIPTION
## Summary

The example classes in the config do not use the same folders/namespaces as the artisan commands generate.

For example:

```bash
php artisan make:graphql:query SomeQuery
```

Will create the following file: `./app/GraphQL/Queries/SomeQuery.php` (notice the plural `Queries`)

In the config, the examples are all give with the singular. For example:

```php

  // ...
  'query' => [
    App\GraphQL\Query\UsersQuery::class,
  ],
```

Not a huge change but helps with consistency. 

Feedback welcomed!

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
