### PR TITLE
schema: a query is always required

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -71,7 +71,7 @@ class GraphQL
             return $schema;
         }
 
-        $schemaQuery = $schema['query'] ?? [];
+        $schemaQuery = $schema['query'];
         $schemaMutation = $schema['mutation'] ?? [];
         $schemaSubscription = $schema['subscription'] ?? [];
         $schemaTypes = $schema['types'] ?? [];


### PR DESCRIPTION
## Summary
Also simplify logic on surrounding code a bit, don't call `->objectType`
if we don't have anything defined.

Thing is: this breaks a lots of test and "usually" it just works.

I've also seen in practice, a schema without a "query" just works but when you try to actually validate the schema, it reports an error.

Reference in the spec https://spec.graphql.org/June2018/#sec-Root-Operation-Types
> The query root operation type must be provided and must be an Object type.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
