### PR TITLE
Don't catch SchemaNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ CHANGELOG
 - Laravels `ValidationException` is now formatted the same way as a `ValidationError` [\#748 / mfn](https://github.com/rebing/graphql-laravel/pull/748)
 
 ### Changed
+- Don't silence broken schemas when normalizing them for generating routes [\#766 / mfn](https://github.com/rebing/graphql-laravel/pull/766)
 - Lazy loading types has been enabled by default [\#758 / mfn](https://github.com/rebing/graphql-laravel/pull/758)
 
 2021-04-10, 7.2.0

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -500,13 +500,12 @@ class GraphQL
      */
     public static function getNormalizedSchemasConfiguration(): array
     {
-        return array_filter(array_map(function ($schema) {
-            try {
+        return array_map(
+            static function ($schema) {
                 return static::getNormalizedSchemaConfiguration($schema);
-            } catch (SchemaNotFound $e) {
-                return null;
-            }
-        }, config('graphql.schemas', [])));
+            },
+            config('graphql.schemas', [])
+        );
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -72,7 +72,6 @@ class TestCase extends BaseTestCase
         ]);
 
         $app['config']->set('graphql.schemas.class_based', ExampleSchema::class);
-        $app['config']->set('graphql.schemas.invalid_class_based', 'ThisClassDoesntExist');
 
         $app['config']->set('graphql.types', [
             'Example' => ExampleType::class,

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -97,6 +97,8 @@ class GraphQLTest extends TestCase
 
     public function testSchemaWithInvalidClassName(): void
     {
+        $this->app['config']->set('graphql.schemas.invalid_class_based', 'ThisClassDoesntExist');
+
         $this->expectException(SchemaNotFound::class);
         $this->expectExceptionMessage('Schema class ThisClassDoesntExist not found.');
         GraphQL::schema('invalid_class_based');


### PR DESCRIPTION
## Summary
A SchemaNotFound is a broken configuration and shouldn't be silenced.

Ref: https://github.com/rebing/graphql-laravel/pull/724#discussion_r627545839

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
