### PR TITLE
Remove provides() method from ServiceProvider

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: src/GraphQLController.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\GraphQLServiceProvider\\:\\:provides\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/GraphQLServiceProvider.php
-
-		-
 			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\|stdClass\\:\\:\\$alias\\.$#"
 			count: 1
 			path: src/Support/AliasArguments/AliasArguments.php

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -155,17 +155,4 @@ class GraphQLServiceProvider extends ServiceProvider
         $this->commands(TypeMakeCommand::class);
         $this->commands(UnionMakeCommand::class);
     }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [
-            GraphQL::class,
-            'graphql',
-        ];
-    }
 }


### PR DESCRIPTION
## Summary
I'm pretty sure this one is only used for deferred providers [1].
However we do more then just registered services, thus with the current
Laravel architecture we can't make it deferred anyway

[1] https://laravel.com/docs/8.x/providers#deferred-providers

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
