### PR TITLE
 apq: adapt test showing that a GET request using query parameters works in master/8.x-dev

### DIFF
--- a/tests/Unit/AutomatedPersistedQueriesTest.php
+++ b/tests/Unit/AutomatedPersistedQueriesTest.php
@@ -139,23 +139,8 @@ class AutomatedPersistedQueriesTest extends TestCase
 
         $content = $response->json();
 
-        $expected = [
-            'errors' => [
-                [
-                    'message' => 'Syntax Error: Unexpected <EOF>',
-                    'extensions' => [
-                        'category' => 'graphql',
-                    ],
-                    'locations' => [
-                        [
-                            'line' => 1,
-                            'column' => 1,
-                        ],
-                    ],
-                ],
-            ],
-        ];
-        self::assertEquals($expected, $content);
+        self::assertArrayHasKey('data', $content);
+        self::assertEquals(['examples' => $this->data], $content['data']);
     }
 
     // This test demonstrates we don't actually check the 'version'


### PR DESCRIPTION
## Summary
See https://github.com/rebing/graphql-laravel/issues/780

In 7.x this fails but in master/8.x-dev it already works due to switch to https://github.com/laragraph/utils and thus the changed handling of parsing the HTTP input.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
