### PR TITLE
Add back the ability to configure per GraphQL schema HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,6 @@ CHANGELOG
     - 1 route for each schema + 1 route for the group prefix (default schema)
     - If GraphiQL is enabled: 1 route graphiql route for each schema + 1 for the
       graphiql group prefix (default schema)
-    - This also means that the per schema config key `method` (aka HTTP method)
-      is not supported anymore
   - It's now possible to prevent the registering of any routes by making the top
     level `route` an empty array or null
   - `\Rebing\GraphQL\GraphQL::routeNameTransformer` has been removed

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ them, in addition to the global middleware. For example:
         
         ],
         'middleware' => ['auth'],
+        'method' => ['GET', 'POST'], 
         'execution_middleware' => [
             \Rebing\GraphQL\Support\ExecutionMiddleware\UnusedVariablesMiddleware::class,
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -87,6 +87,8 @@ return [
             // Laravel HTTP middleware
             'middleware' => null,
 
+            'method' => ['get', 'post'],
+
             // An array of middlewares, overrides the global ones
             'execution_middleware' => null,
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -87,7 +87,8 @@ return [
             // Laravel HTTP middleware
             'middleware' => null,
 
-            'method' => ['get', 'post'],
+            // Which HTTP methods to support
+            'method' => ['GET', 'POST'],
 
             // An array of middlewares, overrides the global ones
             'execution_middleware' => null,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1221,6 +1221,11 @@ parameters:
 			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
 
 		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleSchemaWithMethod\\:\\:toConfig\\(\\) should return array\\(\\?'execution_middleware' \\=\\> array\\<class\\-string\\<Rebing\\\\GraphQL\\\\Support\\\\ExecutionMiddleware\\\\AbstractExecutionMiddleware\\>\\>, \\?'method' \\=\\> array\\<string\\>\\|string, \\?'middleware' \\=\\> array\\<string\\>, \\?'mutation' \\=\\> array\\<class\\-string\\>, 'query' \\=\\> array\\<class\\-string\\>, \\?'types' \\=\\> array\\<class\\-string\\>\\) but returns array\\<non\\-empty\\-string, array\\<string\\>\\|string\\>&nonEmpty\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExampleSchemaWithMethod.php
+
+		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleType\\:\\:\\$attributes has no typehint specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleType.php

--- a/src/Support/Contracts/ConfigConvertible.php
+++ b/src/Support/Contracts/ConfigConvertible.php
@@ -10,6 +10,7 @@ interface ConfigConvertible
     /**
      * @return array{
      *                execution_middleware?:array<class-string<AbstractExecutionMiddleware>>,
+     *                method?:string|string[],
      *                middleware?:array<string|class-string>,
      *                mutation?:array<string,class-string>|array<class-string>,
      *                query:array<string,class-string>|array<class-string>,

--- a/src/Support/Contracts/ConfigConvertible.php
+++ b/src/Support/Contracts/ConfigConvertible.php
@@ -9,11 +9,11 @@ interface ConfigConvertible
 {
     /**
      * @return array{
-     *                query:array<string,class-string>|array<class-string>,
-     *                mutation?:array<string,class-string>|array<class-string>,
-     *                types?:array<string,class-string>|array<class-string>,
+     *                execution_middleware?:array<class-string<AbstractExecutionMiddleware>>,
      *                middleware?:array<string|class-string>,
-     *                execution_middleware?:array<class-string<AbstractExecutionMiddleware>>
+     *                mutation?:array<string,class-string>|array<class-string>,
+     *                query:array<string,class-string>|array<class-string>,
+     *                types?:array<string,class-string>|array<class-string>
      *                }
      */
     public function toConfig(): array;

--- a/src/routes.php
+++ b/src/routes.php
@@ -32,6 +32,7 @@ if ($routeConfig) {
             $defaultSchema = $config->get('graphql.default_schema', 'default');
 
             foreach ($schemas as $schemaName => $schemaConfig) {
+                $method = $schemaConfig['method'] ?? ['GET', 'POST'];
                 $actions = array_filter([
                     'uses' => $schemaConfig['controller'] ?? $routeConfig['controller'] ?? GraphQLController::class . '@query',
                     'middleware' => $schemaConfig['middleware'] ?? $routeConfig['middleware'] ?? null,
@@ -39,7 +40,7 @@ if ($routeConfig) {
 
                 // Add route for each schema…
                 $router->addRoute(
-                    ['GET', 'POST'],
+                    $method,
                     $schemaName,
                     $actions + ['as' => "graphql.$schemaName"]
                 );
@@ -47,7 +48,7 @@ if ($routeConfig) {
                 // … and the default schema against the group itself
                 if ($schemaName === $defaultSchema) {
                     $router->addRoute(
-                        ['GET', 'POST'],
+                        $method,
                         '',
                         $actions + ['as' => 'graphql']
                     );

--- a/tests/Support/Objects/ExampleSchemaWithMethod.php
+++ b/tests/Support/Objects/ExampleSchemaWithMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+class ExampleSchemaWithMethod extends ExampleSchema
+{
+    public function toConfig(): array
+    {
+        return array_merge(parent::toConfig(), ['method' => ['post']]);
+    }
+}

--- a/tests/Support/Objects/ExampleSchemaWithMethod.php
+++ b/tests/Support/Objects/ExampleSchemaWithMethod.php
@@ -7,6 +7,6 @@ class ExampleSchemaWithMethod extends ExampleSchema
 {
     public function toConfig(): array
     {
-        return array_merge(parent::toConfig(), ['method' => ['post']]);
+        return array_merge(parent::toConfig(), ['method' => ['POST']]);
     }
 }

--- a/tests/Unit/NoRoutesRegisteredTest.php
+++ b/tests/Unit/NoRoutesRegisteredTest.php
@@ -28,7 +28,7 @@ class NoRoutesRegisteredTest extends TestCase
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'with_methods' => [
-                    'method' => ['post'],
+                    'method' => ['POST'],
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'class_based' => ExampleSchema::class,

--- a/tests/Unit/NoRoutesRegisteredTest.php
+++ b/tests/Unit/NoRoutesRegisteredTest.php
@@ -7,6 +7,7 @@ use GraphQL\Utils\BuildSchema;
 use Illuminate\Routing\Router;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchemaWithMethod;
 use Rebing\GraphQL\Tests\TestCase;
 
 class NoRoutesRegisteredTest extends TestCase
@@ -27,9 +28,11 @@ class NoRoutesRegisteredTest extends TestCase
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'with_methods' => [
+                    'method' => ['post'],
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'class_based' => ExampleSchema::class,
+                'class_based_with_methods' => ExampleSchemaWithMethod::class,
                 'shorthand' => BuildSchema::build('
                     schema {
                         query: ShorthandExample

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleSchemaWithMethod;
 use Rebing\GraphQL\Tests\TestCase;
 
 class RoutesTest extends TestCase
@@ -30,9 +31,11 @@ class RoutesTest extends TestCase
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'with_methods' => [
+                    'method' => ['post'],
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'class_based' => ExampleSchema::class,
+                'class_based_with_methods' => ExampleSchemaWithMethod::class,
             ],
         ]);
     }
@@ -91,6 +94,17 @@ class RoutesTest extends TestCase
                     'HEAD',
                 ],
                 'uri' => 'graphql_test/class_based',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
+            ],
+            'graphql.class_based_with_methods' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/class_based_with_methods',
                 'middleware' => [
                     ExampleMiddleware::class,
                 ],

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -31,7 +31,7 @@ class RoutesTest extends TestCase
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'with_methods' => [
-                    'method' => ['post'],
+                    'method' => ['POST'],
                     'middleware' => [ExampleMiddleware::class],
                 ],
                 'class_based' => ExampleSchema::class,
@@ -78,9 +78,7 @@ class RoutesTest extends TestCase
             ],
             'graphql.with_methods' => [
                 'methods' => [
-                    'GET',
                     'POST',
-                    'HEAD',
                 ],
                 'uri' => 'graphql_test/with_methods',
                 'middleware' => [
@@ -100,9 +98,7 @@ class RoutesTest extends TestCase
             ],
             'graphql.class_based_with_methods' => [
                 'methods' => [
-                    'GET',
                     'POST',
-                    'HEAD',
                 ],
                 'uri' => 'graphql_test/class_based_with_methods',
                 'middleware' => [


### PR DESCRIPTION
## Summary
This was initially removed in https://github.com/rebing/graphql-laravel/pull/779
and fully cleaned up in https://github.com/rebing/graphql-laravel/pull/764
but there might be valid reasons to change this, e.g. if one desires
only POST HTTP methods for prevent basic CSRF attacks for GET requests.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
