### PR TITLE
Fix 'TypeNotFound' when an interface defined after another type where it is used

### DIFF
--- a/src/Support/Type.php
+++ b/src/Support/Type.php
@@ -97,19 +97,15 @@ abstract class Type implements TypeConvertible
     public function getAttributes(): array
     {
         $attributes = $this->attributes();
-        $interfaces = $this->interfaces();
 
-        $attributes = array_merge($this->attributes, [
+        return array_merge($this->attributes, [
             'fields' => function () {
                 return $this->getFields();
             },
+            'interfaces' => function () {
+                return $this->interfaces();
+            },
         ], $attributes);
-
-        if ($interfaces) {
-            $attributes['interfaces'] = $interfaces;
-        }
-
-        return $attributes;
     }
 
     /**

--- a/tests/Unit/TypeTest.php
+++ b/tests/Unit/TypeTest.php
@@ -47,6 +47,19 @@ class TypeTest extends TestCase
         $attributes['fields']();
     }
 
+    public function testGetAttributesInterfacesClosure(): void
+    {
+        $type = $this->getMockBuilder(ExampleType::class)
+            ->onlyMethods(['interfaces'])
+            ->getMock();
+
+        $type->expects(self::once())
+            ->method('interfaces');
+
+        $attributes = $type->getAttributes();
+        $attributes['interfaces']();
+    }
+
     public function testToArray(): void
     {
         $type = new ExampleType();


### PR DESCRIPTION
## Summary

Throws 'Rebing\GraphQL\Exception\TypeNotFound' when an interface defined in 'types' after another type where it is used.

To reproduce the bug put LikableInterfaceType::class under PostType::class in InterfaceTest::getEnvironmentSetUp() and run tests.

I think that the method 'interfaces' should be used in the same way as 'getFields'. A possible disadvantage of my version is that now there is always a 'interfaces' field in the array, which was not before. I did not dig deep into the webonyx library and am not sure that this will not break any functionality.

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
