### PR TITLE
Cache ttl is in seconds

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -215,7 +215,7 @@ return [
         // The cache prefix
         'cache_prefix' => config('cache.prefix') . ':graphql.apq',
 
-        // The cache ttl in minutes - See https://www.apollographql.com/docs/apollo-server/performance/apq/#adjusting-cache-time-to-live-ttl
+        // The cache ttl in seconds - See https://www.apollographql.com/docs/apollo-server/performance/apq/#adjusting-cache-time-to-live-ttl
         'cache_ttl' => 300,
     ],
 


### PR DESCRIPTION
## Summary
The apq cache_ttl is in seconds not minutes, so this PR updates the comment in the config file.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
