### PR TITLE
Add array type hint for $args in stub files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ CHANGELOG
 
   - `\Rebing\GraphQL\Support\ResolveInfoFieldsAndArguments` has been removed
   - `$getSelectFields` closure no longer takes a depth parameter
+
+- The `$args` argument, of the `handle` method of the execution middlewares requires `array` as type.  
+
 ### Added
 - Command to make an execution middleware [\#772 / mfn](https://github.com/rebing/graphql-laravel/pull/772)
 - Command to make a schema configuration [\#830 / matsn0w](https://github.com/rebing/graphql-laravel/pull/830)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ class UserType extends GraphQLType
             'email' => [
                 'type' => Type::string(),
                 'description' => 'The email of user',
-                'resolve' => function($root, $args) {
+                'resolve' => function($root, array $args) {
                     // If you want to resolve the field yourself,
                     // it can be done here
                     return strtolower($root->email);
@@ -397,7 +397,7 @@ class UserType extends GraphQLType
 
     // You can also resolve a field by declaring a method in the class
     // with the following format resolve[FIELD_NAME]Field()
-    protected function resolveEmailField($root, $args)
+    protected function resolveEmailField($root, array $args)
     {
         return strtolower($root->email);
     }
@@ -481,7 +481,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         if (isset($args['id'])) {
             return User::where('id' , $args['id'])->get();
@@ -568,7 +568,7 @@ class UpdateUserPasswordMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $user = User::find($args['id']);
         if(!$user) {
@@ -662,7 +662,7 @@ class UserProfilePhotoMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $file = $args['profilePicture'];
 
@@ -1049,7 +1049,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $info, SelectFields $fields, SomeClassThatDoLogging $logging)
+    public function resolve($root, array $args, $context, ResolveInfo $info, SelectFields $fields, SomeClassThatDoLogging $logging)
     {
         $logging->log('fetched user');
 
@@ -1100,7 +1100,7 @@ use Rebing\GraphQL\Support\Middleware;
 
 class ResolvePage extends Middleware
 {
-    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    public function handle($root, array $args, $context, ResolveInfo $info, Closure $next)
     {
         Paginator::currentPageResolver(function () use ($args) {
             return $args['pagination']['page'] ?? 1;
@@ -1181,7 +1181,7 @@ use Rebing\GraphQL\Support\Middleware;
 
 class Logstash extends Middleware
 {
-    public function terminate($root, $args, $context, ResolveInfo $info, $result): void
+    public function terminate($root, array $args, $context, ResolveInfo $info, $result): void
     {
         Log::channel('logstash')->info('', (
             collect([
@@ -1441,7 +1441,7 @@ class PictureField extends Field
         ];
     }
 
-    protected function resolve($root, $args)
+    protected function resolve($root, array $args)
     {
         $width = isset($args['width']) ? $args['width']:100;
         $height = isset($args['height']) ? $args['height']:100;
@@ -1530,7 +1530,7 @@ class FormattableDate extends Field
         ];
     }
 
-    protected function resolve($root, $args): ?string
+    protected function resolve($root, array $args): ?string
     {
         $date = $root->{$this->getProperty()};
 
@@ -1645,7 +1645,7 @@ class UsersQuery extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $info, Closure $getSelectFields)
     {
         /** @var SelectFields $fields */
         $fields = $getSelectFields();
@@ -1826,7 +1826,7 @@ class PostsQuery extends Query
 
     // ...
 
-    public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $info, Closure $getSelectFields)
     {
         $fields = $getSelectFields();
 
@@ -1878,7 +1878,7 @@ class PostsQuery extends Query
 
     // ...
 
-    public function resolve($root, $args, $context, ResolveInfo $info, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $info, Closure $getSelectFields)
     {
         $fields = $getSelectFields();
 
@@ -2379,7 +2379,7 @@ class UpdateUserMutation extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $user = User::find($args['id']);
         $user->fill($args['input']));
@@ -2828,7 +2828,7 @@ public function type(): Type
     );
 }
 
-public function resolve($root, $args)
+public function resolve($root, array $args)
 {
     return [
         'data' => Post::find($args['post_id']),

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -18,7 +18,7 @@ class DummyClass extends Field
         return Type::string();
     }
 
-    public function resolve($root, $args): string
+    public function resolve($root, array $args): string
     {
         return 'test';
     }

--- a/src/Console/stubs/middleware.stub
+++ b/src/Console/stubs/middleware.stub
@@ -10,7 +10,7 @@ use Rebing\GraphQL\Support\Middleware;
 
 class DummyClass extends Middleware
 {
-    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    public function handle($root, array $args, $context, ResolveInfo $info, Closure $next)
     {
         return $next($root, $args, $context, $info);
     }

--- a/src/Console/stubs/mutation.stub
+++ b/src/Console/stubs/mutation.stub
@@ -29,7 +29,7 @@ class DummyClass extends Mutation
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         $fields = $getSelectFields();
         $select = $fields->getSelect();

--- a/src/Console/stubs/query.stub
+++ b/src/Console/stubs/query.stub
@@ -29,7 +29,7 @@ class DummyClass extends Query
         ];
     }
 
-    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    public function resolve($root, array $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
     {
         /** @var SelectFields $fields */
         $fields = $getSelectFields();

--- a/src/Support/Middleware.php
+++ b/src/Support/Middleware.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 abstract class Middleware
 {
-    public function handle($root, $args, $context, ResolveInfo $info, Closure $next)
+    public function handle($root, array $args, $context, ResolveInfo $info, Closure $next)
     {
         return $next($root, $args, $context, $info);
     }


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
The $args argument in the stub files could be type hinted as array. The return value of Rebing\GraphQL\Support\Field::getArgs is passed, which always is an array.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
