### PR TITLE
Upgrade to phpstan 1.* / larastan 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,15 @@
         "laragraph/utils": "^1"
     },
     "require-dev": {
-        "orchestra/testbench": "4.0.*|5.0.*|^6.0",
-        "phpunit/phpunit": "~7.0|~8.0|^9",
-        "nunomaduro/larastan": "^0",
-        "mockery/mockery": "^1.2",
-        "friendsofphp/php-cs-fixer": "^3",
         "ext-pdo_sqlite": "*",
+        "friendsofphp/php-cs-fixer": "^3",
         "laravel/legacy-factories": "^1.0",
-        "mfn/php-cs-fixer-config": "^2"
+        "mfn/php-cs-fixer-config": "^2",
+        "mockery/mockery": "^1.2",
+        "nunomaduro/larastan": "^1",
+        "orchestra/testbench": "4.0.*|5.0.*|^6.0",
+        "phpstan/phpstan": "^1",
+        "phpunit/phpunit": "~7.0|~8.0|^9"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,11 +191,6 @@ parameters:
 			path: src/Support/Rules.php
 
 		-
-			message: "#^Binary operation \"\\.\" between non\\-empty\\-string and array\\|string\\|null results in an error\\.$#"
-			count: 1
-			path: src/Support/SelectFields.php
-
-		-
 			message: "#^Instanceof between \\*NEVER\\* and string will always evaluate to false\\.$#"
 			count: 1
 			path: src/Support/SelectFields.php
@@ -291,7 +286,7 @@ parameters:
 			path: src/Support/SelectFields.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func expects callable\\(\\)\\: mixed, array\\(\\*NEVER\\*, mixed\\) given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function call_user_func expects callable\\(\\)\\: mixed, array\\{\\*NEVER\\*, mixed\\} given\\.$#"
 			count: 1
 			path: src/Support/SelectFields.php
 
@@ -321,7 +316,7 @@ parameters:
 			path: src/Support/Type.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\(\\$this\\(Rebing\\\\GraphQL\\\\Support\\\\Type\\), non\\-empty\\-string\\) given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{\\$this\\(Rebing\\\\GraphQL\\\\Support\\\\Type\\), non\\-empty\\-string\\} given\\.$#"
 			count: 1
 			path: src/Support/Type.php
 
@@ -781,7 +776,7 @@ parameters:
 			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleSchemaWithMethod\\:\\:toConfig\\(\\) should return array\\(\\?'execution_middleware' \\=\\> array\\<class\\-string\\<Rebing\\\\GraphQL\\\\Support\\\\ExecutionMiddleware\\\\AbstractExecutionMiddleware\\>\\>, \\?'method' \\=\\> array\\<string\\>\\|string, \\?'middleware' \\=\\> array\\<string\\>, \\?'mutation' \\=\\> array\\<class\\-string\\>, 'query' \\=\\> array\\<class\\-string\\>, \\?'types' \\=\\> array\\<class\\-string\\>\\) but returns array\\<literal\\-string&non\\-empty\\-string, array\\<string\\>\\|string\\>&nonEmpty\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleSchemaWithMethod\\:\\:toConfig\\(\\) should return array\\{execution_middleware\\?\\: array\\<class\\-string\\<Rebing\\\\GraphQL\\\\Support\\\\ExecutionMiddleware\\\\AbstractExecutionMiddleware\\>\\>, method\\?\\: array\\<string\\>\\|string, middleware\\?\\: array\\<string\\>, mutation\\?\\: array\\<class\\-string\\>, query\\: array\\<class\\-string\\>, types\\?\\: array\\<class\\-string\\>\\} but returns non\\-empty\\-array\\<literal\\-string&non\\-empty\\-string, array\\<string\\>\\|string\\>\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleSchemaWithMethod.php
 
@@ -937,16 +932,6 @@ parameters:
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
-			count: 1
-			path: tests/Support/Objects/ExamplesPaginationQuery.php
-
-		-
-			message: "#^Parameter \\#1 \\$offset of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:slice\\(\\) expects int, float\\|int given\\.$#"
-			count: 1
-			path: tests/Support/Objects/ExamplesPaginationQuery.php
-
-		-
-			message: "#^Parameter \\#4 \\$currentPage of class Illuminate\\\\Pagination\\\\LengthAwarePaginator constructor expects int\\|null, float\\|int given\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
@@ -1331,14 +1316,9 @@ parameters:
 			path: tests/Unit/ExecutionMiddlewareTest/ChangeVariableMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Unit/FieldTest.php
-
-		-
-			message: "#^Unable to resolve the template type RealInstanceType in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
-			count: 1
-			path: tests/Unit/FieldTest.php
+			message: "#^Parameter \\#1 \\$abstract of function app expects string\\|null, object\\|string given\\.$#"
+			count: 3
+			path: tests/Unit/GraphQLTest.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
@@ -1401,12 +1381,37 @@ parameters:
 			path: tests/Unit/MutationCustomRulesTests/RuleObject.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
-			count: 1
+			message: "#^Relation 'test' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 7
 			path: tests/Unit/MutationTest.php
 
 		-
-			message: "#^Unable to resolve the template type RealInstanceType in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
+			message: "#^Relation 'test_with_rules' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 6
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Relation 'test_with_rules_closure' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 7
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Relation 'test_with_rules_non_nullable_input_object' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 14
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Relation 'test_with_rules_non_nullable_list_of_non_nullable_input_object' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 3
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Relation 'test_with_rules_nullable_input_object' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 4
+			path: tests/Unit/MutationTest.php
+
+		-
+			message: "#^Return type \\(class\\-string\\<Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\UpdateExampleMutationWithInputType\\>\\) of method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationTest\\:\\:getFieldClass\\(\\) should be compatible with return type \\(class\\-string\\<Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\>\\) of method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\)$#"
 			count: 1
 			path: tests/Unit/MutationTest.php
 
@@ -1421,7 +1426,7 @@ parameters:
 			path: tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectPass.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\QueryTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
+			message: "#^Return type \\(class\\-string\\<Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\>\\) of method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\QueryTest\\:\\:getFieldClass\\(\\) should be compatible with return type \\(class\\-string\\<Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\>\\) of method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\)$#"
 			count: 1
 			path: tests/Unit/QueryTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 			path: src/Support/AliasArguments/AliasArguments.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$prefix with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\AliasArguments\\\\AliasArguments\\:\\:getAliasesInFields\\(\\) has parameter \\$prefix with no type specified\\.$#"
 			count: 1
 			path: src/Support/AliasArguments/AliasArguments.php
 
@@ -81,7 +81,7 @@ parameters:
 			path: src/Support/Field.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:__set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:__set\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: src/Support/Field.php
 
@@ -141,22 +141,22 @@ parameters:
 			path: src/Support/Field.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Support/Middleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: src/Support/Middleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:handle\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: src/Support/Middleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Middleware\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Support/Middleware.php
 
@@ -181,7 +181,7 @@ parameters:
 			path: src/Support/PaginationType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Privacy\\:\\:fire\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Privacy\\:\\:fire\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: src/Support/Privacy.php
 
@@ -336,7 +336,7 @@ parameters:
 			path: src/Support/UploadType.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLContext\\:\\:\\$data has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLContext\\:\\:\\$data has no type specified\\.$#"
 			count: 1
 			path: tests/Database/AuthorizeArgsTests/GraphQLContext.php
 
@@ -356,137 +356,137 @@ parameters:
 			path: tests/Database/MutationValidationUniqueWithCustomRulesTests/RuleObjectPass.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysRelationTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysRelationTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\AlwaysTests\\\\AlwaysQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/AlwaysTests/AlwaysQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ArrayTests\\\\ArrayQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ArrayTests/ArrayQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ComputedPropertiesTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ComputedPropertiesTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\DepthTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/DepthTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/ExampleInterfaceType.php
 
@@ -501,12 +501,12 @@ parameters:
 			path: tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
 
@@ -516,187 +516,187 @@ parameters:
 			path: tests/Database/SelectFields/InterfaceTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\InterfaceTests\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/InterfaceTests/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\LikableInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/LikableInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\MorphRelationshipTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/MorphRelationshipTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\NestedRelationLoadingTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/NestedRelationLoadingTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\PrimaryKeyTests\\\\PrimaryKeyQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyQuery.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\GraphQLContext\\:\\:\\$data has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\GraphQLContext\\:\\:\\$data has no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/QueryArgsAndContextTests/GraphQLContext.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\QueryArgsAndContextTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateFieldTests\\\\ValidateFieldsQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateFieldTests/ValidateFieldsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/CustomExamplesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/CustomExamplesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\CustomExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/CustomExamplesQuery.php
 
@@ -706,12 +706,12 @@ parameters:
 			path: tests/Support/Objects/ErrorFormatter.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleField.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleField\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleField.php
 
@@ -721,7 +721,7 @@ parameters:
 			path: tests/Support/Objects/ExampleField.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleInterfaceType\\:\\:resolveType\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleInterfaceType.php
 
@@ -731,47 +731,47 @@ parameters:
 			path: tests/Support/Objects/ExampleInterfaceType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:handle\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$result with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$result with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleMiddleware\\:\\:terminate\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleNestedValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleNestedValidationInputObject.php
 
@@ -786,22 +786,22 @@ parameters:
 			path: tests/Support/Objects/ExampleSchemaWithMethod.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleUnionType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleUnionType\\:\\:resolveType\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleUnionType.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleValidationField.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationField\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleValidationField.php
 
@@ -811,12 +811,12 @@ parameters:
 			path: tests/Support/Objects/ExampleValidationField.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleValidationInputObject.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleValidationInputObject.php
 
@@ -831,22 +831,22 @@ parameters:
 			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeMessageQuery.php
 
@@ -856,52 +856,52 @@ parameters:
 			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesAuthorizeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesConfigAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesConfigAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesFilteredQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesFilteredQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesFilteredQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesFilteredQuery.php
 
@@ -911,32 +911,32 @@ parameters:
 			path: tests/Support/Objects/ExamplesFilteredQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesMiddlewareQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesMiddlewareQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesMiddlewareQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesMiddlewareQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesPaginationQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
@@ -951,252 +951,252 @@ parameters:
 			path: tests/Support/Objects/ExamplesPaginationQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExamplesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostNonNullWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostNonNullWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithNonInjectableTypehintsQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithNonInjectableTypehintsQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostQueryWithSelectFieldsClassInjectionQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostQueryWithSelectFieldsClassInjectionQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasAndCustomResolverQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasCallbackQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasCallbackQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelAndAliasQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelAndAliasQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostWithSelectFieldsNoModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostWithSelectFieldsNoModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListAndNonNullOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Queries\\\\PostsNonNullAndListOfWithSelectFieldsAndModelQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Support/Queries/PostsNonNullAndListOfWithSelectFieldsAndModelQuery.php
 
@@ -1206,27 +1206,27 @@ parameters:
 			path: tests/Support/Types/MyCustomScalarString.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchema\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchema\\(\\) has parameter \\$schema with no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$key with no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasMutation\\(\\) has parameter \\$schema with no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$key with no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$schema with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:assertGraphQLSchemaHasQuery\\(\\) has parameter \\$schema with no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
@@ -1236,12 +1236,12 @@ parameters:
 			path: tests/TestCase.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$data has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$data has no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$queries has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\TestCase\\:\\:\\$queries has no type specified\\.$#"
 			count: 1
 			path: tests/TestCase.php
 
@@ -1251,17 +1251,17 @@ parameters:
 			path: tests/TestCaseDatabase.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/AliasArguments/Stubs/UpdateExampleMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/AliasArguments/Stubs/UpdateExampleMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\AliasArguments\\\\Stubs\\\\UpdateExampleMutation\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/AliasArguments/Stubs/UpdateExampleMutation.php
 
@@ -1316,12 +1316,12 @@ parameters:
 			path: tests/Unit/Console/UnionMakeCommandTest.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\EngineErrorInResolverTests\\\\QueryWithEngineErrorInCodeQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/EngineErrorInResolverTests/QueryWithEngineErrorInCodeQuery.php
 
@@ -1331,7 +1331,7 @@ parameters:
 			path: tests/Unit/ExecutionMiddlewareTest/ChangeVariableMiddleware.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\FieldTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/FieldTest.php
 
@@ -1351,27 +1351,27 @@ parameters:
 			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:\\$defaultFormat has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\FormattableDate\\:\\:\\$defaultFormat has no type specified\\.$#"
 			count: 1
 			path: tests/Unit/InstantiableTypesTest/FormattableDate.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/InstantiableTypesTest/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/InstantiableTypesTest/UserQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\InstantiableTypesTest\\\\UserQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/InstantiableTypesTest/UserQuery.php
 
@@ -1386,12 +1386,12 @@ parameters:
 			path: tests/Unit/LaravelValidatorTests/RuleObjectPass.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationCustomRulesTests\\\\MutationWithCustomRuleWithClosure\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/MutationCustomRulesTests/MutationWithCustomRuleWithClosure.php
 
@@ -1401,7 +1401,7 @@ parameters:
 			path: tests/Unit/MutationCustomRulesTests/RuleObject.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\MutationTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/MutationTest.php
 
@@ -1421,17 +1421,17 @@ parameters:
 			path: tests/Unit/MutationValidationInWithCustomRulesTests/RuleObjectPass.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\QueryTest\\:\\:getFieldClass\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\QueryTest\\:\\:getFieldClass\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/QueryTest.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\TypesInSchemas\\\\SchemaOne\\\\Query\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\TypesInSchemas\\\\SchemaOne\\\\Query\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/TypesInSchemas/SchemaOne/Query.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\TypesInSchemas\\\\SchemaTwo\\\\Query\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\TypesInSchemas\\\\SchemaTwo\\\\Query\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/TypesInSchemas/SchemaTwo/Query.php
 
@@ -1441,12 +1441,12 @@ parameters:
 			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadMultipleFilesMutation\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
 
@@ -1456,12 +1456,12 @@ parameters:
 			path: tests/Unit/UploadTests/UploadMultipleFilesMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
 
@@ -1476,32 +1476,32 @@ parameters:
 			path: tests/Unit/ValidationAuthorizationTests/ValidationAndAuthorizationMutation.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
 
 		-
-			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\PostMessagesQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/PostMessagesQuery.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$code has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$code has no type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/SimpleMessage.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$message has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$message has no type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/SimpleMessage.php
 
 		-
-			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$type has no typehint specified\\.$#"
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\WithTypeTests\\\\SimpleMessage\\:\\:\\$type has no type specified\\.$#"
 			count: 1
 			path: tests/Unit/WithTypeTests/SimpleMessage.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,7 +171,7 @@ parameters:
 			path: src/Support/Middleware.php
 
 		-
-			message: "#^Anonymous function never returns null so it can be removed from the return typehint\\.$#"
+			message: "#^Anonymous function never returns null so it can be removed from the return type\\.$#"
 			count: 2
 			path: src/Support/PaginationType.php
 
@@ -306,7 +306,7 @@ parameters:
 			path: src/Support/SelectFields.php
 
 		-
-			message: "#^Anonymous function never returns null so it can be removed from the return typehint\\.$#"
+			message: "#^Anonymous function never returns null so it can be removed from the return type\\.$#"
 			count: 2
 			path: src/Support/SimplePaginationType.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
     checkModelProperties: true
     ignoreErrors:
         - '/Call to an undefined method Illuminate\\Testing\\TestResponse::(content|getData|getStatusCode)\(\)/'
-        - '/Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::getAttributes\(\)/'
         # tests/Unit/GraphQLTest.php
         - '/Call to an undefined method GraphQL\\Type\\Definition\\Type::getFields\(\)/'
         - '/Call to an undefined method Mockery\\/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,7 @@ includes:
     - ./phpstan-baseline.neon
     - ./vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
-    level: max
+    level: 8
     tmpDir: tmp/phpstan/
     paths:
         - src/

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -473,7 +473,7 @@ class GraphQL
      *
      * @param string $typeName The original type name
      * @param string $customTypeName The new type name
-     * @param string $wrapperTypeClass The class to create the new type
+     * @param class-string<Type> $wrapperTypeClass The class to create the new type
      */
     public function wrapType(string $typeName, string $customTypeName, string $wrapperTypeClass): Type
     {

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -253,6 +253,9 @@ abstract class Field
         return new $selectFieldsClass($this->type(), $arguments[1], $ctx, $fieldsAndArguments);
     }
 
+    /**
+     * @return class-string<SelectFields>
+     */
     protected function selectFieldClass(): string
     {
         return SelectFields::class;

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -11,6 +11,9 @@ use Rebing\GraphQL\Tests\TestCase;
 
 class FieldTest extends TestCase
 {
+    /**
+     * @return class-string<ExampleField>
+     */
     protected function getFieldClass()
     {
         return ExampleField::class;

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -16,6 +16,9 @@ use Rebing\GraphQL\Tests\Support\Objects\UpdateExampleMutationWithInputType;
 
 class MutationTest extends FieldTest
 {
+    /**
+     * @return class-string<UpdateExampleMutationWithInputType>
+     */
     protected function getFieldClass()
     {
         return UpdateExampleMutationWithInputType::class;

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -8,6 +8,9 @@ use Rebing\GraphQL\Tests\Support\Objects\ExampleType;
 
 class QueryTest extends FieldTest
 {
+    /**
+     * @return class-string<ExamplesQuery>
+     */
     protected function getFieldClass()
     {
         return ExamplesQuery::class;


### PR DESCRIPTION
## Summary
- Couldn't work with `level: max` anymore in phpstan, it's too brutal; lowered to 9
- explicitly depend on phpstan, as we're using it for good too

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
