### PR TITLE
Ignore .php-cs-fixer.dist.php in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 /.github export-ignore
-/.php_cs.dist export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /docker-compose-dev.yml export-ignore
 /Dockerfile.dev export-ignore
 /example export-ignore


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
The config file .php_cs.dist has been renamed in #825. This PR applies that change to .gitattributes as well.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
