### PR TITLE
Don't require a return value for the query option of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1792,8 +1792,9 @@ class UserType extends GraphQLType
                 // $args are the local arguments passed to the relation
                 // $query is the relation builder object
                 // $ctx is the GraphQL context (can be customized by overriding `\Rebing\GraphQL\GraphQLController::queryContext`
-                'query'         => function(array $args, $query, $ctx) {
-                    return $query->where('posts.created_at', '>', $args['date_from']);
+                // The return value should be the query builder or void
+                'query'         => function (array $args, $query, $ctx): void {
+                    $query->where('posts.created_at', '>', $args['date_from']);
                 }
             ]
         ];

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -99,7 +99,7 @@ class SelectFields
 
         return function ($query) use ($with, $select, $customQuery, $requestedFields, $ctx): void {
             if ($customQuery) {
-                $query = $customQuery($requestedFields['args'], $query, $ctx);
+                $query = $customQuery($requestedFields['args'], $query, $ctx) ?? $query;
             }
 
             $query->select($select);

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/PostType.php
@@ -29,14 +29,12 @@ class PostType extends GraphQLType
                         'type' => Type::boolean(),
                     ],
                 ],
-                'query' => function (array $args, HasMany $query, GraphQLContext $ctx): HasMany {
+                'query' => function (array $args, HasMany $query, GraphQLContext $ctx): void {
                     if (isset($ctx->data['flag'])) {
                         $query->where('comments.flag', '=', $ctx->data['flag']);
                     } elseif (isset($args['flag'])) {
                         $query->where('comments.flag', '=', $args['flag']);
                     }
-
-                    return $query;
                 },
             ],
             'id' => [


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
The field's `query` option acts like Laravel's query builder scope, but unlike a scope it currently requires the query builder as return value. If omitted (as I've done several times out of habit), you get a non-descriptive error: "Call to a member function select() on null". With this PR the query builder object will just be used if none was returned.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
