### PR TITLE
Add support for field directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 [Next release](https://github.com/rebing/graphql-laravel/compare/8.0.0...master)
 --------------
 
+### Added
+- Support for field directives [\#860 / sforward](https://github.com/rebing/graphql-laravel/pull/860)
+
 2021-11-15, 8.0.0
 -----------------
 

--- a/config/config.php
+++ b/config/config.php
@@ -83,6 +83,9 @@ return [
             'types' => [
                 // ExampleType::class,
             ],
+            'directives' => [
+                // ExampleDirective::class,
+            ],
 
             // Laravel HTTP middleware
             'middleware' => null,

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -382,14 +382,9 @@ class GraphQL
 
         $directives = Directive::getInternalDirectives();
 
-        foreach ($schemaDirectives as $name => $class) {
+        foreach ($schemaDirectives as $class) {
             $directive = $this->app->make($class);
-
-            if (!\is_string($name)) {
-                $name = $directive->name;
-            }
-
-            $directives[$name] = $directive;
+            $directives[$directive->name] = $directive;
         }
 
         return new Schema([

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -26,6 +26,7 @@ use Rebing\GraphQL\Exception\SchemaNotFound;
 use Rebing\GraphQL\Exception\TypeNotFound;
 use Rebing\GraphQL\Support\Contracts\ConfigConvertible;
 use Rebing\GraphQL\Support\Contracts\TypeConvertible;
+use Rebing\GraphQL\Support\Directive;
 use Rebing\GraphQL\Support\ExecutionMiddleware\GraphqlExecutionMiddleware;
 use Rebing\GraphQL\Support\Field;
 use Rebing\GraphQL\Support\OperationParams;
@@ -363,6 +364,7 @@ class GraphQL
         $schemaMutation = $schemaConfig['mutation'] ?? [];
         $schemaSubscription = $schemaConfig['subscription'] ?? [];
         $schemaTypes = $schemaConfig['types'] ?? [];
+        $schemaDirectives = $schemaConfig['directives'] ?? [];
 
         $this->addTypes($schemaTypes);
 
@@ -378,10 +380,23 @@ class GraphQL
             ? $this->objectType($schemaSubscription, ['name' => 'Subscription'])
             : null;
 
+        $directives = Directive::getInternalDirectives();
+
+        foreach ($schemaDirectives as $name => $class) {
+            $directive = $this->app->make($class);
+
+            if (!\is_string($name)) {
+                $name = $directive->name;
+            }
+
+            $directives[$name] = $directive;
+        }
+
         return new Schema([
             'query' => $query,
             'mutation' => $mutation,
             'subscription' => $subscription,
+            'directives' => $directives,
             'types' => function () {
                 $types = [];
 

--- a/src/Support/Directive.php
+++ b/src/Support/Directive.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Support;
+
+abstract class Directive extends \GraphQL\Type\Definition\Directive
+{
+    /** @var array */
+    protected $attributes = [];
+
+    public function __construct()
+    {
+        $config = [
+            'locations' => $this->locations(),
+            'args' => $this->args(),
+        ];
+
+        parent::__construct(array_merge($this->attributes, $config));
+    }
+
+    /**
+     * Specify the arguments for this directive.
+     */
+    public function args(): array
+    {
+        return [];
+    }
+
+    /**
+     * Specify the locations where this directive can be applied.
+     */
+    abstract public function locations(): array;
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    abstract public function handle($value, array $args = []);
+}

--- a/src/Support/Directive.php
+++ b/src/Support/Directive.php
@@ -5,7 +5,7 @@ namespace Rebing\GraphQL\Support;
 
 abstract class Directive extends \GraphQL\Type\Definition\Directive
 {
-    /** @var array */
+    /** @var array<string, string> */
     protected $attributes = [];
 
     public function __construct()
@@ -20,6 +20,8 @@ abstract class Directive extends \GraphQL\Type\Definition\Directive
 
     /**
      * Specify the arguments for this directive.
+     *
+     * @return array<array<string, mixed>>
      */
     public function args(): array
     {
@@ -28,11 +30,14 @@ abstract class Directive extends \GraphQL\Type\Definition\Directive
 
     /**
      * Specify the locations where this directive can be applied.
+     *
+     * @return array<string>
      */
     abstract public function locations(): array;
 
     /**
      * @param mixed $value
+     * @param array<string, mixed> $args
      *
      * @return mixed
      */

--- a/src/Support/ExecutionMiddleware/GraphqlExecutionMiddleware.php
+++ b/src/Support/ExecutionMiddleware/GraphqlExecutionMiddleware.php
@@ -8,6 +8,7 @@ use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL as GraphQLBase;
 use GraphQL\Type\Schema;
 use Illuminate\Contracts\Config\Repository;
+use Rebing\GraphQL\Support\FieldResolver\FieldResolver;
 use Rebing\GraphQL\Support\OperationParams;
 
 /**
@@ -27,8 +28,13 @@ class GraphqlExecutionMiddleware extends AbstractExecutionMiddleware
     {
         $query = $params->getParsedQuery();
 
-        $defaultFieldResolver = $this->config->get('graphql.defaultFieldResolver');
+        $defaultFieldResolver = $this->getDefaultFieldResolver($schema);
 
         return GraphQLBase::executeQuery($schema, $query, $rootValue, $contextValue, $params->variables, $params->operation, $defaultFieldResolver);
+    }
+
+    private function getDefaultFieldResolver(Schema $schema): callable
+    {
+        return $this->config->get('graphql.defaultFieldResolver') ?? app(FieldResolver::class)->setSchema($schema);
     }
 }

--- a/src/Support/FieldResolver/DirectiveHandler.php
+++ b/src/Support/FieldResolver/DirectiveHandler.php
@@ -30,11 +30,17 @@ class DirectiveHandler
         return $this->directives[$name] ?? null;
     }
 
+    /**
+     * @param mixed $property
+     * @param \GraphQL\Type\Definition\ResolveInfo $info
+     *
+     * @return mixed
+     */
     public function applyDirectives($property, ResolveInfo $info)
     {
         $fieldNode = $info->fieldNodes[0];
 
-        foreach ($fieldNode->directives ?? [] as $directiveNode) {
+        foreach ($fieldNode->directives as $directiveNode) {
             $directive = $this->getDirective($directiveNode->name->value);
 
             if ($directive instanceof \Rebing\GraphQL\Support\Directive) {
@@ -48,6 +54,11 @@ class DirectiveHandler
         return $property;
     }
 
+    /**
+     * @param array<string, mixed> $variableValues
+     *
+     * @return array<string, mixed>
+     */
     protected function getDirectiveArguments(DirectiveNode $directiveNode, Directive $directive, array $variableValues): array
     {
         return Values::getArgumentValues(

--- a/src/Support/FieldResolver/DirectiveHandler.php
+++ b/src/Support/FieldResolver/DirectiveHandler.php
@@ -32,7 +32,6 @@ class DirectiveHandler
 
     /**
      * @param mixed $property
-     * @param \GraphQL\Type\Definition\ResolveInfo $info
      *
      * @return mixed
      */

--- a/src/Support/FieldResolver/DirectiveHandler.php
+++ b/src/Support/FieldResolver/DirectiveHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Support\FieldResolver;
+
+use GraphQL\Executor\Values;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Schema;
+
+class DirectiveHandler
+{
+    /** @var array<\GraphQL\Type\Definition\Directive> */
+    private $directives;
+
+    public function loadDirectivesBySchema(Schema $schema): self
+    {
+        $this->directives = [];
+
+        foreach ($schema->getDirectives() as $directive) {
+            $this->directives[$directive->name] = $directive;
+        }
+
+        return $this;
+    }
+
+    public function getDirective(string $name): ?Directive
+    {
+        return $this->directives[$name] ?? null;
+    }
+
+    public function applyDirectives($property, ResolveInfo $info)
+    {
+        $fieldNode = $info->fieldNodes[0];
+
+        foreach ($fieldNode->directives ?? [] as $directiveNode) {
+            $directive = $this->getDirective($directiveNode->name->value);
+
+            if ($directive instanceof \Rebing\GraphQL\Support\Directive) {
+                $property = $directive->handle(
+                    $property,
+                    $this->getDirectiveArguments($directiveNode, $directive, $info->variableValues)
+                );
+            }
+        }
+
+        return $property;
+    }
+
+    protected function getDirectiveArguments(DirectiveNode $directiveNode, Directive $directive, array $variableValues): array
+    {
+        return Values::getArgumentValues(
+            $directive,
+            $directiveNode,
+            $variableValues
+        );
+    }
+}

--- a/src/Support/FieldResolver/FieldResolver.php
+++ b/src/Support/FieldResolver/FieldResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Support\FieldResolver;
+
+use GraphQL\Executor\Executor;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Schema;
+
+class FieldResolver extends Executor
+{
+    /** @var \Rebing\GraphQL\Support\FieldResolver\DirectiveHandler */
+    private $directiveHandler;
+
+    public function __construct(DirectiveHandler $directiveHandler)
+    {
+        $this->directiveHandler = $directiveHandler;
+    }
+
+    public function setSchema(Schema $schema): self
+    {
+        $this->directiveHandler->loadDirectivesBySchema($schema);
+
+        return $this;
+    }
+
+    public function __invoke($objectValue, $args, $contextValue, ResolveInfo $info)
+    {
+        $property = self::defaultFieldResolver($objectValue, $args, $contextValue, $info);
+
+        return $this->directiveHandler->applyDirectives($property, $info);
+    }
+}

--- a/src/Support/FieldResolver/FieldResolver.php
+++ b/src/Support/FieldResolver/FieldResolver.php
@@ -24,7 +24,14 @@ class FieldResolver extends Executor
         return $this;
     }
 
-    public function __invoke($objectValue, $args, $contextValue, ResolveInfo $info)
+    /**
+     * @param mixed $objectValue
+     * @param array<string, mixed> $args
+     * @param mixed|null $contextValue
+     *
+     * @return mixed
+     */
+    public function __invoke($objectValue, array $args, $contextValue, ResolveInfo $info)
     {
         $property = self::defaultFieldResolver($objectValue, $args, $contextValue, $info);
 

--- a/tests/Support/Directives/LowerCaseDirective.php
+++ b/tests/Support/Directives/LowerCaseDirective.php
@@ -8,11 +8,17 @@ use Rebing\GraphQL\Support\Directive;
 
 class LowerCaseDirective extends Directive
 {
+    /**
+     * @var array<string, string>
+     */
     protected $attributes = [
         'name' => 'lower',
         'description' => 'The lower directive.',
     ];
 
+    /**
+     * @return array<string>
+     */
     public function locations(): array
     {
         return [
@@ -20,6 +26,9 @@ class LowerCaseDirective extends Directive
         ];
     }
 
+    /**
+     * @param array<mixed> $args
+     */
     public function handle($value, array $args = []): ?string
     {
         if (\is_string($value)) {

--- a/tests/Support/Directives/LowerCaseDirective.php
+++ b/tests/Support/Directives/LowerCaseDirective.php
@@ -8,9 +8,7 @@ use Rebing\GraphQL\Support\Directive;
 
 class LowerCaseDirective extends Directive
 {
-    /**
-     * @var array<string, string>
-     */
+    /** @var array<string, string> */
     protected $attributes = [
         'name' => 'lower',
         'description' => 'The lower directive.',

--- a/tests/Support/Directives/LowerCaseDirective.php
+++ b/tests/Support/Directives/LowerCaseDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Directives;
+
+use GraphQL\Language\DirectiveLocation;
+use Rebing\GraphQL\Support\Directive;
+
+class LowerCaseDirective extends Directive
+{
+    protected $attributes = [
+        'name' => 'lower',
+        'description' => 'The lower directive.',
+    ];
+
+    public function locations(): array
+    {
+        return [
+            DirectiveLocation::FIELD,
+        ];
+    }
+
+    public function handle($value, array $args = []): ?string
+    {
+        if (\is_string($value)) {
+            return strtolower($value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Support/Directives/TrimDirective.php
+++ b/tests/Support/Directives/TrimDirective.php
@@ -9,9 +9,7 @@ use Rebing\GraphQL\Support\Directive;
 
 class TrimDirective extends Directive
 {
-    /**
-     * @var array<string, string>
-     */
+    /** @var array<string, string> */
     protected $attributes = [
         'name' => 'trim',
         'description' => 'The trim directive.',

--- a/tests/Support/Directives/TrimDirective.php
+++ b/tests/Support/Directives/TrimDirective.php
@@ -9,11 +9,17 @@ use Rebing\GraphQL\Support\Directive;
 
 class TrimDirective extends Directive
 {
+    /**
+     * @var array<string, string>
+     */
     protected $attributes = [
         'name' => 'trim',
         'description' => 'The trim directive.',
     ];
 
+    /**
+     * @return array<string>
+     */
     public function locations(): array
     {
         return [
@@ -21,6 +27,9 @@ class TrimDirective extends Directive
         ];
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function args(): array
     {
         return [
@@ -31,6 +40,9 @@ class TrimDirective extends Directive
         ];
     }
 
+    /**
+     * @param array<mixed> $args
+     */
     public function handle($value, array $args = []): string
     {
         if (isset($args['chars'])) {

--- a/tests/Support/Directives/TrimDirective.php
+++ b/tests/Support/Directives/TrimDirective.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Directives;
+
+use GraphQL\Language\DirectiveLocation;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Directive;
+
+class TrimDirective extends Directive
+{
+    protected $attributes = [
+        'name' => 'trim',
+        'description' => 'The trim directive.',
+    ];
+
+    public function locations(): array
+    {
+        return [
+            DirectiveLocation::FIELD,
+        ];
+    }
+
+    public function args(): array
+    {
+        return [
+            'chars' => [
+                'type' => Type::string(),
+                'description' => 'Trim field by given characters.',
+            ],
+        ];
+    }
+
+    public function handle($value, array $args = []): string
+    {
+        if (isset($args['chars'])) {
+            return trim($value, $args['chars']);
+        }
+
+        return trim($value);
+    }
+}

--- a/tests/Support/Directives/UpperCaseDirective.php
+++ b/tests/Support/Directives/UpperCaseDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Directives;
+
+use GraphQL\Language\DirectiveLocation;
+use Rebing\GraphQL\Support\Directive;
+
+class UpperCaseDirective extends Directive
+{
+    protected $attributes = [
+        'name' => 'upper',
+        'description' => 'The upper directive.',
+    ];
+
+    public function locations(): array
+    {
+        return [
+            DirectiveLocation::FIELD,
+        ];
+    }
+
+    public function handle($value, array $args = []): ?string
+    {
+        if (\is_string($value)) {
+            return strtoupper($value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Support/Directives/UpperCaseDirective.php
+++ b/tests/Support/Directives/UpperCaseDirective.php
@@ -8,9 +8,7 @@ use Rebing\GraphQL\Support\Directive;
 
 class UpperCaseDirective extends Directive
 {
-    /**
-     * @var array<string, string>
-     */
+    /** @var array<string, string> */
     protected $attributes = [
         'name' => 'upper',
         'description' => 'The upper directive.',

--- a/tests/Support/Directives/UpperCaseDirective.php
+++ b/tests/Support/Directives/UpperCaseDirective.php
@@ -8,11 +8,17 @@ use Rebing\GraphQL\Support\Directive;
 
 class UpperCaseDirective extends Directive
 {
+    /**
+     * @var array<string, string>
+     */
     protected $attributes = [
         'name' => 'upper',
         'description' => 'The upper directive.',
     ];
 
+    /**
+     * @return array<string>
+     */
     public function locations(): array
     {
         return [
@@ -20,6 +26,9 @@ class UpperCaseDirective extends Directive
         ];
     }
 
+    /**
+     * @param array<mixed> $args
+     */
     public function handle($value, array $args = []): ?string
     {
         if (\is_string($value)) {

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -120,4 +120,50 @@ return [
             }
         }
     ',
+
+    'examplesWithFieldDirective' => '
+        query {
+            examples {
+                test @upper
+                alias: test @lower
+            }
+        }
+    ',
+
+    'examplesWithFragmentAndFieldDirective' => '
+        fragment ExampleFragment on Example {
+            test @upper
+            second: test
+        }
+        query {
+            examples {
+                ...ExampleFragment
+            }
+        }
+    ',
+
+    'examplesWithFieldDirectiveWithArgument' => '
+        query ExamplesWithFieldDirectiveWithArgument($chars: String = "E") {
+            examples {
+                test @trim(chars: $chars)
+            }
+        }
+    ',
+
+    'examplesWithConsecutiveFieldDirectives' => '
+        query {
+            examples {
+                test @upper @lower
+            }
+        }
+    ',
+
+    'examplesWithInternalDirective' => '
+        query ExamplesWithBuildInDirective($index: Int = 0, $withField: Boolean!) {
+            examples {
+                test
+                test_validation(index: $index) @include(if: $withField)
+            }
+        }
+    ',
 ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Directives\LowerCaseDirective;
+use Rebing\GraphQL\Tests\Support\Directives\TrimDirective;
+use Rebing\GraphQL\Tests\Support\Directives\UpperCaseDirective;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
@@ -59,6 +62,11 @@ class TestCase extends BaseTestCase
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class,
+            ],
+            'directives' => [
+                LowerCaseDirective::class,
+                TrimDirective::class,
+                UpperCaseDirective::class,
             ],
         ]);
 

--- a/tests/Unit/DirectiveTest.php
+++ b/tests/Unit/DirectiveTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class DirectiveTest extends TestCase
+{
+    public function testInternalDirective(): void
+    {
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithInternalDirective']),
+            'variables' => [
+                'withField' => false,
+            ],
+        ])->assertOk()->json();
+
+        self::assertArrayHasKey('data', $content);
+
+        // Assert response doesn't contain the `test_validation` field
+        self::assertSame([
+            'examples' => array_map(function ($n) {
+                return ['test' => $n['test']];
+            }, $this->data),
+        ], $content['data']);
+
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithInternalDirective']),
+            'variables' => [
+                'withField' => true,
+            ],
+        ])->assertOk()->json();
+
+        // Assert response does contain the `test_validation` field
+        self::assertSame([
+            'examples' => array_map(function ($n) {
+                return ['test' => $n['test'], 'test_validation' => ['test']];
+            }, $this->data),
+        ], $content['data']);
+    }
+
+    public function testFieldDirective(): void
+    {
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithFieldDirective']),
+        ])->assertOk()->json();
+
+        self::assertArrayHasKey('data', $content);
+
+        self::assertEquals([
+            'examples' => array_map(function ($n) {
+                return [
+                    'test' => strtoupper($n['test']),
+                    'alias' => strtolower($n['test']),
+                ];
+            }, $this->data),
+        ], $content['data']);
+    }
+
+    public function testFragmentAndFieldDirective(): void
+    {
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithFragmentAndFieldDirective']),
+        ])->assertOk()->json();
+
+        self::assertArrayHasKey('data', $content);
+
+        self::assertEquals([
+            'examples' => array_map(function ($n) {
+                return [
+                    'test' => strtoupper($n['test']),
+                    'second' => $n['test'],
+                ];
+            }, $this->data),
+        ], $content['data']);
+    }
+
+    public function testFieldDirectiveWithArgument(): void
+    {
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithFieldDirectiveWithArgument']),
+        ])->assertOk()->json();
+
+        self::assertArrayHasKey('data', $content);
+
+        self::assertEquals([
+            'examples' => array_map(function ($n) {
+                return [
+                    'test' => trim($n['test'], 'E'),
+                ];
+            }, $this->data),
+        ], $content['data']);
+    }
+
+    public function testConsecutiveFieldDirectives(): void
+    {
+        $content = $this->call('GET', '/graphql', [
+            'query' => trim($this->queries['examplesWithConsecutiveFieldDirectives']),
+        ])->assertOk()->json();
+
+        self::assertArrayHasKey('data', $content);
+
+        self::assertEquals([
+            'examples' => array_map(function ($n) {
+                return ['test' => strtolower(strtoupper($n['test']))];
+            }, $this->data),
+        ], $content['data']);
+    }
+}


### PR DESCRIPTION
## Summary
This PR starts where #703 was left off. It is a non-breaking implementation of the field directive, by overriding the default field resolver.

*Locations*
There are two types of directive locations: type system (or schema) directive locations and executable directive locations. The type system directives are not supported by webonyx/graphql-php, [see here](https://github.com/webonyx/graphql-php/issues/588#issuecomment-557806121). This isn't a real problem though, since similar functionality can be achieved via the types, queries, middleware, etc of this package. I have added a warning for this in the readme.

I decided to make a PR for the field location only, since the other locations will act on different parts of the query execution.

*Built-in directives*
The `include` and `skip` directives already worked, so I added these to the readme as well.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
