### PR TITLE
composer require --dev thecodingmachine/phpstan-safe-rule:^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "orchestra/testbench": "4.0.*|5.0.*|^6.0",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "~7.0|~8.0|^9",
-        "thecodingmachine/phpstan-safe-rule": "dev-master#a630c7bf9f3060b6e3dc74a4d9ef5edc0feec052"
+        "thecodingmachine/phpstan-safe-rule": "^1"
     },
     "autoload": {
         "psr-4": {
@@ -93,24 +93,5 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true
-    },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "thecodingmachine/phpstan-safe-rule",
-                "type": "library",
-                "version": "dev-master",
-                "dist": {
-                    "url": "https://codeload.github.com/thecodingmachine/phpstan-safe-rule/legacy.zip/a630c7bf9f3060b6e3dc74a4d9ef5edc0feec052",
-                    "type": "zip"
-                },
-                "autoload": {
-                    "psr-4": {
-                        "TheCodingMachine\\Safe\\PHPStan\\": "src/"
-                    }
-                }
-            }
-        }
-    ]
+    }
 }


### PR DESCRIPTION
## Summary
Get rid of the custom repository as a new release has already been made.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
