### PR TITLE
gha: remove deprecated --no-suggest option

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - run: composer install --prefer-dist --no-suggest
+      - run: composer install --prefer-dist
 
       - run: tests/integration-laravel.sh


### PR DESCRIPTION
## Summary
See https://php.watch/articles/composer-2#no--no-suggest

> Composer v2 deprecates the --no-suggest option that was available in require and update commands.
> 
> You will get a notice saying this option is deprecated:
> 
> You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
> 

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
