### PR TITLE
Make it possible to modify eager-loading queries by extending SelectFields

### DIFF
--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -118,7 +118,7 @@ class SelectFields
                 $query = $customQuery($requestedFields['args'], $query, $this->getCtx()) ?? $query;
             }
 
-            $query->select($select);
+            $query->addSelect($select);
             $query->with($with);
 
             $this->onAfterModifyQuery($query, $parentType, $with, $select, $requestedFields);

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -56,9 +56,9 @@ class SelectFields
             $parentType = $parentType->getWrappedType(true);
         }
 
-        $this->parentType         = $parentType;
-        $this->queryArgs          = $queryArgs;
-        $this->ctx                = $ctx;
+        $this->parentType = $parentType;
+        $this->queryArgs = $queryArgs;
+        $this->ctx = $ctx;
         $this->fieldsAndArguments = $fieldsAndArguments;
 
         $requestedFields = [
@@ -511,25 +511,16 @@ class SelectFields
         };
     }
 
-    /**
-     * @return GraphqlType
-     */
     public function getParentType(): GraphqlType
     {
         return $this->parentType;
     }
 
-    /**
-     * @return array
-     */
     public function getQueryArgs(): array
     {
         return $this->queryArgs;
     }
 
-    /**
-     * @return mixed
-     */
     public function getCtx()
     {
         return $this->ctx;

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -30,6 +30,18 @@ class SelectFields
     /** @var array */
     protected $relations = [];
 
+    /** @var GraphqlType */
+    protected $parentType;
+
+    /** @var array */
+    protected $queryArgs;
+
+    /** @var mixed */
+    protected $ctx;
+
+    /** @var array<string,mixed> */
+    protected $fieldsAndArguments;
+
     public const ALWAYS_RELATION_KEY = 'ALWAYS_RELATION_KEY';
 
     /**
@@ -43,6 +55,11 @@ class SelectFields
         if ($parentType instanceof WrappingType) {
             $parentType = $parentType->getWrappedType(true);
         }
+
+        $this->parentType         = $parentType;
+        $this->queryArgs          = $queryArgs;
+        $this->ctx                = $ctx;
+        $this->fieldsAndArguments = $fieldsAndArguments;
 
         $requestedFields = [
             'args' => $queryArgs,
@@ -517,6 +534,38 @@ class SelectFields
 
             return $callable($query);
         };
+    }
+
+    /**
+     * @return GraphqlType
+     */
+    public function getParentType(): GraphqlType
+    {
+        return $this->parentType;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryArgs(): array
+    {
+        return $this->queryArgs;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCtx()
+    {
+        return $this->ctx;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getFieldsAndArguments(): array
+    {
+        return $this->fieldsAndArguments;
     }
 
     public function getSelect(): array

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -110,13 +110,18 @@ class SelectFields
             return [$select, $with];
         }
 
-        return function ($query) use ($with, $select, $customQuery, $requestedFields): void {
+        return function ($query) use ($parentType, $with, $select, $customQuery, $requestedFields): void {
+            /** @var Relation $query */
+            $this->onBeforeModifyQuery($query, $parentType, $with, $select, $requestedFields);
+
             if ($customQuery) {
                 $query = $customQuery($requestedFields['args'], $query, $this->getCtx()) ?? $query;
             }
 
             $query->select($select);
             $query->with($with);
+
+            $this->onAfterModifyQuery($query, $parentType, $with, $select, $requestedFields);
         };
     }
 
@@ -509,6 +514,40 @@ class SelectFields
 
             return $callable($query);
         };
+    }
+
+    /**
+     * This method is called before the query is modified to make it eagerly load the fields and relations
+     *
+     * @param Relation $query The query to be executed
+     * @param array $with The relations to be eagerly loaded by the query
+     * @param array $select The fields to be selected with the query
+     */
+    protected function onBeforeModifyQuery(
+        $query,
+        GraphqlType $parentType,
+        array &$with,
+        array &$select,
+        array $requestedFields
+    ): void {
+        // Do nothing. This is left for child classes to implement when needed.
+    }
+
+    /**
+     * This method is called after the query is modified by adding select fields and relations to be eagerly loaded.
+     *
+     * @param Relation $query The query to be executed
+     * @param array $with The relations to be eagerly loaded by the query
+     * @param array $select The fields to be selected with the query
+     */
+    protected function onAfterModifyQuery(
+        $query,
+        GraphqlType $parentType,
+        array $with,
+        array $select,
+        array $requestedFields
+    ): void {
+        // Do nothing. This is left for child classes to implement when needed.
     }
 
     public function getParentType(): GraphqlType


### PR DESCRIPTION
## Summary
This project is a tremendous help. However, when it comes to eagerly loading relations, I always end up in examining `SelectFields` class to figure out how to implement the functionality I want. Most of the time, I simply need to modify the eager-loading query, created in `SelectFields` class, by considering the requested fields. I probably spent more than 100 hours in total trying to hack the package to implement what I need. The reason I spent this much time is because `SelectFields` class is not extendible. For example, #510 talks about eagerly loading counts, which is not possible currently. The reason why I created this pull request is that I need to eagerly load counts as well. There are also other issues related to `SelectFields` in this repository. For example, #875 mentions a need for a custom behavior. #806 wants to modify the behavior of eager-loading function. #799 was a nice attempt, which made it possible to extend `SelectFields` and provide a custom `SelectFields` class to be used by the package, but it is not enough for many use-cases. The class is quite complex, as also stated [here](https://github.com/rebing/graphql-laravel/pull/799#discussion_r657792900). The complexity of the class partially comes from using static methods too. This pull request partially addresses these issues.

Here is a summary of the changes made in this pull request:
- Use instance methods instead of static methods. By this way, we do not need to pass certain variables as parameters to all the methods.
- Store constructor parameters in instance variables. Their getters are added as well. With this, a child class can retrieve the constructor parameters from any method, when overriding the methods. Also, we do not need to pass `$queryArgs` and `$ctx` variables. The methods that need them simply retrieve them via the getters. This reduces the complexity of the class.
- Make it possible to modify the eager-loading queries. This is the main contribution of this pull request.  This will make it possible to customize the behavior of eager-loading.
- Do not override the columns added to the select statement of the queries by the custom queries. This lets the custom queries define custom columns.

There are many [eager-loading methods in Laravel](https://laravel.com/docs/8.x/eloquent-relationships#other-aggregate-functions). We might also need to customize the eager-loading behavior to use them as well. With the changes in this pull request, everybody can implement their own behavior. Below is an example of extending `SelectFields` to eagerly load counts:

```php
<?php

namespace App\GraphQL\Helpers\SelectFields;

use App\GraphQL\Fields\Pagination\CustomPaginationType;
use GraphQL\Type\Definition\Type as GraphqlType;
use Illuminate\Database\Eloquent\Relations\Relation;
use Illuminate\Support\Str;
use Rebing\GraphQL\Support\SelectFields;

class AppSelectFields extends SelectFields {

    // Override the onAfterModifyQuery method to modify the query after select fields and relations 
    // are added to it. Also, by overriding onBeforeModifyQuery, it is possible to modify $with and
    // $select variables that will be added to the query in SelectFields.
    protected function onAfterModifyQuery($query, GraphqlType $parentType, array $with, array $select,
                                          array $requestedFields): void {
        parent::onAfterModifyQuery($query, $parentType, $with, $select, $requestedFields);

        if ($parentType instanceof CustomPaginationType) {
            $type = $parentType->getUnderlyingType();
            $actualRequestedFields = data_get($requestedFields, 'fields.items.fields') ?? [];
            $this->eagerlyLoadCounts($query, array_keys($actualRequestedFields), $type);
        }
    }

    /*
     *
     */

    /**
     * @param Relation    $query
     * @param string[]    $requestedFields
     * @param GraphqlType $type
     * @return void
     * @noinspection PhpMissingParamTypeInspection
     */
    protected function eagerlyLoadCounts($query, array $requestedFields, GraphqlType $type) {
        foreach($requestedFields as $fieldName) {
            if (!str_ends_with($fieldName, '_count')) continue;

            $exploded = explode('.', $fieldName);
            $this->eagerlyLoadCount($query, $exploded[count($exploded) - 1], $type);
        }
    }

    /**
     * @param Relation    $query
     * @param string      $fieldName
     * @param GraphqlType $type
     * @return void
     */
    protected function eagerlyLoadCount($query, string $fieldName, GraphqlType $type): void {
        $field = $type->findField($fieldName);
        if (!$field) return;

        $config = $field->config;
        // 'count' is a custom config that I added to customize the behavior
        if (($config['count'] ?? true) !== true) return;

        // 'relation' is a custom config that I added to customize the behavior
        $relationName = $config['relation'] ?? Str::replace('_count', '', $fieldName);
        $query->withCount($relationName);
    }

}
```

Switching to instance methods from static methods opens up the possibility of adding more hooks like `onBeforeModifyQuery` and  `onAfterModifyQuery`. In the future, I expect other pull requests that add other hooks when developers come across other use-cases.

The changes I made are breaking changes for the applications that extend `SelectFields`. Other than that, this is non-breaking. I did not add any tests. The existing tests all pass. If this pull request is intended to be merged, I can add the tests with your directions. I did not update `README.md` because I did not see any guidance on how to extend `SelectFields`.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
