### PR TITLE
Add Support for Laravel 9

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           coverage: none
 
       # Remove unnecessary dependencies not needed in this context
@@ -58,7 +58,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           coverage: none
 
       - name: Get composer cache directory

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -71,4 +71,4 @@ jobs:
 
       - run: composer install --prefer-dist
 
-      - run: tests/integration-laravel.sh
+      - run: tests/integration-laravel.sh ${{ matrix.laravel }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
         laravel: [^6.0, ^7.0, ^8.0, ^9.0]
-        lazy_types: ['false', 'true']
         exclude:
           - php: 7.2
             laravel: ^8.0
@@ -39,7 +38,7 @@ jobs:
             laravel: ^6.0
           - php: 8.1
             laravel: ^7.0
-    name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
+    name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
     env:
       COMPOSER_NO_INTERACTION: 1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,7 +18,28 @@ on:
 
 jobs:
   integration:
-    name: laravel
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        laravel: [^6.0, ^7.0, ^8.0, ^9.0]
+        lazy_types: ['false', 'true']
+        exclude:
+          - php: 7.2
+            laravel: ^8.0
+          - php: 7.2
+            laravel: ^9.0
+          - php: 7.3
+            laravel: ^9.0
+          - php: 7.4
+            laravel: ^9.0
+          - php: 8.0
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^7.0
+    name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
     runs-on: ubuntu-latest
     env:
       COMPOSER_NO_INTERACTION: 1
@@ -28,13 +49,15 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
           coverage: none
 
       # Due to version incompatibility with older Laravels we test, we remove it
-      - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
       - run: composer remove --dev nunomaduro/larastan --no-update
-      - run: composer require illuminate/contracts:^8.0 --no-update
+      - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
+      - run: composer remove --dev laravel/legacy-factories --no-update
+        if: (matrix.laravel == '^6.0' || matrix.laravel == '^7.0')
+      - run: composer require illuminate/contracts:${{ matrix.laravel }} --no-update
 
       - name: Get composer cache directory
         id: composercache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
-        laravel: [^6.0, ^7.0, ^8.0]
+        laravel: [^6.0, ^7.0, ^8.0, ^9.0]
         lazy_types: ['false', 'true']
         exclude:
           - php: 7.2
             laravel: ^8.0
+          - php: 7.2
+            laravel: ^9.0
+          - php: 7.3
+            laravel: ^9.0
+          - php: 7.4
+            laravel: ^9.0
           - php: 8.0
             laravel: ^6.0
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  integration:
+  tests:
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/8.0.0...master)
 --------------
+### Added
+- Support for Laravel 9 [\#879 / mfn](https://github.com/rebing/graphql-laravel/pull/879)
 
 2021-11-15, 8.0.0
 -----------------

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,6 @@ RUN install-php-extensions \
 
 COPY --from=composer:2.2.4 /usr/bin/composer /usr/local/bin/
 
-COPY ./ /app
+RUN mkdir /app
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,12 @@
-FROM php:8.1.0-cli-alpine
+FROM php:8.1.1-cli-alpine
 
-COPY --from=mlocati/php-extension-installer:1.4.2 /usr/bin/install-php-extensions /usr/local/bin/
+COPY --from=mlocati/php-extension-installer:1.4.12 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN install-php-extensions \
       xdebug && \
       rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-COPY --from=composer:2.1.14 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2.2.4 /usr/bin/composer /usr/local/bin/
 
 COPY ./ /app
 

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
     "require": {
         "php": ">= 7.2",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "laragraph/utils": "^1",
-        "thecodingmachine/safe": "^1.3",
+        "thecodingmachine/safe": "^1.3|^2",
         "webonyx/graphql-php": "^14.6.4"
     },
     "require-dev": {
@@ -49,7 +49,7 @@
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.2",
         "nunomaduro/larastan": "^1",
-        "orchestra/testbench": "4.0.*|5.0.*|^6.0",
+        "orchestra/testbench": "4.0.*|5.0.*|^6.0|^7.0",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "~7.0|~8.0|^9",
         "thecodingmachine/phpstan-safe-rule": "^1"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "laragraph/utils": "^1",
-        "thecodingmachine/safe": "^1.3|^2",
+        "thecodingmachine/safe": "^1.3",
         "webonyx/graphql-php": "^14.6.4"
     },
     "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/GraphQL.php
 
 		-
+			message: "#^Property Rebing\\\\GraphQL\\\\GraphQL\\:\\:\\$types \\(array\\<string, object\\|string\\>\\) does not accept array\\<int\\|string, object\\|string\\>\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
 			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\|stdClass\\:\\:\\$alias\\.$#"
 			count: 1
 			path: src/Support/AliasArguments/AliasArguments.php

--- a/tests/integration-laravel.sh
+++ b/tests/integration-laravel.sh
@@ -8,21 +8,21 @@
 # This script is meant to be run on CI environments
 
 echo "Install Laravel"
-composer create-project --quiet --prefer-dist "laravel/laravel" ../laravel
+composer create-project --quiet --prefer-dist "laravel/laravel" ../laravel || exit 1
 cd ../laravel
 
 echo "Add package from source"
-sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../graphql-laravel" } ],|' -i composer.json
-composer require --dev "rebing/graphql-laravel:*"
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../graphql-laravel" } ],|' -i composer.json || exit 1
+composer require --dev "rebing/graphql-laravel:*" || exit 1
 
 echo "Publish vendor files"
-php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider"
+php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider" || exit 1
 
 echo "Make GraphQL ExampleQuery"
-php artisan make:graphql:query ExampleQuery
+php artisan make:graphql:query ExampleQuery || exit 1
 
 echo "Add ExampleQuery to config"
-sed -e "s|// ExampleQuery::class,|\\\App\\\GraphQL\\\Queries\\\ExampleQuery::class,|" -i config/graphql.php
+sed -e "s|// ExampleQuery::class,|\\\App\\\GraphQL\\\Queries\\\ExampleQuery::class,|" -i config/graphql.php || exit 1
 
 echo "Start Webserver"
 php -S 127.0.0.1:8001 -t public >/dev/null 2>&1 &

--- a/tests/integration-laravel.sh
+++ b/tests/integration-laravel.sh
@@ -7,8 +7,19 @@
 #
 # This script is meant to be run on CI environments
 
+LARAVEL_VERSION="$1"
+if [[ "$LARAVEL_VERSION" = "" ]]; then
+    echo "ERROR: Usage of this script is: $0 <laravel version>"
+    exit 1
+fi
+
+# TODO: temporary until laravel/laravel for 9 was released
+if [[ "$LARAVEL_VERSION" = "^9.0" ]]; then
+    LARAVEL_VERSION=dev-master
+fi
+
 echo "Install Laravel"
-composer create-project --prefer-dist "laravel/laravel" ../laravel || exit 1
+composer create-project --prefer-dist laravel/laravel:$LARAVEL_VERSION ../laravel || exit 1
 cd ../laravel
 
 echo "Add package from source"

--- a/tests/integration-laravel.sh
+++ b/tests/integration-laravel.sh
@@ -8,7 +8,7 @@
 # This script is meant to be run on CI environments
 
 echo "Install Laravel"
-composer create-project --quiet --prefer-dist "laravel/laravel" ../laravel || exit 1
+composer create-project --prefer-dist "laravel/laravel" ../laravel || exit 1
 cd ../laravel
 
 echo "Add package from source"


### PR DESCRIPTION
## Summary
- Add support for Laravel 9 in composer.json version constraints
- Do some chores and bump PHP version and misc software stack
- expanded integration tests into a matrix with all combinations from unit tests too
- make integration test script more resilient / abort early if something does not work

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
