### PR TITLE
Fix "No configuration for schema '' found" when route prefix is empty string

### DIFF
--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -19,7 +19,7 @@ class GraphQLController extends Controller
     public function query(Request $request, RequestParser $parser, Repository $config, GraphQL $graphql): JsonResponse
     {
         $routePrefix = $config->get('graphql.route.prefix', 'graphql');
-        $schemaName = $this->findSchemaNameInRequest($request, "$routePrefix/") ?? $config->get('graphql.default_schema', 'default');
+        $schemaName = $this->findSchemaNameInRequest($request, "$routePrefix/") ?: $config->get('graphql.default_schema', 'default');
 
         $operations = $parser->parseRequest($request);
 

--- a/tests/Unit/EmptyRoutePrefixTest.php
+++ b/tests/Unit/EmptyRoutePrefixTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class EmptyRoutePrefixTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.route.prefix', '');
+    }
+
+    public function testEmptyRoutePrefix():void
+    {
+        $response = $this->call('GET', '/', [
+            'query' => $this->queries['examples'],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

`Rebing\GraphQL\Exception\SchemaNotFound: No configuration for schema '' found` is thrown if route prefix is empty string.

```
<?php

return [
    'route' => [
        'prefix' => '',
        ...
    ],
    ...
];
```

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
