### PR TITLE
Fix schema parsing issue when route prefix is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/8.1.0...master)
 --------------
+### Fixed
+- Fix schema parsing issue when route prefix is empty string [\#890 / hello-liang-shan](https://github.com/rebing/graphql-laravel/pull/890)
 
 2022-01-27, 8.2.0
 -----------------
 ### Fixed
-- Fix "No configuration for schema '' found" when route prefix is empty string [\888 / hello-liang-shan](https://github.com/rebing/graphql-laravel/pull/888)
+- Fix "No configuration for schema '' found" when route prefix is empty string [\#888 / hello-liang-shan](https://github.com/rebing/graphql-laravel/pull/888)
 
 2022-01-15, 8.1.0
 -----------------

--- a/src/GraphQLController.php
+++ b/src/GraphQLController.php
@@ -19,7 +19,7 @@ class GraphQLController extends Controller
     public function query(Request $request, RequestParser $parser, Repository $config, GraphQL $graphql): JsonResponse
     {
         $routePrefix = $config->get('graphql.route.prefix', 'graphql');
-        $schemaName = $this->findSchemaNameInRequest($request, "$routePrefix/") ?: $config->get('graphql.default_schema', 'default');
+        $schemaName = $this->findSchemaNameInRequest($request, "/$routePrefix") ?: $config->get('graphql.default_schema', 'default');
 
         $operations = $parser->parseRequest($request);
 
@@ -51,13 +51,15 @@ class GraphQLController extends Controller
     public function graphiql(Request $request, Repository $config, Factory $viewFactory): View
     {
         $routePrefix = $config->get('graphql.graphiql.prefix', 'graphiql');
-        $schemaName = $this->findSchemaNameInRequest($request, "$routePrefix/");
+        $schemaName = $this->findSchemaNameInRequest($request, "/$routePrefix");
 
         $graphqlPath = '/' . $config->get('graphql.route.prefix', 'graphql');
 
         if ($schemaName) {
             $graphqlPath .= '/' . $schemaName;
         }
+
+        $graphqlPath = '/' . trim($graphqlPath, '/');
 
         $view = $config->get('graphql.graphiql.view', 'graphql::graphiql');
 
@@ -97,12 +99,12 @@ class GraphQLController extends Controller
 
     protected function findSchemaNameInRequest(Request $request, string $routePrefix): ?string
     {
-        $path = $request->path();
+        $path = $request->getPathInfo();
 
         if (!Str::startsWith($path, $routePrefix)) {
             return null;
         }
 
-        return Str::after($path, $routePrefix);
+        return trim(Str::after($path, $routePrefix), '/');
     }
 }

--- a/tests/Unit/EmptyRoutePrefixTest.php
+++ b/tests/Unit/EmptyRoutePrefixTest.php
@@ -22,4 +22,27 @@ class EmptyRoutePrefixTest extends TestCase
 
         self::assertEquals(200, $response->getStatusCode());
     }
+
+    public function testGetCustomSchema(): void
+    {
+        $response = $this->call('GET', '/custom', [
+            'query' => $this->queries['examplesCustom'],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetGraphiQL(): void
+    {
+        $response = $this->call('GET', '/graphiql');
+
+        $response->assertSee('return fetch(\'/\', {', false);
+    }
+
+    public function testGetGraphiQLCustomSchema(): void
+    {
+        $response = $this->call('GET', '/graphiql/custom');
+
+        $response->assertSee('return fetch(\'/custom\', {', false);
+    }
 }


### PR DESCRIPTION
## Summary

Fix schema parsing issue

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
