### PR TITLE
make 'always'-feature work on objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/8.2.1...master)
 --------------
+### Fixed
+- Allow 'always' to work on object types [\#473 / tinyoverflow \#369 / zjbarg](https://github.com/rebing/graphql-laravel/pull/892)
 
 ### Removed
 - Support for PHP 7.2, PHP 7.3 and Laravel 7.0 (all EOL) [\#914 / mfn](https://github.com/rebing/graphql-laravel/pull/914)

--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -247,10 +247,8 @@ class SelectFields
                 $fieldObject->resolveFn = function (): void {
                 };
             }
-            // If allowed field, but not selectable
-            elseif (false === $canSelect) {
-                static::addAlwaysFields($fieldObject, $select, $parentTable);
-            }
+
+            static::addAlwaysFields($fieldObject, $select, $parentTable);
         }
 
         // If parent type is an union or interface we select all fields

--- a/tests/Database/SelectFields/AlwaysRelationTests/UserType.php
+++ b/tests/Database/SelectFields/AlwaysRelationTests/UserType.php
@@ -23,14 +23,12 @@ class UserType extends GraphQLType
             ],
             'likes' => [
                 'type' => Type::listOf(GraphQL::Type('Like')),
-                'always' => 'likable',
             ],
             'name' => [
                 'type' => Type::nonNull(Type::string()),
             ],
             'posts' => [
                 'type' => Type::listOf(GraphQL::type('Post')),
-                'always' => 'comments',
             ],
         ];
     }

--- a/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
+++ b/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
@@ -47,7 +47,6 @@ class AlwaysTest extends TestCaseDatabase
         $query = <<<'GRAQPHQL'
 {
   alwaysQuery {
-    body
     title
     comments_always_single_field {
       id
@@ -62,7 +61,7 @@ GRAQPHQL;
 
         $this->assertSqlQueries(
             <<<'SQL'
-select "posts"."body", "posts"."title", "posts"."id" from "posts";
+select "posts"."title", "posts"."body", "posts"."id" from "posts";
 select "comments"."id", "comments"."post_id", "comments"."body" from "comments" where "comments"."post_id" in (?) order by "comments"."id" asc;
 SQL
         );
@@ -71,7 +70,6 @@ SQL
             'data' => [
                 'alwaysQuery' => [
                     [
-                        'body' => 'post body',
                         'title' => 'post title',
                         'comments_always_single_field' => [
                             [


### PR DESCRIPTION
## Summary
fixes always not working on non simple types (objects)

issues: 
https://github.com/rebing/graphql-laravel/issues/473
https://github.com/rebing/graphql-laravel/issues/369


Type of change:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
