### PR TITLE
Validation attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 ### Added
 - Add support to use array in `controller` param in config [\#906 / viktorruskai](https://github.com/rebing/graphql-laravel/pull/906)
+- Add support for laravel validation attributes [\#901 / jacobdekeizer](https://github.com/rebing/graphql-laravel/pull/901)
 
 ### Fixed
 - Allow 'always' to work on object types [\#473 / tinyoverflow \#369 / zjbarg](https://github.com/rebing/graphql-laravel/pull/892)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The default GraphiQL view makes use of the global `csrf_token()` helper function
       - [Example using Laravel's validator directly](#example-using-laravels-validator-directly)
       - [Handling validation errors](#handling-validation-errors)
       - [Customizing error messages](#customizing-error-messages)
+      - [Customizing attributes](#customizing-attributes)
       - [Misc notes](#misc-notes)
     - [Resolve method](#resolve-method)
     - [Resolver middleware](#resolver-middleware)
@@ -989,6 +990,21 @@ public function validationErrorMessages(array $args = []): array
         'email.required' => 'Please enter your email address',
         'email.email' => 'Please enter a valid email address',
         'email.exists' => 'Sorry, this email address is already in use',
+    ];
+}
+```
+
+#### Customizing attributes
+
+The validation attributes can be customised by overriding the
+`validationAttributes` method. This method should return an array of custom
+attributes in the same way documented by Laravel's validation.
+
+```php
+public function validationAttributes(array $args = []): array
+{
+    return [
+        'email' => 'email address',
     ];
 }
 ```

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1396,6 +1396,11 @@ parameters:
 			path: tests/Unit/MutationTest.php
 
 		-
+			message: "#^Relation 'test_validation_custom_attributes' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
+			count: 7
+			path: tests/Unit/MutationTest.php
+
+		-
 			message: "#^Relation 'test_with_rules_non_nullable_list_of_non_nullable_input_object' is not found in Illuminate\\\\Contracts\\\\Support\\\\MessageBag model\\.$#"
 			count: 3
 			path: tests/Unit/MutationTest.php

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -64,6 +64,16 @@ abstract class Field
     }
 
     /**
+     * Define custom Laravel Validator attributes as per Laravel 'custom attributes'.
+     *
+     * @param array $args submitted arguments
+     */
+    public function validationAttributes(array $args = []): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<string,mixed> $args
      * @return array<string,mixed>
      */
@@ -119,8 +129,11 @@ abstract class Field
     {
         // allow our error messages to be customised
         $messages = $this->validationErrorMessages($args);
+        
+        // allow our attributes to be customized
+        $attributes = $this->validationAttributes($args);
 
-        return Validator::make($args, $rules, $messages);
+        return Validator::make($args, $rules, $messages, $attributes);
     }
 
     /**

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -129,7 +129,7 @@ abstract class Field
     {
         // allow our error messages to be customised
         $messages = $this->validationErrorMessages($args);
-        
+
         // allow our attributes to be customized
         $attributes = $this->validationAttributes($args);
 

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -66,7 +66,8 @@ abstract class Field
     /**
      * Define custom Laravel Validator attributes as per Laravel 'custom attributes'.
      *
-     * @param array $args submitted arguments
+     * @param array<string,mixed> $args submitted arguments
+     * @return array<string,string>
      */
     public function validationAttributes(array $args = []): array
     {

--- a/tests/Support/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Support/Objects/UpdateExampleMutationWithInputType.php
@@ -62,6 +62,19 @@ class UpdateExampleMutationWithInputType extends Mutation
                 'name' => 'test',
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('ExampleValidationInputObject')))),
             ],
+
+            'test_validation_custom_attributes' => [
+                'name' => 'custom validation attributes',
+                'type' => Type::string(),
+                'rules' => ['required'],
+            ],
+        ];
+    }
+
+    public function validationAttributes(array $args = []): array
+    {
+        return [
+            'test_validation_custom_attributes' => 'custom attribute',
         ];
     }
 

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -74,6 +74,7 @@ class MutationTest extends FieldTest
                     ['email' => 'test@test.com'],
                 ],
             ],
+            'test_validation_custom_attributes' => 'test',
         ], [], $this->resolveInfoMock());
     }
 
@@ -117,7 +118,8 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.otherValue'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.nest'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.list'));
-        self::assertCount(6, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(7, $messages->all());
     }
 
     public function testWithInput(): void
@@ -154,7 +156,8 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.otherValue'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.nest'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.list'));
-        self::assertCount(6, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(7, $messages->all());
     }
 
     public function testWithEmptyInput(): void
@@ -182,7 +185,8 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object'));
         self::assertTrue($messages->has('test_with_rules_closure'));
-        self::assertCount(4, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(5, $messages->all());
     }
 
     public function testWithInputDepthOne(): void
@@ -212,7 +216,8 @@ class MutationTest extends FieldTest
 
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object'));
         self::assertTrue($messages->has('test_with_rules_closure'));
-        self::assertCount(3, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(4, $messages->all());
     }
 
     public function testWithInputWithEmptyInputObjects(): void
@@ -245,6 +250,8 @@ class MutationTest extends FieldTest
 
         self::assertTrue($messages->has('test_with_rules'));
 
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+
         self::assertTrue($messages->has('test_with_rules_nullable_input_object.otherValue'));
         self::assertTrue($messages->has('test_with_rules_nullable_input_object.val'));
         self::assertTrue($messages->has('test_with_rules_nullable_input_object.nest'));
@@ -253,7 +260,7 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.val'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.nest'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object.list'));
-        self::assertCount(12, $messages->all());
+        self::assertCount(13, $messages->all());
     }
 
     public function testWithEmptyArrayOfInputsObjects(): void
@@ -282,7 +289,8 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_input_object'));
         self::assertTrue($messages->has('test_with_rules_closure'));
-        self::assertCount(4, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(5, $messages->all());
     }
 
     public function testWithArrayOfInputsObjects(): void
@@ -319,7 +327,8 @@ class MutationTest extends FieldTest
         self::assertTrue($messages->has('test_with_rules_non_nullable_list_of_non_nullable_input_object.0.otherValue'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_list_of_non_nullable_input_object.0.nest'));
         self::assertTrue($messages->has('test_with_rules_non_nullable_list_of_non_nullable_input_object.0.list'));
-        self::assertCount(7, $messages->all());
+        self::assertTrue($messages->has('test_validation_custom_attributes'));
+        self::assertCount(8, $messages->all());
     }
 
     public function testCustomValidationErrorMessages(): void
@@ -354,6 +363,25 @@ class MutationTest extends FieldTest
             'The test with rules non nullable input object.nest.email must be a valid email address.',
             $messages->first('test_with_rules_non_nullable_input_object.nest.email')
         );
+    }
+
+    public function testCustomValidationAttributes(): void
+    {
+        $class = $this->getFieldClass();
+        $field = new $class();
+        $attributes = $field->getAttributes();
+
+        /** @var ValidationError $exception */
+        $exception = null;
+
+        try {
+            $attributes['resolve'](null, [], [], $this->resolveInfoMock());
+        } catch (ValidationError $exception) {
+        }
+
+        $messages = $exception->getValidatorMessages();
+
+        self::assertEquals('The custom attribute field is required.', $messages->first('test_validation_custom_attributes'));
     }
 
     public function testRuleCallbackArgumentsMatchesTheInput(): void


### PR DESCRIPTION
## Summary

Thanks for making this package. I wanted to add custom attributes to the Laravel validator so I can translate the attribute names for the mutation arguments, but this is currently not possible. This pull request will add the custom attributes to the Laravel validator in the GraphQL Field class.

Laravel documentation: https://laravel.com/docs/9.x/validation#customizing-the-validation-attributes

Don't know if you consider adding a new public method as a breaking change or not. Let me know if you have any questions!

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
