### PR TITLE
tests: make them L9 compatible due to changed console message format

### DIFF
--- a/tests/Support/Traits/MakeCommandAssertionTrait.php
+++ b/tests/Support/Traits/MakeCommandAssertionTrait.php
@@ -57,6 +57,6 @@ trait MakeCommandAssertionTrait
         ]);
 
         self::assertSame(0, $tester->getStatusCode());
-        self::assertMatchesRegularExpression("/$graphqlKind created successfully/", $tester->getDisplay());
+        self::assertMatchesRegularExpression("/$graphqlKind.*created successfully/", $tester->getDisplay());
     }
 }

--- a/tests/Unit/Console/FieldMakeCommandTest.php
+++ b/tests/Unit/Console/FieldMakeCommandTest.php
@@ -44,6 +44,6 @@ class FieldMakeCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $tester->getStatusCode());
-        self::assertMatchesRegularExpression('/Field created successfully/', $tester->getDisplay());
+        self::assertMatchesRegularExpression('/Field.*created successfully/', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
## Summary
Make the assertion compatible with L9 and the other versions we test against.

This is due to https://github.com/laravel/framework/pull/44266

---
Type of change:
- [x] Misc. change (internal, infrastructure, maintenance, etc.)
