### PR TITLE
chore: bump PHP infra version to 8.2

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           coverage: none
 
       # Remove unnecessary dependencies not needed in this context

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,12 @@
-FROM php:8.1.10-cli-alpine
+FROM php:8.2.1-cli-alpine
 
-COPY --from=mlocati/php-extension-installer:1.5.37 /usr/bin/install-php-extensions /usr/local/bin/
+COPY --from=mlocati/php-extension-installer:1.5.52 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN install-php-extensions \
       xdebug && \
       rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-COPY --from=composer:2.4.1 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2.5.1 /usr/bin/composer /usr/local/bin/
 
 RUN mkdir /app
 


### PR DESCRIPTION
## Summary
Except for php-cs-fixer, which still requires 8.1

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
