### PR TITLE
Custom query on relationship is not called when Query returns Union type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -641,6 +641,26 @@ parameters:
 			path: tests/Database/SelectFields/QueryArgsAndContextTests/UsersQuery.php
 
 		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\UnionTests\\\\SearchQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/UnionTests/SearchQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\UnionTests\\\\SearchQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/UnionTests/SearchQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\UnionTests\\\\SearchQuery\\:\\:resolve\\(\\) has parameter \\$ctx with no type specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/UnionTests/SearchQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\UnionTests\\\\SearchQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
+			count: 1
+			path: tests/Database/SelectFields/UnionTests/SearchQuery.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\SelectFields\\\\ValidateDiffNodeTests\\\\UsersQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Database/SelectFields/ValidateDiffNodeTests/UsersQuery.php

--- a/tests/Database/SelectFields/UnionTests/CommentType.php
+++ b/tests/Database/SelectFields/UnionTests/CommentType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\SelectFields\UnionTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+
+class CommentType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Comment',
+        'model' => Comment::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/UnionTests/PostType.php
+++ b/tests/Database/SelectFields/UnionTests/PostType.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\SelectFields\UnionTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class PostType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Post',
+        'model' => Post::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'body' => [
+                'type' => Type::string(),
+            ],
+            'comments' => [
+                'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
+                'query' => function (array $args, $query, $ctx) {
+                    $query->where('title', 'like', 'lorem');
+                },
+            ],
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+}

--- a/tests/Database/SelectFields/UnionTests/SearchQuery.php
+++ b/tests/Database/SelectFields/UnionTests/SearchQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\SelectFields\UnionTests;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Support\Str;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class SearchQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'searchQuery',
+    ];
+
+    public function type(): Type
+    {
+        return GraphQL::type('SearchUnion');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args, $ctx, ResolveInfo $info, Closure $getSelectFields)
+    {
+        /** @var SelectFields $selectFields */
+        $selectFields = $getSelectFields();
+
+        if (Str::startsWith($args['id'], 'comment:')) {
+            return Comment::select($selectFields->getSelect())
+                ->with($selectFields->getRelations())
+                ->where('id', (int)Str::after($args['id'], 'comment:'))
+                ->first();
+        } else {
+            return Post::select($selectFields->getSelect())
+                ->with($selectFields->getRelations())
+                ->where('id', (int)$args['id'])
+                ->first();
+        }
+    }
+}

--- a/tests/Database/SelectFields/UnionTests/SearchUnionTest.php
+++ b/tests/Database/SelectFields/UnionTests/SearchUnionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rebing\GraphQL\Tests\Database\SelectFields\UnionTests;
+
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class SearchUnionTest extends TestCaseDatabase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                SearchQuery::class,
+            ],
+        ]);
+
+        $app['config']->set('graphql.types', [
+            CommentType::class,
+            PostType::class,
+            SearchUnionType::class,
+        ]);
+    }
+
+    public function testCustomQueryIsExecutedUsingUnionTypeOnQuery(): void
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create();
+        /** @var Comment $comment1 */
+        $comment1 = factory(Comment::class)->create(['post_id' => $post->id, 'title' => 'lorem']);
+        /** @var Comment $comment2 */
+        $comment2 = factory(Comment::class)->create(['post_id' => $post->id, 'title' => 'ipsum']);
+
+        $query = <<<'GRAQPHQL'
+query ($id: String!) {
+  searchQuery(id: $id) {
+    ... on Post {
+        id
+        comments {
+            id
+        }
+    }
+    ... on Comment {
+        id
+    }
+  }
+}
+GRAQPHQL;
+
+        $result = $this->httpGraphql($query, [
+            'variables' => ['id' => (string)$post->id],
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'searchQuery' => [
+                    'id' => (string)$post->id,
+                    'comments' => [
+                        ['id' => $comment1->id],
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Database/SelectFields/UnionTests/SearchUnionType.php
+++ b/tests/Database/SelectFields/UnionTests/SearchUnionType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\SelectFields\UnionTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\UnionType;
+use Rebing\GraphQL\Tests\Support\Models\Comment;
+use Rebing\GraphQL\Tests\Support\Models\Post;
+
+class SearchUnionType extends UnionType
+{
+    protected $attributes = [
+        'name' => 'SearchUnion',
+    ];
+
+    public function types(): array
+    {
+        return [
+            GraphQL::type('Post'),
+            GraphQL::type('Comment'),
+        ];
+    }
+
+    /**
+     * @param object $value
+     * @return Type|null
+     */
+    public function resolveType($value): ?Type
+    {
+        if ($value instanceof Post) {
+            return GraphQL::type('Post');
+        } elseif ($value instanceof Comment) {
+            return GraphQL::type('Comment');
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When GraphQL query returns Union Type, it doesn't call [custom query](https://github.com/rebing/graphql-laravel#type-relationship-query) on relationship field.

Issue here - #900 

As I discussed with @mfn I'm a bit confused how to solve this bug. From my initial observations, it looks like it may involve major code rewrites to fix it, but I could be wrong. I don't have that much knowledge how this package works under the hood, the least I can help with is add tests showing the bug.

I'll appreciate anyone who might want to look at this.

### Context

`PostType.php`

This should only query comments where `title` column value is `lorem`.

```php
'comments' => [
	'type' => Type::nonNull(Type::listOf(Type::nonNull(GraphQL::type('Comment')))),
	'query' => function (array $args, $query, $ctx) {
		$query->where('title', 'like', 'lorem');
	},
],
```

`SearchUnionTest.php`

- On line 35, we create a comment for a post with title `lorem`.
- On line 36, we create a comment for a post with title `ipsum`. This should not be included in results.

But it returns both comments.

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
