### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
-        laravel: [^6.0, ^8.0, ^9.0]
+        laravel: [^6.0, ^8.0, ^9.0, ^10.0]
         exclude:
           - php: 7.4
             laravel: ^9.0
@@ -44,6 +44,8 @@ jobs:
             laravel: ^6.0
           - php: 8.2
             laravel: ^6.0
+          - php: 8.0
+            laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,6 +46,8 @@ jobs:
             laravel: ^6.0
           - php: 8.0
             laravel: ^10.0
+          - php: 7.4
+            laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
-        laravel: [^6.0, ^8.0, ^9.0]
+        laravel: [^6.0, ^8.0, ^9.0, ^10.0]
         lazy_types: ['false', 'true']
         exclude:
           - php: 7.4
@@ -45,6 +45,8 @@ jobs:
             laravel: ^6.0
           - php: 8.2
             laravel: ^6.0
+          - php: 8.0
+            laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
             laravel: ^6.0
           - php: 8.0
             laravel: ^10.0
+          - php: 7.4
+            laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }} Lazy types=${{ matrix.lazy_types }}
     runs-on: ubuntu-latest
     env:

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     "require": {
         "php": ">= 7.4",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^8.0|^9.0",
+        "illuminate/contracts": "^6.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^6.0|^8.0|^9.0|^10.0",
         "laragraph/utils": "^1",
         "thecodingmachine/safe": "^1.1|^2.4",
         "webonyx/graphql-php": "^14.6.4"
@@ -48,9 +48,8 @@
         "laravel/legacy-factories": "^1.0",
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.2",
-        "nunomaduro/larastan": "1.0.3",
-        "orchestra/testbench": "4.0.*|5.0.*|^6.0|^7.0",
-        "phpstan/phpstan": "1.8.4",
+        "nunomaduro/larastan": "1.0.3|^2.0",
+        "orchestra/testbench": "4.0.*|5.0.*|^6.0|^7.0|^8.0",
         "phpunit/phpunit": "~7.0|~8.0|^9",
         "thecodingmachine/phpstan-safe-rule": "^1"
     },

--- a/tests/Unit/Input/UserInputTest.php
+++ b/tests/Unit/Input/UserInputTest.php
@@ -36,9 +36,10 @@ GRAQPHQL;
                     'extensions' => [
                         'category' => 'validation',
                         'validation' => [
-                                'data.0.password' => [
-                                    'The data.0.password and data.*.password confirmation must match.',
-                                ],
+                            'data.0.password' => [
+                                // The data.0.password and data.*.password confirmation must match.
+                                trans('validation.same', ['attribute' => 'data.0.password', 'other' => 'data.*.password confirmation']),
+                            ],
                         ],
                     ],
                     'locations' => [
@@ -90,10 +91,12 @@ GRAQPHQL;
                         'category' => 'validation',
                         'validation' => [
                             'data.0.password' => [
-                                'The data.0.password and data.*.password confirmation must match.',
+                                // The data.0.password and data.*.password confirmation must match.
+                                trans('validation.same', ['attribute' => 'data.0.password', 'other' => 'data.*.password confirmation']),
                             ],
                             'data.1.password' => [
-                                'The data.1.password and data.*.password confirmation must match.',
+                                // The data.1.password and data.*.password confirmation must match.
+                                trans('validation.same', ['attribute' => 'data.1.password', 'other' => 'data.*.password confirmation']),
                             ],
                         ],
                     ],

--- a/tests/Unit/MutationTest.php
+++ b/tests/Unit/MutationTest.php
@@ -356,11 +356,13 @@ class MutationTest extends FieldTest
 
         self::assertEquals('The test field is required.', $messages->first('test'));
         self::assertEquals(
-            'The test with rules nullable input object.nest.email must be a valid email address.',
+            // The test with rules nullable input object.nest.email must be a valid email address.
+            trans('validation.email', ['attribute' => 'test with rules nullable input object.nest.email']),
             $messages->first('test_with_rules_nullable_input_object.nest.email')
         );
         self::assertEquals(
-            'The test with rules non nullable input object.nest.email must be a valid email address.',
+            // The test with rules non nullable input object.nest.email must be a valid email address.
+            trans('validation.email', ['attribute' => 'test with rules non nullable input object.nest.email']),
             $messages->first('test_with_rules_non_nullable_input_object.nest.email')
         );
     }

--- a/tests/Unit/ValidationOfFieldArguments/ValidationOfFieldArgumentsTest.php
+++ b/tests/Unit/ValidationOfFieldArguments/ValidationOfFieldArgumentsTest.php
@@ -54,13 +54,16 @@ GRAPHQL;
                         'category' => 'validation',
                         'validation' => [
                             'profile.fields.name.args.includeMiddleNames' => [
-                                'The profile.fields.name.args.include middle names format is invalid.',
+                                // The profile.fields.name.args.include middle names format is invalid.',
+                                trans('validation.regex', ['attribute' => 'profile.fields.name.args.include middle names']),
                             ],
                             'profile.fields.height.args.unit' => [
-                                'The profile.fields.height.args.unit format is invalid.',
+                                // 'The profile.fields.height.args.unit format is invalid.
+                                trans('validation.regex', ['attribute' => 'profile.fields.height.args.unit']),
                             ],
                             'profile.args.profileId' => [
-                                'The profile.args.profile id must not be greater than 10.',
+                                // The profile.args.profile id must not be greater than 10.
+                                trans('validation.max.numeric', ['attribute' => 'profile.args.profile id', 'max' => 10]),
                             ],
                         ],
                     ],
@@ -113,7 +116,8 @@ GRAPHQL;
                         'category' => 'validation',
                         'validation' => [
                             'alias.args.type' => [
-                                'The alias.args.type format is invalid.',
+                                // The alias.args.type format is invalid.
+                                trans('validation.regex', ['attribute' => 'alias.args.type']),
                             ],
                         ],
                     ],


### PR DESCRIPTION
## Summary

This PR adds Laravel 10 support.

- Updates dependencies
- Updates GitHub Action workflows
- The only failing tests had to do with validation strings, which have changed slightly in Laravel 10. I've updated the tests to use `lang()` helper instead of the strings

Only issue is code analysis:

PHPStan is now failing. This is a little over my head. I had to require v2 of larastan in order for Laravel 10 to be installable. I removed the phpstan explicit requirement so larastan can deal with that. Maybe that's why it's failing. Or maybe it has to do with all the typehints added to Laravel 10.

I noticed in [this commit](https://github.com/rebing/graphql-laravel/commit/6b8c3702941be95f0ff44b57e4596e8f0ccf5580) that you required explicit versions. Not sure of the story behind that.

From my end, this PR is done / ready for review. Let me know what you want done regarding Larastan/PHPStan.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
