### PR TITLE
chore(tests): fix "assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10."

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -256,4 +256,15 @@ class TestCase extends BaseTestCase
     {
         self::assertThat($string, new RegularExpression($pattern), $message);
     }
+
+    /**
+     * @note Maybe can be removed in PHPUnit 10+ if https://github.com/sebastianbergmann/phpunit/pull/5231 gets merged and replaced with `assertObjectHasProperty`. For now uses suggested workaround from https://github.com/sebastianbergmann/phpunit/issues/4601#issuecomment-1418923160
+     *
+     * @param mixed $object
+     */
+    public static function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
+    {
+        self::assertIsObject($object);
+        self::assertTrue(property_exists($object, $attributeName));
+    }
 }


### PR DESCRIPTION
## Summary
By introducing our own version for now.

See:
- https://github.com/sebastianbergmann/phpunit/issues/4601#issuecomment-1418923160
- https://github.com/sebastianbergmann/phpunit/issues/5220

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
