### PR TITLE
Update argument notation for example directive

### DIFF
--- a/tests/Support/Directives/ExampleDirective.php
+++ b/tests/Support/Directives/ExampleDirective.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Support\Directives;
 
 use GraphQL\Language\DirectiveLocation;
-use GraphQL\Type\Definition\Argument;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\Type;
 
@@ -20,11 +19,10 @@ class ExampleDirective extends Directive
                 DirectiveLocation::QUERY,
             ],
             'args' => [
-                'first' => new Argument([
-                    'name' => 'first',
+                'first' => [
                     'description' => 'Description of this argument',
                     'type' => Type::string(),
-                ]),
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
## Summary
The argument notation has been changed since v15 of graphql-php ([see example](https://webonyx.github.io/graphql-php/type-definitions/directives/#custom-directives)). The argument object is now instantiated internally.
- …

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
