### PR TITLE
Commands improvements

### DIFF
--- a/src/Console/EnumMakeCommand.php
+++ b/src/Console/EnumMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:enum')]
 class EnumMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:enum {name}';

--- a/src/Console/EnumMakeCommand.php
+++ b/src/Console/EnumMakeCommand.php
@@ -13,17 +13,17 @@ class EnumMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL enum class';
     protected $type = 'Enum';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/enum.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Enums';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/ExecutionMiddlewareMakeCommand.php
+++ b/src/Console/ExecutionMiddlewareMakeCommand.php
@@ -13,12 +13,12 @@ class ExecutionMiddlewareMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL execution middleware class';
     protected $type = 'ExecutionMiddleware';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/executionMiddleware.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Middleware\Execution';
     }

--- a/src/Console/ExecutionMiddlewareMakeCommand.php
+++ b/src/Console/ExecutionMiddlewareMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:executionMiddleware')]
 class ExecutionMiddlewareMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:executionMiddleware {name}';

--- a/src/Console/FieldMakeCommand.php
+++ b/src/Console/FieldMakeCommand.php
@@ -13,12 +13,12 @@ class FieldMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL field class';
     protected $type = 'Field';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/field.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Fields';
     }

--- a/src/Console/FieldMakeCommand.php
+++ b/src/Console/FieldMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:field')]
 class FieldMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:field {name}';

--- a/src/Console/InputMakeCommand.php
+++ b/src/Console/InputMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:input')]
 class InputMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:input {name}';

--- a/src/Console/InputMakeCommand.php
+++ b/src/Console/InputMakeCommand.php
@@ -13,17 +13,17 @@ class InputMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL input class';
     protected $type = 'Input';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/input.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Inputs';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/InterfaceMakeCommand.php
+++ b/src/Console/InterfaceMakeCommand.php
@@ -13,17 +13,17 @@ class InterfaceMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL interface class';
     protected $type = 'Interface';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/interface.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Interfaces';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/InterfaceMakeCommand.php
+++ b/src/Console/InterfaceMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:interface')]
 class InterfaceMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:interface {name}';

--- a/src/Console/MiddlewareMakeCommand.php
+++ b/src/Console/MiddlewareMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:middleware')]
 class MiddlewareMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:middleware {name}';

--- a/src/Console/MiddlewareMakeCommand.php
+++ b/src/Console/MiddlewareMakeCommand.php
@@ -13,12 +13,12 @@ class MiddlewareMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL middleware class';
     protected $type = 'Middleware';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/middleware.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Middleware';
     }

--- a/src/Console/MutationMakeCommand.php
+++ b/src/Console/MutationMakeCommand.php
@@ -13,17 +13,17 @@ class MutationMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL mutation class';
     protected $type = 'Mutation';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/mutation.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Mutations';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/MutationMakeCommand.php
+++ b/src/Console/MutationMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:mutation')]
 class MutationMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:mutation {name}';

--- a/src/Console/QueryMakeCommand.php
+++ b/src/Console/QueryMakeCommand.php
@@ -13,17 +13,17 @@ class QueryMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL query class';
     protected $type = 'Query';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/query.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Queries';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/QueryMakeCommand.php
+++ b/src/Console/QueryMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:query')]
 class QueryMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:query {name}';

--- a/src/Console/ScalarMakeCommand.php
+++ b/src/Console/ScalarMakeCommand.php
@@ -13,12 +13,12 @@ class ScalarMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL scalar class';
     protected $type = 'Scalar';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/scalar.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Scalars';
     }

--- a/src/Console/ScalarMakeCommand.php
+++ b/src/Console/ScalarMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:scalar')]
 class ScalarMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:scalar {name}';

--- a/src/Console/SchemaConfigMakeCommand.php
+++ b/src/Console/SchemaConfigMakeCommand.php
@@ -13,12 +13,12 @@ class SchemaConfigMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL schema configuration class';
     protected $type = 'Schema';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/schemaConfig.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Schemas';
     }

--- a/src/Console/SchemaConfigMakeCommand.php
+++ b/src/Console/SchemaConfigMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:schemaConfig')]
 class SchemaConfigMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:schemaConfig {name}';

--- a/src/Console/TypeMakeCommand.php
+++ b/src/Console/TypeMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:type')]
 class TypeMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:type {name}';

--- a/src/Console/TypeMakeCommand.php
+++ b/src/Console/TypeMakeCommand.php
@@ -13,17 +13,17 @@ class TypeMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL type class';
     protected $type = 'Type';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/type.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Types';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/UnionMakeCommand.php
+++ b/src/Console/UnionMakeCommand.php
@@ -13,17 +13,17 @@ class UnionMakeCommand extends GeneratorCommand
     protected $description = 'Create a new GraphQL union class';
     protected $type = 'Union';
 
-    protected function getStub()
+    protected function getStub(): string
     {
         return __DIR__ . '/stubs/union.stub';
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\GraphQL\Unions';
     }
 
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 

--- a/src/Console/UnionMakeCommand.php
+++ b/src/Console/UnionMakeCommand.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('make:graphql:union')]
 class UnionMakeCommand extends GeneratorCommand
 {
     protected $signature = 'make:graphql:union {name}';

--- a/src/GraphQLServiceProvider.php
+++ b/src/GraphQLServiceProvider.php
@@ -130,17 +130,19 @@ class GraphQLServiceProvider extends ServiceProvider
      */
     public function registerConsole(): void
     {
-        $this->commands(EnumMakeCommand::class);
-        $this->commands(FieldMakeCommand::class);
-        $this->commands(InputMakeCommand::class);
-        $this->commands(InterfaceMakeCommand::class);
-        $this->commands(InterfaceMakeCommand::class);
-        $this->commands(MiddlewareMakeCommand::class);
-        $this->commands(MutationMakeCommand::class);
-        $this->commands(QueryMakeCommand::class);
-        $this->commands(ScalarMakeCommand::class);
-        $this->commands(SchemaConfigMakeCommand::class);
-        $this->commands(TypeMakeCommand::class);
-        $this->commands(UnionMakeCommand::class);
+        $this->commands([
+            EnumMakeCommand::class,
+            FieldMakeCommand::class,
+            InputMakeCommand::class,
+            InterfaceMakeCommand::class,
+            InterfaceMakeCommand::class,
+            MiddlewareMakeCommand::class,
+            MutationMakeCommand::class,
+            QueryMakeCommand::class,
+            ScalarMakeCommand::class,
+            SchemaConfigMakeCommand::class,
+            TypeMakeCommand::class,
+            UnionMakeCommand::class,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
Three improvements to the generator commands:
- Register all commands at once, preventing extra method calls
- Add `AsCommand` attribute to all commands, so they are not all instantiated on every artisan command execution
- Add return types (breaking change)

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
