### PR TITLE
Remove support for Laravel 8 (and PHP 7.4)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,13 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
-        laravel: [^8.0, ^9.0, ^10.0]
+        laravel: [^9.0, ^10.0]
         exclude:
-          - php: 7.4
-            laravel: ^9.0
           - php: 8.0
-            laravel: ^10.0
-          - php: 7.4
             laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
@@ -58,8 +54,6 @@ jobs:
       # Due to version incompatibility with older Laravels we test, we remove it
       - run: composer remove --dev nunomaduro/larastan --no-update
       - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
-      - run: composer remove --dev laravel/legacy-factories --no-update
-        if: (matrix.laravel == '^6.0' || matrix.laravel == '^7.0')
       - run: composer require illuminate/contracts:${{ matrix.laravel }} --no-update
 
       - name: Get composer cache directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,13 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
-        laravel: [^8.0, ^9.0, ^10.0]
+        laravel: [^9.0, ^10.0]
         exclude:
-          - php: 7.4
-            laravel: ^9.0
           - php: 8.0
-            laravel: ^10.0
-          - php: 7.4
             laravel: ^10.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
@@ -59,8 +55,6 @@ jobs:
       # Due to version incompatibility with older Laravels we test, we remove it
       - run: composer remove --dev nunomaduro/larastan --no-update
       - run: composer remove --dev friendsofphp/php-cs-fixer --no-update
-      - run: composer remove --dev laravel/legacy-factories --no-update
-        if: (matrix.laravel == '^6.0' || matrix.laravel == '^7.0')
       - run: composer require illuminate/contracts:${{ matrix.laravel }} --no-update
 
       - name: Get composer cache directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ CHANGELOG
   name have to match.
 - Remove integrated GraphiQL support in favour of https://github.com/mll-lab/laravel-graphiql [\#986 / mfn](https://github.com/rebing/graphql-laravel/pull/986)
 - Laravel 6 is no longer supported [\#967 / mfn](https://github.com/rebing/graphql-laravel/pull/967)
+- Laravel 8 is no longer supported [\#1049 / mfn](https://github.com/rebing/graphql-laravel/pull/1049)
 
 ## Changed
 - The type resolver is now able to resolve the top level types 'Query',

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://img.shields.io/packagist/dt/rebing/graphql-laravel.svg?style=flat-square)](https://packagist.org/packages/rebing/graphql-laravel)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/rebing-graphql/shared_invite/enQtNTE5NjQzNDI5MzQ4LTdhNjk0ZGY1N2U1YjE4MGVlYmM2YTc2YjQ0MmIwODY5MWMwZWIwYmY1MWY4NTZjY2Q5MzdmM2Q3NTEyNDYzZjc)
 
-Use Facebook's GraphQL with PHP 7.4+ on Laravel 8.0+. It is based on the [PHP port of GraphQL reference implementation](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](https://reactjs.org/blog/2015/05/01/graphql-introduction.html) on the [React](https://reactjs.org/) blog or you can read the [GraphQL specifications](https://spec.graphql.org/).
+Use Facebook's GraphQL with PHP 8.0+ on Laravel 9.0+. It is based on the [PHP port of GraphQL reference implementation](https://github.com/webonyx/graphql-php). You can find more information about GraphQL in the [GraphQL Introduction](https://reactjs.org/blog/2015/05/01/graphql-introduction.html) on the [React](https://reactjs.org/) blog or you can read the [GraphQL specifications](https://spec.graphql.org/).
 
 * Allows creating **queries** and **mutations** as request endpoints
 * Supports multiple schemas
@@ -33,7 +33,7 @@ It offers following features and improvements over the original package by
 
 ### Dependencies:
 
-* [Laravel 6.0+](https://github.com/laravel/laravel)
+* [Laravel 9.0+](https://github.com/laravel/laravel)
 * [GraphQL PHP](https://github.com/webonyx/graphql-php)
 
 

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": ">= 7.4",
+        "php": "^8.0",
         "ext-json": "*",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "laragraph/utils": "^2",
-        "thecodingmachine/safe": "^1.1|^2.4",
+        "thecodingmachine/safe": "^2.4",
         "webonyx/graphql-php": "^15"
     },
     "require-dev": {
@@ -50,8 +50,8 @@
         "mockery/mockery": "^1.2",
         "phpstan/phpstan": "1.10.18",
         "nunomaduro/larastan": "2.6.2",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "~8.0|^9",
+        "orchestra/testbench": "^7.0|^8.0",
+        "phpunit/phpunit": "^9",
         "thecodingmachine/phpstan-safe-rule": "^1"
     },
     "autoload": {
@@ -69,7 +69,7 @@
         "phpstan-baseline": "phpstan analyse --memory-limit=512M --generate-baseline",
         "lint": "php-cs-fixer fix --diff --dry-run",
         "fix-style": "php-cs-fixer fix",
-        "tests": "phpunit --colors=always --verbose"
+        "tests": "phpunit"
     },
     "extra": {
         "branch-alias": {

--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -134,7 +134,7 @@ class EmptyQueryTest extends TestCaseDatabase
     /**
      * @return array<mixed>
      */
-    public function dataForEmptyQuery(): array
+    public static function dataForEmptyQuery(): array
     {
         return [
             // completely empty request

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,6 @@ use GraphQL\Type\Schema;
 use Illuminate\Console\Command;
 use Illuminate\Http\JsonResponse;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
@@ -241,14 +240,6 @@ class TestCase extends BaseTestCase
                 return $line;
             }, $trace, array_keys($trace))
         );
-    }
-
-    /**
-     * @todo Remove this method once we're PHPUnit 9+ only.
-     */
-    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
-    {
-        self::assertThat($string, new RegularExpression($pattern), $message);
     }
 
     /**

--- a/tests/Unit/Console/EnumMakeCommandTest.php
+++ b/tests/Unit/Console/EnumMakeCommandTest.php
@@ -31,7 +31,7 @@ class EnumMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/ExecutionMiddlewareMakeCommandTest.php
+++ b/tests/Unit/Console/ExecutionMiddlewareMakeCommandTest.php
@@ -29,7 +29,7 @@ class ExecutionMiddlewareMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/InputMakeCommandTest.php
+++ b/tests/Unit/Console/InputMakeCommandTest.php
@@ -31,7 +31,7 @@ class InputMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/InterfaceMakeCommandTest.php
+++ b/tests/Unit/Console/InterfaceMakeCommandTest.php
@@ -31,7 +31,7 @@ class InterfaceMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/MiddlewareMakeCommandTest.php
+++ b/tests/Unit/Console/MiddlewareMakeCommandTest.php
@@ -29,7 +29,7 @@ class MiddlewareMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/MutationMakeCommandTest.php
+++ b/tests/Unit/Console/MutationMakeCommandTest.php
@@ -31,7 +31,7 @@ class MutationMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/QueryMakeCommandTest.php
+++ b/tests/Unit/Console/QueryMakeCommandTest.php
@@ -31,7 +31,7 @@ class QueryMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/ScalarMakeCommandTest.php
+++ b/tests/Unit/Console/ScalarMakeCommandTest.php
@@ -31,7 +31,7 @@ class ScalarMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/SchemaConfigMakeCommandTest.php
+++ b/tests/Unit/Console/SchemaConfigMakeCommandTest.php
@@ -32,7 +32,7 @@ class SchemaConfigMakeCommandTest extends TestCase
     /**
      * @return array<string,mixed>
      */
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/TypeMakeCommandTest.php
+++ b/tests/Unit/Console/TypeMakeCommandTest.php
@@ -31,7 +31,7 @@ class TypeMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [

--- a/tests/Unit/Console/UnionMakeCommandTest.php
+++ b/tests/Unit/Console/UnionMakeCommandTest.php
@@ -31,7 +31,7 @@ class UnionMakeCommandTest extends TestCase
         );
     }
 
-    public function dataForMakeCommand(): array
+    public static function dataForMakeCommand(): array
     {
         return [
             'Example' => [


### PR DESCRIPTION
## Summary
See title.

Reasoning: Laravel 8 as well as PHP 7.4 are long EOL and out of security support

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
