### PR TITLE
Revert "chore(gha): target 8.x branch for now"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,12 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    target-branch: 8.x
     schedule:
       interval: weekly
 
   - package-ecosystem: composer
     directory: /
-    target-branch: 8.x
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary
This reverts commit af33df4e77fb8d1149cec088733f576961c4aa35.

In light of the upcoming 9.0.0 release, change dependabot back to target master for updates.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
