### PR TITLE
Implement lazy root types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/9.1.0...master)
 --------------
+### Changed
+- Implement lazy root types [\#1091 / sforward](https://github.com/rebing/graphql-laravel/pull/1091)
 
 2023-08-06, 9.1.0
 -----------------

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "illuminate/support": "^9.0|^10.0",
         "laragraph/utils": "^2.0.1",
         "thecodingmachine/safe": "^2.4",
-        "webonyx/graphql-php": "^15.0.3"
+        "webonyx/graphql-php": "^15.6.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			path: src/GraphQL.php
 
 		-
-			message: "#^Parameter \\#1 \\$config of class GraphQL\\\\Type\\\\Schema constructor expects array\\{query\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, mutation\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, subscription\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, types\\?\\: \\(callable\\(\\)\\: iterable\\<GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\>\\)\\|iterable\\<GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\>\\|null, directives\\?\\: array\\<GraphQL\\\\Type\\\\Definition\\\\Directive\\>\\|null, typeLoader\\?\\: \\(callable\\(string\\)\\: \\(\\(GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\)\\|null\\)\\)\\|null, assumeValid\\?\\: bool\\|null, astNode\\?\\: GraphQL\\\\Language\\\\AST\\\\SchemaDefinitionNode\\|null, \\.\\.\\.\\}\\|GraphQL\\\\Type\\\\SchemaConfig, array\\{query\\: GraphQL\\\\Type\\\\Definition\\\\Type, mutation\\: GraphQL\\\\Type\\\\Definition\\\\Type\\|null, subscription\\: GraphQL\\\\Type\\\\Definition\\\\Type\\|null, directives\\: array\\<int\\|string, mixed\\>, types\\: Closure\\(\\)\\: list\\<GraphQL\\\\Type\\\\Definition\\\\Type\\>, typeLoader\\: Closure\\(mixed\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\)\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$config of class GraphQL\\\\Type\\\\Schema constructor expects array\\{query\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, mutation\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, subscription\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, types\\?\\: \\(callable\\(\\)\\: iterable\\<GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\>\\)\\|iterable\\<GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\>\\|null, directives\\?\\: array\\<GraphQL\\\\Type\\\\Definition\\\\Directive\\>\\|null, typeLoader\\?\\: \\(callable\\(string\\)\\: \\(\\(GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\)\\|null\\)\\)\\|null, assumeValid\\?\\: bool\\|null, astNode\\?\\: GraphQL\\\\Language\\\\AST\\\\SchemaDefinitionNode\\|null, \\.\\.\\.\\}\\|GraphQL\\\\Type\\\\SchemaConfig, array\\{query\\: Closure\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\), mutation\\: Closure\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\), subscription\\: Closure\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\), directives\\: array\\<int\\|string, mixed\\>, types\\: Closure\\(\\)\\: list\\<GraphQL\\\\Type\\\\Definition\\\\Type\\>, typeLoader\\: Closure\\(mixed\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\)\\} given\\.$#"
 			count: 1
 			path: src/GraphQL.php
 
@@ -27,6 +27,11 @@ parameters:
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\GraphQL\\:\\:\\$types \\(array\\<string, object\\|string\\>\\) does not accept array\\<int\\|string, object\\|string\\>\\.$#"
+			count: 1
+			path: src/GraphQL.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\GraphQL\\:\\:\\$typesInstances \\(array\\<GraphQL\\\\Type\\\\Definition\\\\Type\\>\\) does not accept array\\<GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\>\\.$#"
 			count: 1
 			path: src/GraphQL.php
 


### PR DESCRIPTION
## Summary
This PR implements the lazy root types, supported since 15.6.0 of webonyx/graphql-php. I see some performance improvements by this change, tested in a project with several queries and mutations.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
