### PR TITLE
Make fields of root types lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/9.1.0...master)
 --------------
+### Changed
+- Implement lazy fields for root types [\#1092 / sforward](https://github.com/rebing/graphql-laravel/pull/1092)
 
 2023-08-06, 9.1.0
 -----------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,7 +2,7 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Cannot access offset 'name' on array\\<string, mixed\\>\\|Rebing\\\\GraphQL\\\\Support\\\\Field\\.$#"
-			count: 2
+			count: 3
 			path: src/GraphQL.php
 
 		-
@@ -11,7 +11,7 @@ parameters:
 			path: src/GraphQL.php
 
 		-
-			message: "#^Parameter \\#1 \\$config of class GraphQL\\\\Type\\\\Definition\\\\ObjectType constructor expects array\\{name\\?\\: string\\|null, description\\?\\: string\\|null, resolveField\\?\\: \\(callable\\(mixed, array\\<string, mixed\\>, mixed, GraphQL\\\\Type\\\\Definition\\\\ResolveInfo\\)\\: mixed\\)\\|null, fields\\: \\(callable\\(\\)\\: iterable\\)\\|iterable, interfaces\\?\\: \\(callable\\(\\)\\: iterable\\<callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\|GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\>\\)\\|iterable\\<\\(callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\)\\|GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\>, isTypeOf\\?\\: \\(callable\\(mixed, mixed, GraphQL\\\\Type\\\\Definition\\\\ResolveInfo\\)\\: \\(bool\\|GraphQL\\\\Deferred\\|null\\)\\)\\|null, astNode\\?\\: GraphQL\\\\Language\\\\AST\\\\ObjectTypeDefinitionNode\\|null, extensionASTNodes\\?\\: array\\<int, GraphQL\\\\Language\\\\AST\\\\ObjectTypeExtensionNode\\>\\|null\\}, non\\-empty\\-array\\<string, array\\<int\\|string, non\\-empty\\-array\\<string, mixed\\>\\|\\(ArrayAccess&Rebing\\\\GraphQL\\\\Support\\\\Field\\)\\>\\|string\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$config of class GraphQL\\\\Type\\\\Definition\\\\ObjectType constructor expects array\\{name\\?\\: string\\|null, description\\?\\: string\\|null, resolveField\\?\\: \\(callable\\(mixed, array\\<string, mixed\\>, mixed, GraphQL\\\\Type\\\\Definition\\\\ResolveInfo\\)\\: mixed\\)\\|null, fields\\: \\(callable\\(\\)\\: iterable\\)\\|iterable, interfaces\\?\\: \\(callable\\(\\)\\: iterable\\<callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\|GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\>\\)\\|iterable\\<\\(callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\)\\|GraphQL\\\\Type\\\\Definition\\\\InterfaceType\\>, isTypeOf\\?\\: \\(callable\\(mixed, mixed, GraphQL\\\\Type\\\\Definition\\\\ResolveInfo\\)\\: \\(bool\\|GraphQL\\\\Deferred\\|null\\)\\)\\|null, astNode\\?\\: GraphQL\\\\Language\\\\AST\\\\ObjectTypeDefinitionNode\\|null, extensionASTNodes\\?\\: array\\<int, GraphQL\\\\Language\\\\AST\\\\ObjectTypeExtensionNode\\>\\|null\\}, non\\-empty\\-array\\<string, array\\<int\\|string, non\\-empty\\-array\\<string, mixed\\>\\|\\(ArrayAccess&Rebing\\\\GraphQL\\\\Support\\\\Field\\)\\|\\(Closure\\(\\)\\: \\(array\\<string, mixed\\>\\|Rebing\\\\GraphQL\\\\Support\\\\Field\\)\\)\\>\\|string\\> given\\.$#"
 			count: 1
 			path: src/GraphQL.php
 
@@ -1414,6 +1414,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$visitor of static method GraphQL\\\\Language\\\\Visitor\\:\\:visit\\(\\) expects array\\<string, array\\<string, callable\\(GraphQL\\\\Language\\\\AST\\\\Node\\)\\: \\(GraphQL\\\\Language\\\\VisitorOperation\\|void\\|false\\|null\\)\\>\\|\\(callable\\(GraphQL\\\\Language\\\\AST\\\\Node\\)\\: \\(GraphQL\\\\Language\\\\VisitorOperation\\|void\\|false\\|null\\)\\)\\>, array\\{VariableDefinition\\: Closure\\(mixed, mixed, mixed, mixed, mixed\\)\\: mixed\\} given\\.$#"
 			count: 1
 			path: tests/Unit/ExecutionMiddlewareTest/ChangeQueryArgTypeMiddleware.php
+
+		-
+			message: "#^Cannot call method afterResolving\\(\\) on Illuminate\\\\Foundation\\\\Application\\|null\\.$#"
+			count: 1
+			path: tests/Unit/GraphQLQueryTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with non\\-empty\\-array will always evaluate to true\\.$#"

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -332,13 +332,29 @@ class GraphQL
         $typeFields = [];
 
         foreach ($fields as $name => $field) {
-            if (\is_string($field)) {
-                $field = $this->app->make($field);
-                /** @var Field $field */
-                $field = $field->toArray();
+            $fieldResolver = function () use ($field, $name) {
+                if (\is_string($field)) {
+                    $field = $this->app->make($field);
+                    /** @var Field $field */
+                    $field = $field->toArray();
+                }
+
+                if (!is_numeric($name)) {
+                    $field['name'] = $name;
+                }
+
+                return $field;
+            };
+
+            if (is_numeric($name)) {
+                $field = $fieldResolver();
+
+                $name = $field['name'];
+                $field['name'] = $name;
+            } else {
+                $field = $fieldResolver;
             }
-            $name = is_numeric($name) ? $field['name'] : $name;
-            $field['name'] = $name;
+
             $typeFields[$name] = $field;
         }
 


### PR DESCRIPTION
## Summary
This makes the fields of the Query and Mutation root types lazy, so they aren't all initialized anymore on every request. Names are required in the schema config to apply this performance benefit, for example:

```
    'query' => [
        'example' => ExampleQuery::class,
    ],
```

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
