### PR TITLE
Remove Duplicate HTTP Status Code Assertion

### DIFF
--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -474,7 +474,6 @@ SQL
             ],
         ];
 
-        self::assertEquals(200, $response->getStatusCode());
         self::assertEquals($expectedResult, $response->json());
     }
 
@@ -533,7 +532,6 @@ SQL
             ],
         ];
 
-        self::assertEquals(200, $response->getStatusCode());
         self::assertEquals($expectedResult, $response->json());
     }
 
@@ -576,7 +574,6 @@ SQL
             ],
         ];
 
-        self::assertEquals(200, $response->getStatusCode());
         self::assertEquals($expectedResult, $response->json());
     }
 


### PR DESCRIPTION
Remove redundant assertions for the HTTP status code in the `SelectFieldsTest`.