### PR TITLE
laravel: use new factory approach

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "3.37.1",
-        "laravel/legacy-factories": "^1.0",
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.2",
         "phpstan/phpstan": "1.10.40",

--- a/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
+++ b/tests/Database/MutationValidationUniqueWithCustomRulesTests/MutationValidationUniqueWithCustomRulesTest.php
@@ -25,7 +25,7 @@ class MutationValidationUniqueWithCustomRulesTest extends TestCaseDatabase
     public function testUniquePassRulePass(): void
     {
         /* @var User $user */
-        factory(User::class)
+        User::factory()
             ->create([
                 'name' => 'name_unique',
             ]);
@@ -62,7 +62,7 @@ SQL
     public function testUniqueFailRulePass(): void
     {
         /* @var User $user */
-        factory(User::class)
+        User::factory()
             ->create([
                 'name' => 'name_unique',
             ]);
@@ -118,7 +118,7 @@ SQL
     public function testUniquePassRuleFail(): void
     {
         /* @var User $user */
-        factory(User::class)
+        User::factory()
             ->create([
                 'name' => 'name_unique',
             ]);
@@ -168,7 +168,7 @@ GRAPHQL;
     public function testUniqueFailRuleFail(): void
     {
         /* @var User $user */
-        factory(User::class)
+        User::factory()
             ->create([
                 'name' => 'name_unique',
             ]);
@@ -225,7 +225,7 @@ SQL
     public function testErrorExtension(): void
     {
         /* @var User $user */
-        factory(User::class)
+        User::factory()
             ->create([
                 'name' => 'name_unique',
             ]);

--- a/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
+++ b/tests/Database/SelectFields/AlwaysRelationTests/AlwaysRelationTest.php
@@ -36,16 +36,16 @@ class AlwaysRelationTest extends TestCaseDatabase
     public function testAlwaysSingleHasManyRelationField(): void
     {
         /** @var User $user */
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'name' => 'User Name',
         ]);
 
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'user_id' => $user->id,
         ]);
 
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'post_id' => $post->id,
         ]);
 
@@ -101,14 +101,14 @@ GRAQPHQL;
 
     public function testAlwaysSingleMorphRelationField(): void
     {
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'name' => 'User Name',
         ]);
 
         /** @var Post $post */
-        $post = factory(Post::class)->create();
+        $post = Post::factory()->create();
 
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'post_id' => $post->id,
             ]);

--- a/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
+++ b/tests/Database/SelectFields/AlwaysTests/AlwaysTest.php
@@ -31,13 +31,13 @@ class AlwaysTest extends TestCaseDatabase
     public function testAlwaysSingleField(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -86,13 +86,13 @@ SQL
     public function testAlwaysSingleMultipleFieldInString(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -143,13 +143,13 @@ SQL
     public function testAlwaysSingleMultipleFieldInArray(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -200,13 +200,13 @@ SQL
     public function testAlwaysSameFieldTwice(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,

--- a/tests/Database/SelectFields/ArrayTests/ArrayTest.php
+++ b/tests/Database/SelectFields/ArrayTests/ArrayTest.php
@@ -38,7 +38,7 @@ class ArrayTest extends TestCaseDatabase
         ];
 
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'properties' => $properties,
         ]);
 

--- a/tests/Database/SelectFields/ComputedPropertiesTests/ComputedPropertiesTest.php
+++ b/tests/Database/SelectFields/ComputedPropertiesTests/ComputedPropertiesTest.php
@@ -32,11 +32,11 @@ class ComputedPropertiesTest extends TestCaseDatabase
     public function testComputedProperty(): void
     {
         /** @var User $user */
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
         ]);
 
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'user_id' => $user->id,
         ]);
 

--- a/tests/Database/SelectFields/DepthTests/DepthTest.php
+++ b/tests/Database/SelectFields/DepthTests/DepthTest.php
@@ -31,8 +31,8 @@ class DepthTest extends TestCaseDatabase
     public function testDefaultDepthExceeded(): void
     {
         /** @var User $user */
-        $user = factory(User::class)->create();
-        factory(Post::class)->create([
+        $user = User::factory()->create();
+        Post::factory()->create([
             'user_id' => $user->id,
         ]);
 

--- a/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
+++ b/tests/Database/SelectFields/InterfaceTests/InterfaceTest.php
@@ -42,7 +42,7 @@ class InterfaceTest extends TestCaseDatabase
 
     public function testGeneratedSqlQuery(): void
     {
-        factory(Post::class)->create([
+        Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -79,11 +79,11 @@ SQL
     public function testGeneratedRelationSqlQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'title' => 'Title of the post',
             ]);
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'title' => 'Title of the comment',
                 'post_id' => $post->id,
@@ -133,18 +133,18 @@ SQL
     public function testGeneratedInterfaceFieldSqlQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'title' => 'Title of the post',
             ]);
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'title' => 'Title of the comment',
                 'post_id' => $post->id,
             ]);
 
         /** @var User $user */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         Like::create([
             'likable_id' => $post->id,
             'likable_type' => Post::class,
@@ -200,18 +200,18 @@ SQL
     public function testGeneratedInterfaceFieldInlineFragmentsAndAlias(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'title' => 'Title of the post',
             ]);
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'title' => 'Title of the comment',
                 'post_id' => $post->id,
             ]);
 
         /** @var User $user */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         Like::create([
             'likable_id' => $post->id,
             'likable_type' => Post::class,
@@ -273,20 +273,20 @@ SQL
     public function testGeneratedInterfaceFieldWithRelationSqlQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'title' => 'Title of the post',
             ]);
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'title' => 'Title of the comment',
                 'post_id' => $post->id,
             ]);
 
         /** @var User $user */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         /** @var User $user2 */
-        $user2 = factory(User::class)->create();
+        $user2 = User::factory()->create();
         $like1 = Like::create([
             'likable_id' => $post->id,
             'likable_type' => Post::class,
@@ -378,21 +378,21 @@ SQL
     public function testGeneratedInterfaceFieldWithRelationAndCustomQueryOnInterfaceSqlQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'title' => 'Title of the post',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'title' => 'Title of the comment',
                 'post_id' => $post->id,
             ]);
 
         /** @var User $user */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         /** @var User $user2 */
-        $user2 = factory(User::class)->create();
+        $user2 = User::factory()->create();
         $like1 = Like::create([
             'likable_id' => $comment->id,
             'likable_type' => Comment::class,

--- a/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
+++ b/tests/Database/SelectFields/MorphRelationshipTests/MorphRelationshipTest.php
@@ -35,20 +35,20 @@ class MorphRelationshipTest extends TestCaseDatabase
     public function testMorphRelationship(): void
     {
         /** @var User $user */
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'name' => 'User Name',
         ]);
 
         /** @var User $otherUser */
-        $otherUser = factory(User::class)->create();
+        $otherUser = User::factory()->create();
 
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'user_id' => $user->id,
         ]);
 
         /** @var Like $like */
-        $like = factory(Like::class)->make([
+        $like = Like::factory()->make([
             'user_id' => $otherUser->id,
         ]);
 

--- a/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/NestedRelationLoadingTests/NestedRelationLoadingTest.php
@@ -33,15 +33,15 @@ class NestedRelationLoadingTest extends TestCaseDatabase
     public function testQueryNoSelectFields(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -175,15 +175,15 @@ SQL
     public function testQuerySelect(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -317,15 +317,15 @@ SQL
     public function testQueryWith(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -455,15 +455,15 @@ SQL
     public function testQuerySelectAndWith(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -598,26 +598,26 @@ SQL
     public function testQuerySelectAndWithAndSubArgs(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class, 2)
+                Comment::factory()->count(2)
                     ->create([
                         'post_id' => $post->id,
                     ]);
 
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class, 2)
+                Comment::factory()->count(2)
                     ->create([
                         'post_id' => $post->id,
                     ]);
@@ -717,36 +717,36 @@ SQL
     public function testQuerySelectAndWithAndNestedSubArgs(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
 
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
@@ -830,10 +830,10 @@ SQL
 
     public function testRelationshipAlias(): void
     {
-        $users = factory(User::class, 1)
+        $users = User::factory()->count(1)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class)
+                Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,

--- a/tests/Database/SelectFields/PrimaryKeyTests/PaginationTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PaginationTest.php
@@ -32,18 +32,18 @@ class PaginationTest extends TestCaseDatabase
     public function testPagination(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 1',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 1 comment 1',
             'post_id' => $post->id,
         ]);
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 2',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 2 comment 1',
             'post_id' => $post->id,
         ]);

--- a/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/PrimaryKeyTest.php
@@ -32,9 +32,9 @@ class PrimaryKeyTest extends TestCaseDatabase
     public function testPrimaryKeyRetrievedWhenSelectingRelations(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create();
+        $post = Post::factory()->create();
         /** @var Comment $comment */
-        $comment = factory(Comment::class)->create(['post_id' => $post->id]);
+        $comment = Comment::factory()->create(['post_id' => $post->id]);
 
         $query = <<<'GRAQPHQL'
 {
@@ -76,18 +76,18 @@ SQL
     public function testPrimaryKeyRetrievedWhenSelectingRelationsAndResultPaginated(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 1',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 1 comment 1',
             'post_id' => $post->id,
         ]);
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 2',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 2 comment 1',
             'post_id' => $post->id,
         ]);

--- a/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
+++ b/tests/Database/SelectFields/PrimaryKeyTests/SimplePaginationTest.php
@@ -32,18 +32,18 @@ class SimplePaginationTest extends TestCaseDatabase
     public function testSimplePagination(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 1',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 1 comment 1',
             'post_id' => $post->id,
         ]);
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 2',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 2 comment 1',
             'post_id' => $post->id,
         ]);
@@ -104,10 +104,10 @@ SQL
     public function testSimplePaginationHasNoMorePage(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'post 1',
         ]);
-        factory(Comment::class)->create([
+        Comment::factory()->create([
             'title' => 'post 1 comment 1',
             'post_id' => $post->id,
         ]);

--- a/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
+++ b/tests/Database/SelectFields/QueryArgsAndContextTests/NestedRelationLoadingTest.php
@@ -37,36 +37,36 @@ class NestedRelationLoadingTest extends TestCaseDatabase
     public function testGraphqlQueryFlagOverridesCustomQueryThroughContext(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
 
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
@@ -125,15 +125,15 @@ SQL
     public function testQueryNoSelectFields(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -267,15 +267,15 @@ SQL
     public function testQuerySelect(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -409,15 +409,15 @@ SQL
     public function testQueryWith(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -547,15 +547,15 @@ SQL
     public function testQuerySelectAndWith(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class, 2)
+                Post::factory()->count(2)
                     ->create([
                         'user_id' => $user->id,
                     ])
                     ->each(function (Post $post): void {
-                        factory(Comment::class, 2)
+                        Comment::factory()->count(2)
                             ->create([
                                 'post_id' => $post->id,
                             ]);
@@ -685,26 +685,26 @@ SQL
     public function testQuerySelectAndWithAndSubArgs(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class, 2)
+                Comment::factory()->count(2)
                     ->create([
                         'post_id' => $post->id,
                     ]);
 
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class, 2)
+                Comment::factory()->count(2)
                     ->create([
                         'post_id' => $post->id,
                     ]);
@@ -799,36 +799,36 @@ SQL
     public function testQuerySelectAndWithAndNestedSubArgs(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
 
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'flag' => true,
                         'post_id' => $post->id,
                     ]);
-                factory(Comment::class)
+                Comment::factory()
                     ->create([
                         'post_id' => $post->id,
                     ]);
@@ -912,10 +912,10 @@ SQL
 
     public function testRelationshipAlias(): void
     {
-        $users = factory(User::class, 1)
+        $users = User::factory()->count(1)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class)
+                Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,
@@ -972,11 +972,11 @@ SQL
     public function testCustomQueryAllowColumnToBeAdded(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
                 /** @var Post $post */
-                $post = factory(Post::class)
+                $post = Post::factory()
                     ->create([
                         'flag' => true,
                         'user_id' => $user->id,

--- a/tests/Database/SelectFields/UnionTests/SearchUnionTest.php
+++ b/tests/Database/SelectFields/UnionTests/SearchUnionTest.php
@@ -37,11 +37,11 @@ class SearchUnionTest extends TestCaseDatabase
     public function testCustomQueryIsExecutedUsingUnionTypeOnQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create();
+        $post = Post::factory()->create();
         /** @var Comment $comment1 */
-        $comment1 = factory(Comment::class)->create(['post_id' => $post->id, 'title' => 'lorem']);
+        $comment1 = Comment::factory()->create(['post_id' => $post->id, 'title' => 'lorem']);
         /** @var Comment $comment2 */
-        $comment2 = factory(Comment::class)->create(['post_id' => $post->id, 'title' => 'ipsum']);
+        $comment2 = Comment::factory()->create(['post_id' => $post->id, 'title' => 'ipsum']);
 
         $query = <<<'GRAQPHQL'
 query ($id: String!) {

--- a/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
+++ b/tests/Database/SelectFields/ValidateDiffNodeTests/ValidateDiffNodeTests.php
@@ -35,15 +35,15 @@ class ValidateDiffNodeTests extends TestCaseDatabase
     public function testDiffValueNodeAndNestedValueNodeArgs(): void
     {
         /** @var User[] $users */
-        $users = factory(User::class, 2)
+        $users = User::factory()->count(2)
             ->create()
             ->each(function (User $user): void {
-                factory(Post::class)
+                Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);
 
-                factory(Post::class)
+                Post::factory()
                     ->create([
                         'user_id' => $user->id,
                     ]);

--- a/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
+++ b/tests/Database/SelectFields/ValidateFieldTests/ValidateFieldTest.php
@@ -34,13 +34,13 @@ class ValidateFieldTest extends TestCaseDatabase
     public function testSelectableFalse(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -91,13 +91,13 @@ SQL
     public function testSelectableNull(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -148,13 +148,13 @@ SQL
     public function testSelectableTrue(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)
+        $post = Post::factory()
             ->create([
                 'body' => 'post body',
                 'title' => 'post title',
             ]);
         /** @var Comment $comment */
-        $comment = factory(Comment::class)
+        $comment = Comment::factory()
             ->create([
                 'body' => 'comment body',
                 'post_id' => $post->id,
@@ -204,7 +204,7 @@ SQL
 
     public function testPrivacyClosureAllowed(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -241,7 +241,7 @@ SQL
 
     public function testPrivacyClosureDenied(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -278,7 +278,7 @@ SQL
 
     public function testPrivacyClassAllowed(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -315,7 +315,7 @@ SQL
 
     public function testPrivacyClassDenied(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -352,7 +352,7 @@ SQL
 
     public function testPrivacyClassMultipleTimesIsCalledMultipleTimes(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -404,7 +404,7 @@ SQL
      */
     public function testPrivacyClosureReceivesQueryArgs(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -444,7 +444,7 @@ SQL
      */
     public function testPrivacyClassReceivesQueryArgs(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -481,7 +481,7 @@ SQL
 
     public function testPrivacyWrongType(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -533,7 +533,7 @@ GRAQPHQL;
      */
     public function testPrivacyClosureReceivesContext(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);
@@ -580,7 +580,7 @@ SQL
      */
     public function testPrivacyClassReceivesQueryContext(): void
     {
-        factory(Post::class)
+        Post::factory()
             ->create([
                 'title' => 'post title',
             ]);

--- a/tests/Database/SelectFieldsTest.php
+++ b/tests/Database/SelectFieldsTest.php
@@ -69,7 +69,7 @@ class SelectFieldsTest extends TestCaseDatabase
     public function testWithoutSelectFields(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -110,7 +110,7 @@ SQL
     public function testWithSelectFieldsClassInjection(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -151,7 +151,7 @@ SQL
     public function testWithSelectFieldsNonInjectableTypehints(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -202,7 +202,7 @@ GRAQPHQL;
     public function testWithSelectFieldsAndModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -243,7 +243,7 @@ SQL
     public function testWithNonNullSelectFieldsAndModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -278,7 +278,7 @@ GRAQPHQL;
     public function testWithListOfSelectFieldsAndModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -317,7 +317,7 @@ GRAQPHQL;
     public function testWithListOfSelectFieldsAndModelWithSameFieldsInFragment(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -364,7 +364,7 @@ GRAQPHQL;
     public function testWithNonNullAndListOfSelectFieldsAndModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -401,7 +401,7 @@ GRAQPHQL;
     public function testWithNonNullAndListOfAndNonNullSelectFieldsAndModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -438,7 +438,7 @@ GRAQPHQL;
     public function testWithSelectFieldsAndModelAndAlias(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Description of the post',
         ]);
 
@@ -480,19 +480,19 @@ SQL
     public function testWithSelectFieldsAndModelAndCallbackSqlAlias(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Description of the post',
         ]);
 
         Carbon::setTestNow('2018-01-01');
 
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'post_id' => $post->id,
                 'created_at' => new Carbon('2000-01-01'),
             ]);
 
-        factory(Comment::class)
+        Comment::factory()
             ->create([
                 'post_id' => $post->id,
                 'created_at' => new Carbon('2018-05-05'),
@@ -538,7 +538,7 @@ SQL
     public function testWithSelectFieldsAndModelAndAliasAndCustomResolver(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Description of the post',
         ]);
 
@@ -580,7 +580,7 @@ SQL
     public function testWithSelectFieldsNoModel(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -620,7 +620,7 @@ SQL
     public function testPostNonNullPaginationQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 
@@ -709,7 +709,7 @@ GQL;
     public function testPostNonNullSimplePaginationQuery(): void
     {
         /** @var Post $post */
-        $post = factory(Post::class)->create([
+        $post = Post::factory()->create([
             'title' => 'Title of the post',
         ]);
 

--- a/tests/Support/Models/Comment.php
+++ b/tests/Support/Models/Comment.php
@@ -4,9 +4,12 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Support\Models;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Rebing\GraphQL\Tests\Support\database\factories\CommentFactory;
 
 /**
  * @property int $id
@@ -19,6 +22,8 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
  */
 class Comment extends Model
 {
+    use HasFactory;
+
     public function post(): BelongsTo
     {
         return $this->belongsTo(Post::class);
@@ -27,5 +32,10 @@ class Comment extends Model
     public function likes(): MorphMany
     {
         return $this->morphMany(Like::class, 'likable');
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return CommentFactory::new();
     }
 }

--- a/tests/Support/Models/Like.php
+++ b/tests/Support/Models/Like.php
@@ -3,9 +3,12 @@
 declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Support\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Rebing\GraphQL\Tests\Support\database\factories\LikeFactory;
 
 /**
  * @property int $id
@@ -15,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 class Like extends Model
 {
+    use HasFactory;
+
     /** @var string[] */
     protected $guarded = [];
 
@@ -26,5 +31,10 @@ class Like extends Model
     public function likable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return LikeFactory::new();
     }
 }

--- a/tests/Support/Models/Post.php
+++ b/tests/Support/Models/Post.php
@@ -4,11 +4,14 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Support\Models;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
+use Rebing\GraphQL\Tests\Support\database\factories\PostFactory;
 
 /**
  * @property int $id
@@ -24,6 +27,8 @@ use Illuminate\Support\Carbon;
  */
 class Post extends Model
 {
+    use HasFactory;
+
     /** @var string[] */
     protected $dates = [
         'published_at',
@@ -54,5 +59,10 @@ class Post extends Model
         $publishedAt = $this->published_at;
 
         return null !== $publishedAt;
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return PostFactory::new();
     }
 }

--- a/tests/Support/Models/User.php
+++ b/tests/Support/Models/User.php
@@ -4,8 +4,11 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Support\Models;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Rebing\GraphQL\Tests\Support\database\factories\UserFactory;
 
 /**
  * @property int $id
@@ -15,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class User extends Model
 {
+    use HasFactory;
+
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class)->orderBy('posts.id');
@@ -23,5 +28,10 @@ class User extends Model
     public function likes(): HasMany
     {
         return $this->hasMany(Like::class);
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return UserFactory::new();
     }
 }

--- a/tests/Support/database/factories/CommentFactory.php
+++ b/tests/Support/database/factories/CommentFactory.php
@@ -1,15 +1,23 @@
 <?php
 
 declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\database\factories;
 
-use Faker\Generator as Faker;
-use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Rebing\GraphQL\Tests\Support\Models\Comment;
 
-/* @var Factory $factory */
-$factory->define(Comment::class, function (Faker $faker) {
-    return [
-        'title' => $faker->title,
-        'body' => $faker->sentence,
-    ];
-});
+/**
+ * @extends Factory<Comment>
+ */
+class CommentFactory extends Factory
+{
+    protected $model = Comment::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->title,
+            'body' => fake()->sentence,
+        ];
+    }
+}

--- a/tests/Support/database/factories/LikeFactory.php
+++ b/tests/Support/database/factories/LikeFactory.php
@@ -1,12 +1,21 @@
 <?php
 
 declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\database\factories;
 
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Rebing\GraphQL\Tests\Support\Models\Like;
 
-/* @var Factory $factory */
-$factory->define(Like::class, function (Faker $faker) {
-    return [
-    ];
-});
+/**
+ * @extends Factory<Like>
+ */
+class LikeFactory extends Factory
+{
+    protected $model = Like::class;
+
+    public function definition(): array
+    {
+        return [
+        ];
+    }
+}

--- a/tests/Support/database/factories/PostFactory.php
+++ b/tests/Support/database/factories/PostFactory.php
@@ -1,15 +1,23 @@
 <?php
 
 declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\database\factories;
 
-use Faker\Generator as Faker;
-use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Rebing\GraphQL\Tests\Support\Models\Post;
 
-/* @var Factory $factory */
-$factory->define(Post::class, function (Faker $faker) {
-    return [
-        'title' => $faker->title,
-        'body' => $faker->sentence,
-    ];
-});
+/**
+ * @extends Factory<Post>
+ */
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->title,
+            'body' => fake()->sentence,
+        ];
+    }
+}

--- a/tests/Support/database/factories/UserFactory.php
+++ b/tests/Support/database/factories/UserFactory.php
@@ -1,14 +1,22 @@
 <?php
 
 declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\database\factories;
 
-use Faker\Generator as Faker;
-use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Rebing\GraphQL\Tests\Support\Models\User;
 
-/* @var Factory $factory */
-$factory->define(User::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-    ];
-});
+/**
+ * @extends Factory<User>
+ */
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name,
+        ];
+    }
+}

--- a/tests/TestCaseDatabase.php
+++ b/tests/TestCaseDatabase.php
@@ -12,7 +12,6 @@ abstract class TestCaseDatabase extends TestCase
         parent::setUp();
 
         $this->loadMigrationsFrom(__DIR__ . '/Support/database/migrations');
-        $this->withFactories(__DIR__ . '/Support/database/factories');
 
         // This takes care of refreshing the database between tests
         // as we are using the in-memory SQLite db we do not need RefreshDatabase


### PR DESCRIPTION
## Summary
Removed "laravel/legacy-factories

Time to move on, legacy-factories was to support pre Laravel 8 factories

---

Type of change:
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
