### PR TITLE
Loosen phpstan/larastan constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
         "friendsofphp/php-cs-fixer": "3.37.1",
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.2",
-        "phpstan/phpstan": "1.10.40",
-        "larastan/larastan": "2.6.4",
+        "phpstan/phpstan": "^1",
+        "larastan/larastan": "^2",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^9.x-dev",
         "phpunit/phpunit": "^9|^10",
         "thecodingmachine/phpstan-safe-rule": "^1"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1416,11 +1416,6 @@ parameters:
 			path: tests/Unit/ExecutionMiddlewareTest/ChangeQueryArgTypeMiddleware.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with non\\-empty\\-array will always evaluate to true\\.$#"
-			count: 1
-			path: tests/Unit/GraphQLTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$abstract of function app expects string\\|null, object\\|string given\\.$#"
 			count: 3
 			path: tests/Unit/GraphQLTest.php

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -310,7 +310,6 @@ class GraphQLTest extends TestCase
         unset($error['extensions']['file']);
         unset($error['extensions']['line']);
 
-        self::assertIsArray($error);
         self::assertArrayHasKey('message', $error);
         self::assertArrayHasKey('locations', $error);
         $expectedError = [


### PR DESCRIPTION
## Summary
`assertIsArray` has been removed because, as phpstan rightly complained, it's not possible otherwise: the return type of `formatError` is always an error

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
