### PR TITLE
Remove unnecessary check for PHP 7.4 compatibility

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL;
 
 use Closure;
-use OutOfBoundsException;
 
 class Helpers
 {
@@ -23,37 +22,5 @@ class Helpers
         }
 
         return $callback($valueOrValues);
-    }
-
-    /**
-     * Check compatible ability to use thecodingmachine/safe.
-     *
-     * @return string|false
-     */
-    public static function shouldUseSafe(string $methodName)
-    {
-        $packageName = 'thecodingmachine/safe';
-        $safeVersion = \Composer\InstalledVersions::getVersion($packageName);
-
-        if (!$safeVersion) {
-            throw new OutOfBoundsException("Package {$packageName} is being replaced or provided but is not really installed");
-        }
-
-        $skipFunctions = [
-            'uksort',
-        ];
-
-        // Version 2.
-        if (version_compare($safeVersion, '2', '>=')) {
-            if (\in_array(str_replace('\\Safe\\', '', $methodName), $skipFunctions)) {
-                return false;
-            }
-        }
-
-        if (!\is_callable($methodName)) {
-            return false;
-        }
-
-        return $methodName;
     }
 }

--- a/src/Support/AliasArguments/ArrayKeyChange.php
+++ b/src/Support/AliasArguments/ArrayKeyChange.php
@@ -3,8 +3,6 @@
 declare(strict_types = 1);
 namespace Rebing\GraphQL\Support\AliasArguments;
 
-use Rebing\GraphQL\Helpers;
-
 class ArrayKeyChange
 {
     public function modify(array $array, array $pathKeyMappings): array
@@ -27,14 +25,7 @@ class ArrayKeyChange
             return $this->pathLevels($b) <=> $this->pathLevels($a);
         };
 
-        // TODO: can be removed once PHP 7.4 is dropped
-        $functionName = Helpers::shouldUseSafe('\\Safe\\uksort');
-
-        if (\is_callable($functionName)) {
-            $functionName($paths, $callback);
-        } else {
-            uksort($paths, $callback);
-        }
+        uksort($paths, $callback);
 
         return $paths;
     }


### PR DESCRIPTION
## Summary
The project is exclusively using PHP 8.1+ and thecodingmatchine/safe 2

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
