### PR TITLE
Allow global resolver Middlewares

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -51,6 +51,13 @@ class GraphQL
      */
     protected $types = [];
 
+    /**
+     * These middleware are executed before all resolve methods
+     *
+     * @var array<object|class-string>
+     */
+    protected $globalResolverMiddlewares = [];
+
     /** @var Type[] */
     protected $typesInstances = [];
 
@@ -184,6 +191,22 @@ class GraphQL
         $middlewares[] = GraphqlExecutionMiddleware::class;
 
         return $middlewares;
+    }
+
+    /**
+     * @phpstan-param class-string|object $class
+     */
+    public function appendGlobalResolverMiddleware(object|string $class): void
+    {
+        $this->globalResolverMiddlewares[] = $class;
+    }
+
+    /**
+     * @phpstan-return array<object|class-string>
+     */
+    public function getGlobalResolverMiddlewares(): array
+    {
+        return $this->globalResolverMiddlewares;
     }
 
     /**

--- a/src/Support/Facades/GraphQL.php
+++ b/src/Support/Facades/GraphQL.php
@@ -24,6 +24,8 @@ use Rebing\GraphQL\Support\OperationParams;
  * @method static Schema buildSchemaFromConfig(array $schemaConfig)
  * @method static array getSchemas()
  * @method static void addSchema(string $name, Schema $schema)
+ * @method static array getGlobalResolverMiddlewares()
+ * @method static void appendGlobalResolverMiddleware(object|string $class)
  * @method static void addType(object|string $class, string $name = null)
  * @method static Type objectType(ObjectType|array|string $type, array $opts = [])
  * @method static array formatError(Error $e)

--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ValidationError;
 use Rebing\GraphQL\Support\AliasArguments\AliasArguments;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use ReflectionMethod;
 
 /**
@@ -145,6 +146,15 @@ abstract class Field
         return $this->middleware;
     }
 
+    /**
+     * @return array<string>
+     * @phpstan-param array<string> $middleware
+     */
+    protected function appendGlobalMiddlewares(array $middleware): array
+    {
+        return array_merge($middleware, GraphQL::getGlobalResolverMiddlewares());
+    }
+
     protected function getResolver(): ?Closure
     {
         $resolver = $this->originalResolver();
@@ -154,7 +164,7 @@ abstract class Field
         }
 
         return function ($root, ...$arguments) use ($resolver) {
-            $middleware = $this->getMiddleware();
+            $middleware = $this->appendGlobalMiddlewares($this->getMiddleware());
 
             return app()->make(Pipeline::class)
                 ->send(array_merge([$this], $arguments))


### PR DESCRIPTION
## Summary
Add possibility to define Global Resovler Middleware using GraphQL Facade.
Usefell when external service like "Laravel Pulse" recorder want to register globally new middleware to intercept each query and track execution time.

This can be done by using the new `GraphQL::appendGlobalResolverMiddleware(YourMiddleware::class)` method

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
