### PR TITLE
Relax PaginationType getPaginationFields typehint

### DIFF
--- a/src/Support/PaginationType.php
+++ b/src/Support/PaginationType.php
@@ -29,7 +29,7 @@ class PaginationType extends ObjectType
         parent::__construct($config);
     }
 
-    protected function getPaginationFields(ObjectType $underlyingType): array
+    protected function getPaginationFields(GraphQLType $underlyingType): array
     {
         return [
             'data' => [


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

When upgrading a project from 8.0 to 9.0, I began to see errors around pagination:

```
TypeError: Rebing\GraphQL\Support\PaginationType::getPaginationFields(): Argument #1 ($underlyingType) must be of type GraphQL\Type\Definition\ObjectType, GraphQL\Type\Definition\InterfaceType given, called in /path/to/rebing/graphql-laravel/src/Support/PaginationType.php on line 22
```

We have queries where the `type` is a paginator with interfaces:

```php
class EntriesQuery extends Query
{
    public function type(): Type
    {
        return GraphQL::paginate(GraphQL::type('EntryInterface'));
    }
}
```

This has worked fine until v9 (specifically #1033) since the typehint of `PaginationType::getPaginationFields()` was changed to `ObjectType`.

This PR changes the typehint from an `ObjectType` definition to the parent `Type` definition, which covers both `ObjectType` and `InterfaceType`.

I'm not sure if there's a specific reason `ObjectType` was used, but this fixes our issue and all of this package's tests continue to pass.

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
