### PR TITLE
Add `authenticate` function to Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ config/graphql.php
       - [Defining middleware](#defining-middleware)
       - [Registering middleware](#registering-middleware)
       - [Terminable middleware](#terminable-middleware)
+    - [Authentication](#authenticationAu)
     - [Authorization](#authorization)
     - [Privacy](#privacy)
     - [Query variables](#query-variables)
@@ -1244,6 +1245,60 @@ The terminate method receives both the resolver arguments and the query result.
 
 Once you have defined a terminable middleware, you should add it to the list of
 middleware in your queries and mutations.
+
+### Authentication
+
+For Query or Mutation authentication, we can use `authenticate()` function.
+
+```php
+namespace App\GraphQL\Queries;
+
+use Auth;
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class UserFeedQuery extends Query
+{
+    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        // true, if logged in
+        return ! Auth::guest();
+    }
+
+    // ...
+}
+```
+
+This function is called before `authorization()` which can be used to check whether authenticated user is authorized (has ability/permission) to use this Query or Mutation.
+If not provided, it will default to true - passing authenticate function and continuing to `authorize()` check.
+
+If user is not authenticated, an "Unauthenticated" error message will be thrown.
+
+You can also provide a custom error message when the authentication fails:
+
+```php
+namespace App\GraphQL\Queries;
+
+use Auth;
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class UserFeedQuery extends Query
+{
+    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        // true, if logged in
+        return ! Auth::guest();
+    }
+
+    public function getAuthenticationMessage(): string
+    {
+        return 'You are not authenticated';
+    }
+
+    // ...
+}
+```
 
 ### Authorization
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,6 +146,11 @@ parameters:
 			path: src/Support/Field.php
 
 		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:authenticate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Support/Field.php
+
+		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Support\\\\Field\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Support/Field.php
@@ -409,6 +414,16 @@ parameters:
 			message: "#^Offset 'uses' might not exist on array\\{uses\\?\\: mixed, middleware\\?\\: mixed\\}\\.$#"
 			count: 1
 			path: src/routes.php
+
+		-
+			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthenticateArgsTest\\\\GraphQLContext\\:\\:\\$data has no type specified\\.$#"
+			count: 1
+			path: tests/Database/AuthenticateArgsTest/GraphQLContext.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthenticateArgsTest\\\\TestAuthenticationArgsQuery\\:\\:authenticate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Database/AuthenticateArgsTest/TestAuthenticationArgsQuery.php
 
 		-
 			message: "#^Property Rebing\\\\GraphQL\\\\Tests\\\\Database\\\\AuthorizeArgsTests\\\\GraphQLContext\\:\\:\\$data has no type specified\\.$#"
@@ -914,6 +929,56 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExampleValidationInputObject\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Support/Objects/ExampleValidationInputObject.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateMessageQuery\\:\\:authenticate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateMessageQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateMessageQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateMessageQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateMessageQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateQuery\\:\\:authenticate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateQuery\\:\\:resolve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateQuery\\:\\:resolve\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateQuery\\:\\:resolve\\(\\) has parameter \\$context with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateQuery.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthenticateQuery\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
+			count: 1
+			path: tests/Support/Objects/ExamplesAuthenticateQuery.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Support\\\\Objects\\\\ExamplesAuthorizeMessageQuery\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
@@ -1554,6 +1619,11 @@ parameters:
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\UploadTests\\\\UploadSingleFileMutation\\:\\:resolve\\(\\) has parameter \\$root with no type specified\\.$#"
 			count: 1
 			path: tests/Unit/UploadTests/UploadSingleFileMutation.php
+
+		-
+			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\ValidationAuthenticationTests\\\\ValidationAndAuthenticateMutation\\:\\:authenticate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Unit/ValidationAuthenticationTests/ValidationAndAuthenticateMutation.php
 
 		-
 			message: "#^Method Rebing\\\\GraphQL\\\\Tests\\\\Unit\\\\ValidationAuthorizationTests\\\\ValidationAndAuthorizationMutation\\:\\:authorize\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"

--- a/src/Error/AuthenticationError.php
+++ b/src/Error/AuthenticationError.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Error;
+
+use GraphQL\Error\Error;
+
+class AuthenticationError extends Error implements ProvidesErrorCategory
+{
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return 'authentication';
+    }
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -21,6 +21,7 @@ use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\ValidationException;
+use Rebing\GraphQL\Error\AuthenticationError;
 use Rebing\GraphQL\Error\AuthorizationError;
 use Rebing\GraphQL\Error\ProvidesErrorCategory;
 use Rebing\GraphQL\Error\ValidationError;
@@ -579,6 +580,7 @@ class GraphQL
             // Don't report certain GraphQL errors
             if ($error instanceof ValidationError ||
                 $error instanceof AuthorizationError ||
+                $error instanceof AuthenticationError ||
                 !(
                     $error instanceof Exception ||
                     $error instanceof PhpError

--- a/tests/Database/AuthenticateArgsTest/AuthenticateArgsTest.php
+++ b/tests/Database/AuthenticateArgsTest/AuthenticateArgsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\AuthenticateArgsTest;
+
+use Rebing\GraphQL\Tests\TestCaseDatabase;
+
+class AuthenticateArgsTest extends TestCaseDatabase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'query' => [
+                TestAuthenticationArgsQuery::class,
+            ],
+        ]);
+    }
+
+    public function testAuthorizeArgs(): void
+    {
+        $graphql = <<<'GRAPHQL'
+query {
+  testAuthenticationArgs(id: "foobar")
+}
+GRAPHQL;
+
+        // All relevant test assertions are in \Rebing\GraphQL\Tests\Database\AuthenticateArgsTests\TestAuthenticationArgsQuery::authenticate
+        $this->httpGraphql($graphql, [
+            'expectErrors' => true,
+        ]);
+    }
+}

--- a/tests/Database/AuthenticateArgsTest/GraphQLContext.php
+++ b/tests/Database/AuthenticateArgsTest/GraphQLContext.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\AuthenticateArgsTest;
+
+class GraphQLContext
+{
+    public $data;
+}

--- a/tests/Database/AuthenticateArgsTest/TestAuthenticationArgsQuery.php
+++ b/tests/Database/AuthenticateArgsTest/TestAuthenticationArgsQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Database\AuthenticateArgsTest;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Assert;
+use Rebing\GraphQL\Support\Query;
+use Rebing\GraphQL\Support\SelectFields;
+use Rebing\GraphQL\Tests\Database\AuthorizeArgsTests\GraphQLContext;
+
+class TestAuthenticationArgsQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'testAuthenticationArgs',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::ID()),
+            ],
+        ];
+    }
+
+    public function authenticate(
+        $root,
+        array $args,
+        $ctx,
+        ResolveInfo $resolveInfo = null,
+        Closure $getSelectFields = null
+    ): bool {
+        Assert::assertNull($root);
+
+        $expectedArgs = [
+            'id' => 'foobar',
+        ];
+        Assert::assertSame($expectedArgs, $args);
+
+        Assert::assertInstanceOf(GraphQLContext::class, $ctx);
+
+        Assert::assertInstanceOf(ResolveInfo::class, $resolveInfo);
+
+        $selectFields = $getSelectFields();
+        Assert::assertInstanceOf(SelectFields::class, $selectFields);
+
+        return true;
+    }
+
+    public function resolve(): void
+    {
+    }
+}

--- a/tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
+++ b/tests/Support/Objects/ExamplesAuthenticateMessageQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+class ExamplesAuthenticateMessageQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Examples authenticate query',
+    ];
+
+    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        return false;
+    }
+
+    public function getAuthenticationMessage(): string
+    {
+        return 'You are not authenticated';
+    }
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('Example'));
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => ['name' => 'index', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    {
+        $data = include __DIR__ . '/data.php';
+
+        if (isset($args['index'])) {
+            return [
+                $data[$args['index']],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Support/Objects/ExamplesAuthenticateQuery.php
+++ b/tests/Support/Objects/ExamplesAuthenticateQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+class ExamplesAuthenticateQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Examples authenticate query',
+    ];
+
+    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        return false;
+    }
+
+    public function type(): Type
+    {
+        return Type::listOf(GraphQL::type('Example'));
+    }
+
+    public function args(): array
+    {
+        return [
+            'index' => ['name' => 'index', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args, $context, ResolveInfo $resolveInfo, Closure $getSelectFields)
+    {
+        $data = include __DIR__ . '/data.php';
+
+        if (isset($args['index'])) {
+            return [
+                $data[$args['index']],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -73,6 +73,22 @@ return [
         }
     ',
 
+    'examplesWithAuthenticate' => '
+        query QueryExamplesAuthenticate {
+            examplesAuthenticate {
+                test
+            }
+        }
+    ',
+
+    'examplesWithAuthenticateMessage' => '
+        query QueryExamplesAuthenticateMessage {
+            examplesAuthenticateMessage {
+                test
+            }
+        }
+    ',
+
     'examplesWithError' => '
         query QueryExamplesWithError {
             examplesQueryNotFound {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\ExpectationFailedException;
 use Rebing\GraphQL\GraphQLServiceProvider;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleFilterInputType;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthenticateMessageQuery;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthenticateQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeMessageQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesAuthorizeQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExampleSchema;
@@ -45,6 +47,8 @@ class TestCase extends BaseTestCase
                 'examples' => ExamplesQuery::class,
                 'examplesAuthorize' => ExamplesAuthorizeQuery::class,
                 'examplesAuthorizeMessage' => ExamplesAuthorizeMessageQuery::class,
+                'examplesAuthenticate' => ExamplesAuthenticateQuery::class,
+                'examplesAuthenticateMessage' => ExamplesAuthenticateMessageQuery::class,
                 'examplesMiddleware' => ExamplesMiddlewareQuery::class,
                 'examplesPagination' => ExamplesPaginationQuery::class,
                 'examplesFiltered' => ExamplesFilteredQuery::class,

--- a/tests/Unit/EndpointTest.php
+++ b/tests/Unit/EndpointTest.php
@@ -105,6 +105,36 @@ class EndpointTest extends TestCase
         self::assertNull($content['data']['examplesAuthorizeMessage']);
     }
 
+    public function testGetUnauthenticated(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => $this->queries['examplesWithAuthenticate'],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertArrayHasKey('data', $content);
+        self::assertArrayHasKey('errors', $content);
+        self::assertEquals('Unauthenticated', $content['errors'][0]['message']);
+        self::assertNull($content['data']['examplesAuthenticate']);
+    }
+
+    public function testGetUnauthenticatedWithCustomError(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => $this->queries['examplesWithAuthenticateMessage'],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertArrayHasKey('data', $content);
+        self::assertArrayHasKey('errors', $content);
+        self::assertEquals('You are not authenticated', $content['errors'][0]['message']);
+        self::assertNull($content['data']['examplesAuthenticateMessage']);
+    }
+
     public function testBatchedQueries(): void
     {
         $response = $this->call('POST', '/graphql', [

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -83,6 +83,24 @@ class GraphQLQueryTest extends TestCase
         self::assertEquals('You are not authorized to perform this action', $result['errors'][0]['message']);
     }
 
+    public function testQueryAndReturnResultWithAuthenticate(): void
+    {
+        $result = $this->httpGraphql($this->queries['examplesWithAuthenticate'], [
+            'expectErrors' => true,
+        ]);
+        self::assertNull($result['data']['examplesAuthenticate']);
+        self::assertEquals('Unauthenticated', $result['errors'][0]['message']);
+    }
+
+    public function testQueryAndReturnResultWithCustomAuthenticateMessage(): void
+    {
+        $result = $this->httpGraphql($this->queries['examplesWithAuthenticateMessage'], [
+            'expectErrors' => true,
+        ]);
+        self::assertNull($result['data']['examplesAuthenticateMessage']);
+        self::assertEquals('You are not authenticated', $result['errors'][0]['message']);
+    }
+
     /**
      * If an error was encountered before execution begins, the data entry should not be present in the result.
      */

--- a/tests/Unit/ValidationAuthenticationTests/ValidationAndAuthenticateMutation.php
+++ b/tests/Unit/ValidationAuthenticationTests/ValidationAndAuthenticateMutation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ValidationAuthenticationTests;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+class ValidationAndAuthenticateMutation extends Mutation
+{
+    protected $attributes = [
+        'name' => 'validationAndAuthentication',
+    ];
+
+    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    {
+        return 'value1' === $args['arg1'];
+    }
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'arg1' => [
+                'type' => Type::string(),
+                'rules' => 'in:value1',
+            ],
+        ];
+    }
+
+    public function resolve(): string
+    {
+        return 'value';
+    }
+}

--- a/tests/Unit/ValidationAuthenticationTests/ValidationAuthenticationTest.php
+++ b/tests/Unit/ValidationAuthenticationTests/ValidationAuthenticationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ValidationAuthenticationTests;
+
+use Rebing\GraphQL\Tests\TestCase;
+
+class ValidationAuthenticationTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default', [
+            'mutation' => [
+                ValidationAndAuthenticateMutation::class,
+            ],
+        ]);
+    }
+
+    public function testAuthorizeArgumentsInvalid(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg1: String) {
+  validationAndAuthentication(arg1: $arg1)
+}
+GRAPHQL;
+
+        $result = $this->httpGraphql($graphql, [
+            'expectErrors' => true,
+            'variables' => [
+                'arg1' => 'invalid value',
+            ],
+        ]);
+
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'validation',
+                    'extensions' => [
+                        'category' => 'validation',
+                        'validation' => [
+                            'arg1' => [
+                                'The selected arg1 is invalid.',
+                            ],
+                        ],
+                    ],
+                    'locations' => [
+                        [
+                            'line' => 2,
+                            'column' => 3,
+                        ],
+                    ],
+                    'path' => [
+                        'validationAndAuthentication',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($expected, $result);
+    }
+
+    public function testAuthorizeArgumentsValid(): void
+    {
+        $graphql = <<<'GRAPHQL'
+mutation Mutate($arg1: String) {
+  validationAndAuthentication(arg1: $arg1)
+}
+GRAPHQL;
+
+        $result = $this->httpGraphql($graphql, [
+            'variables' => [
+                'arg1' => 'value1',
+            ],
+        ]);
+
+        $expectedResult = [
+            'data' => [
+                'validationAndAuthentication' => 'value',
+            ],
+        ];
+        self::assertSame($expectedResult, $result);
+    }
+}


### PR DESCRIPTION
## Summary
This feature adds `authenticate()` function to `Field` used by Query and Mutation. This is very similar to existing `authorization()` function.

The alternative use case before this PR would be like this:

```php
<?php
namespace App\GraphQL\Queries;

use Auth;
use Closure;
use GraphQL\Type\Definition\ResolveInfo;
use Rebing\GraphQL\Error\AuthorizationError;

class UsersQuery extends Query
{
    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
    {
        if (Auth::guest()) {
            throw new AuthorizationError('Unauthenticated');
        }
    
        return Auth::user()->can_see_users;
    }

    // ...
}
```

The main problem is that this way authorize method is not really reusable, e.g. when Query uses Trait which has a implementation of `authorize()` to check whether user is authenticated. After this PR, separating `authenticate()` and `authorize()` that can be solved putting `authentication()` logic in Trait and leaving `authorize()` to check specific ability.

At the end, developers code may look like this:

**app/Traits/RequiresGraphQLAuthentication.php**
```php
<?php

namespace App\Traits;

trait RequiresGraphQLAuthentication 
{

    public function authenticate($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
    {
        // true, if logged in
        return ! Auth::guest();
    }
}
```

**app/GraphQL/Queries/UsersQuery.php**

```php
<?php
namespace App\GraphQL\Queries;

use Auth;
use Closure;
use App\Traits\RequiresGraphQLAuthentication;
use GraphQL\Type\Definition\ResolveInfo;
use Rebing\GraphQL\Error\AuthorizationError;

class UsersQuery extends Query
{
    use RequiresGraphQLAuthentication;

    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
    {
        return Auth::user()->can_see_users;
    }

    // ...
}
```

At the same time using `authenticate()` in a failure will return "Unauthenticated" while `authorize()` will throw "Unauthorized" and frontend could more easily  determine the error context by default.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
