### PR TITLE
Use testbench `WithConfig` attribute to set app.debug

### DIFF
--- a/tests/Database/EmptyQueryTest.php
+++ b/tests/Database/EmptyQueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Rebing\GraphQL\Tests\Database;
 
 use Laragraph\Utils\BadRequestGraphQLException;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Rebing\GraphQL\Tests\TestCaseDatabase;
 
 class EmptyQueryTest extends TestCaseDatabase
@@ -23,6 +24,7 @@ class EmptyQueryTest extends TestCaseDatabase
         self::assertSame($expectedError, $result['errors'][0]['message']);
     }
 
+    #[WithConfig('app.debug', true)]
     public function testNoExplicitContentType(): void
     {
         $response = $this->call('POST', '/graphql', [


### PR DESCRIPTION
## Summary
This fixes the failing test `testNoExplicitContentType` (#1137)

We do set it in `\Rebing\GraphQL\Tests\TestCase::getEnvironmentSetUp` which _is_ executed in the this test, but too late.

By the time `\Illuminate\Foundation\Providers\FoundationServiceProvider::registerExceptionRenderer` is called, the `getEnvironmentSetUp()` is not yet called and therefore the debug mode being enabled is not realized.

But other parts in the framework later "see" the enabled debug mode, and due to this mismatch the framework expects registered classes which however arent.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
