### PR TITLE
Fix/validate operation params

### DIFF
--- a/src/Support/OperationParams.php
+++ b/src/Support/OperationParams.php
@@ -28,6 +28,7 @@ class OperationParams extends BaseOperationParams
         $this->operation = $baseOperationParams->operation;
         $this->variables = $baseOperationParams->variables;
         $this->extensions = $baseOperationParams->extensions;
+        $this->originalInput = $baseOperationParams->originalInput;
 
         $this->baseOperationParams = $baseOperationParams;
     }

--- a/tests/Unit/ExecutionMiddlewareTest/ExecutionMiddlewareTest.php
+++ b/tests/Unit/ExecutionMiddlewareTest/ExecutionMiddlewareTest.php
@@ -182,7 +182,7 @@ GRAPHQL;
         $result = $this->httpGraphql($this->queries['examples'], [
             'expectErrors' => true,
             'variables' => [
-                []
+                [],
             ],
         ]);
 

--- a/tests/Unit/ExecutionMiddlewareTest/ExecutionMiddlewareTest.php
+++ b/tests/Unit/ExecutionMiddlewareTest/ExecutionMiddlewareTest.php
@@ -5,6 +5,7 @@ namespace Rebing\GraphQL\Tests\Unit\ExecutionMiddlewareTest;
 
 use Illuminate\Auth\GenericUser;
 use Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware;
 use Rebing\GraphQL\Tests\TestCase;
 
 class ExecutionMiddlewareTest extends TestCase
@@ -170,5 +171,31 @@ GRAPHQL;
             ],
         ];
         self::assertSame($expected, $result);
+    }
+
+    public function testValidateOperationParamsMiddlewareWithInvalidParams(): void
+    {
+        $this->app['config']->set('graphql.execution_middleware', [
+            ValidateOperationParamsMiddleware::class,
+        ]);
+
+        $result = $this->httpGraphql($this->queries['examples'], [
+            'expectErrors' => true,
+            'variables' => [
+                []
+            ],
+        ]);
+
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'GraphQL Request parameter "variables" must be object or JSON string parsed to object, but got [[]]',
+                    'extensions' => [
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
## Summary
- Added initialization of `$originalInput` property in the `init` method of `OperationParams` class.
- This fix addresses the issue: "Typed property GraphQL\Server\OperationParams::$originalInput must not be accessed before initialization".
- The change ensures that `$originalInput` is properly set from the `BaseOperationParams` object during initialization.
- This prevents potential errors when accessing `$originalInput` and maintains consistency with other properties initialized in the `init` method.

---

Type of change:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [X] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [X] Code style has been fixed via `composer fix-style`