### PR TITLE
:sparkles: Support laravel-mongodb v4.x namespace

### DIFF
--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -260,9 +260,16 @@ class SelectFields
 
     protected static function isMongodbInstance(GraphqlType $parentType): bool
     {
-        $mongoType = 'Jenssegers\Mongodb\Eloquent\Model';
+        $jenssegersMongoType = 'Jenssegers\Mongodb\Eloquent\Model';
+        $laravelMongoType = 'MongoDB\Laravel\Eloquent\Model';
 
-        return isset($parentType->config['model']) ? app($parentType->config['model']) instanceof $mongoType : false;
+        if (isset($parentType->config['model'])) {
+            $modelInstance = app($parentType->config['model']);
+
+            return $modelInstance instanceof $jenssegersMongoType || $modelInstance instanceof $laravelMongoType;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
Packages:
```
"mongodb/laravel-mongodb": "^4.7",
"rebing/graphql-laravel": "^9.2",
```
This pull request addresses an issue encountered when using `$query->select($fields->getSelect())`. Without this fix, the result of the query is incorrect, as it fails to properly handle the selection of fields when working with the latest version of `laravel-mongodb`.

The issue arises due to the change in the namespace from `Jenssegers\Mongodb\` to `MongoDB\Laravel\` in the latest version 4 of `laravel-mongodb`. This change affects the way fields are selected and retrieved in queries, leading to discrepancies in the output.

### Example Output Before the Fix

When executing the following code:
```php
$query->select($fields->getSelect());

//  The output of dd($fields->getSelect()) is as follows:

array:15 [
  0 => "users._id"
  1 => "users.active"
  2 => "users.email"
  3 => "users.name"
  4 => "users.password"
  5 => "users.created_at"
  6 => "users.updated_at"
]
```


### Example Output After the Fix

With the fix applied (also support `MongoDB\Laravel\Eloquent\Model`), the output is corrected to:
```php
array:16 [ 
  0 => "_id"
  1 => "active"
  2 => "email"
  3 => "name"
  4 => "password"
  5 => "created_at"
  6 => "updated_at"
]
```

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
