### PR TITLE
Explicit nullable parameter declarations to fix PHP 8.4 deprecation

### DIFF
--- a/src/Support/Field.php
+++ b/src/Support/Field.php
@@ -34,7 +34,7 @@ abstract class Field
      * @param mixed $root
      * @param mixed $ctx
      */
-    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    public function authorize($root, array $args, $ctx, ?ResolveInfo $resolveInfo = null, ?Closure $getSelectFields = null): bool
     {
         return true;
     }

--- a/tests/Support/Traits/MakeCommandAssertionTrait.php
+++ b/tests/Support/Traits/MakeCommandAssertionTrait.php
@@ -18,7 +18,7 @@ trait MakeCommandAssertionTrait
         string $expectedFilename,
         string $expectedNamespace,
         string $expectedClassDefinition,
-        string $expectedGraphqlName = null
+        ?string $expectedGraphqlName = null
     ): void {
         $filesystemMock = $this
             ->getMockBuilder(Filesystem::class)


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

Implicitly nullable parameter declarations [have been deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) in PHP 8.4.

This pull request prevents deprecation warnings from being output by being explicit about nullable parameters.

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
