### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [^10.0, ^11.0]
+        laravel: [^10.0, ^11.0, ^12.0]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.1
             laravel: ^11.0
+          - php: 8.1
+            laravel: ^12.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }} ${{ matrix.stability }}
     runs-on: ubuntu-latest
     env:

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "illuminate/contracts": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "laragraph/utils": "^2.0.1",
         "thecodingmachine/safe": "^2.4",
         "webonyx/graphql-php": "^15.0.3"
@@ -47,10 +47,10 @@
         "fakerphp/faker": "^1.6",
         "friendsofphp/php-cs-fixer": "^3",
         "larastan/larastan": "^2",
-        "laravel/framework": "^10.0|^11.0",
+        "laravel/framework": "^10.0|^11.0|^12.0",
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.5",
-        "orchestra/testbench-core": "^8.0|^9.0",
+        "orchestra/testbench-core": "^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^10.5.32",
         "thecodingmachine/phpstan-safe-rule": "^1"


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

This pull request adds Laravel 12 support to `graphql-laravel`, which will be released on 24th February.

Depends on:

* [ ] https://github.com/laragraph/utils/pull/20
* [ ] https://github.com/larastan/larastan/pull/2198

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
