### PR TITLE
Remove support for Laravel 10 / PHP 8.1

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -25,11 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [^10.0, ^11.0]
-        exclude:
-          - php: 8.1
-            laravel: ^11.0
+        php: [8.2, 8.3, 8.4]
+        laravel: [^11.0]
     name: P=${{ matrix.php }} L=${{ matrix.laravel }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,14 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [^10.0, ^11.0, ^12.0]
+        php: [8.2, 8.3, 8.4]
+        laravel: [^11.0, ^12.0]
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.1
-            laravel: ^11.0
-          - php: 8.1
-            laravel: ^12.0
     name: P=${{ matrix.php }} L=${{ matrix.laravel }} ${{ matrix.stability }}
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/9.8.0...master)
 
+## Removed
+- Support for Laravel 10 & PHP 8.1 have been removed [\#1170 / mfn](https://github.com/rebing/graphql-laravel/pull/1170)
+
 2025-02-24, 9.8.0
 -----------------
 

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0",
         "laragraph/utils": "^2.0.1",
         "thecodingmachine/safe": "^3.0",
         "webonyx/graphql-php": "^15.0.3"
@@ -47,11 +47,11 @@
         "fakerphp/faker": "^1.6",
         "friendsofphp/php-cs-fixer": "^3",
         "larastan/larastan": "^3",
-        "laravel/framework": "^10.0|^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.0",
         "mfn/php-cs-fixer-config": "^2",
         "mockery/mockery": "^1.5",
         "phpstan/phpstan": "^2",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "phpunit/phpunit": "^10.5.32 || ^11.0",
         "thecodingmachine/phpstan-safe-rule": "^1"
     },


### PR DESCRIPTION
## Summary
Laravel 10 become EOL on 2025-02-04, see https://laravel.com/docs/10.x/releases#support-policy

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
