### PR TITLE
fix: allow query to be passed as instance

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -352,7 +352,7 @@ class GraphQL
     }
 
     /**
-     * @param array<int|string,class-string|array<string,mixed>> $fields
+     * @param array<int|string,class-string|array<string,mixed>|Field> $fields
      * @param array<string,string> $opts
      */
     protected function buildObjectTypeFromFields(array $fields, array $opts = []): ObjectType
@@ -363,6 +363,8 @@ class GraphQL
             if (\is_string($field)) {
                 $field = $this->app->make($field);
                 /** @var Field $field */
+                $field = $field->toArray();
+            } elseif ($field instanceof Field) {
                 $field = $field->toArray();
             }
             $name = is_numeric($name) ? $field['name'] : $name;

--- a/tests/Support/Objects/ExampleProseInstanceQuery.php
+++ b/tests/Support/Objects/ExampleProseInstanceQuery.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Support\Objects;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Query;
+
+class ExampleProseInstanceQuery extends Query
+{
+    public function __construct(public string $prose)
+    {
+    }
+
+    protected $attributes = [
+        'name' => 'exampleProse',
+    ];
+
+    public function type(): Type
+    {
+        return Type::string();
+    }
+
+    public function args(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     */
+    public function resolve($root, $args): string
+    {
+        return $this->prose;
+    }
+}

--- a/tests/Support/Objects/queries.php
+++ b/tests/Support/Objects/queries.php
@@ -19,6 +19,18 @@ return [
         }
     ',
 
+    'exampleProse' => '
+        query QueryExamplesProse {
+            exampleProse
+        }
+    ',
+
+    'exampleProseRenamed' => '
+        query QueryExamplesProseRenamed {
+            loremIpsum
+        }
+    ',
+
     'examplesWithConfigAlias' => '
         query examplesConfigAlias($index: Int) {
             examplesConfigAlias(index: $index) {

--- a/tests/Unit/GraphQLQueryTest.php
+++ b/tests/Unit/GraphQLQueryTest.php
@@ -5,6 +5,7 @@ namespace Rebing\GraphQL\Tests\Unit;
 
 use GraphQL\Utils\SchemaPrinter;
 use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleProseInstanceQuery;
 use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
 use Rebing\GraphQL\Tests\TestCase;
 
@@ -228,5 +229,26 @@ class GraphQLQueryTest extends TestCase
 }';
 
         self::assertStringContainsString($queryFragment, $gql);
+    }
+
+    public function testQueryCanBeSetAsInstance(): void
+    {
+        $schema = GraphQL::buildSchemaFromConfig([
+            'query' => [
+                new ExampleProseInstanceQuery('A simple prose'),
+                'loremIpsum' => new ExampleProseInstanceQuery('Lorem ipsum dolor sit amet'),
+            ],
+        ]);
+        GraphQL::addSchema('default', $schema);
+
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleProse']);
+        $expectedDataResult = ['exampleProse' => 'A simple prose'];
+        self::assertSame($expectedDataResult, $result->data);
+        self::assertCount(0, $result->errors);
+
+        $result = GraphQL::queryAndReturnResult($this->queries['exampleProseRenamed']);
+        $expectedDataResult = ['loremIpsum' => 'Lorem ipsum dolor sit amet'];
+        self::assertSame($expectedDataResult, $result->data);
+        self::assertCount(0, $result->errors);
     }
 }


### PR DESCRIPTION
## Summary

### PR: Allow Using a Query Instance in Addition to a Class-String  

This PR adds the ability to use a `Query` instance in addition to a class-string by default.  

#### Before:  
Previously, if I built my schema at runtime like this:  

```php
$config = [
    'types'     => [/*...*/],
    'mutations' => [/*...*/],
    'query'     => [new FindQueryForModel(User::class)]
];

$schema = GraphQL::buildSchemaFromConfig($config);
```  

I would get the following error:  
`Cannot use object of type FindQueryForModel as array`  

#### Changes:  
- I have added tests.  
- I have handled instantiated `Field` objects by adding a specific case in `GraphQL.php -> buildObjectTypeFromFields`:  

```php
elseif ($field instanceof Field) {
    $field = $field->toArray();
}
```  

#### Documentation:  
I have **not** documented this possibility in `README.md` because it would be a bad practice to use this in the config file. Doing so would break Laravel's caching mechanism, as this type is not serializable.  

---

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] ~Update the README.md (Not needed)~
- [x] Code style has been fixed via `composer fix-style`
