### PR TITLE
Allow custom relationships

### DIFF
--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -366,9 +366,11 @@ class SelectFields
             $foreignKey = $relation->getForeignKey();
         } elseif (method_exists($relation, 'getQualifiedForeignPivotKeyName')) {
             $foreignKey = $relation->getQualifiedForeignPivotKeyName();
-        } else {
+        } elseif (method_exists($relation, 'getQualifiedForeignKeyName')) {
             /** @var BelongsTo|HasManyThrough|HasOneOrMany $relation */
             $foreignKey = $relation->getQualifiedForeignKeyName();
+        } else {
+            return;
         }
         $foreignKey = $parentTable ? ($parentTable . '.' . \Safe\preg_replace(
             '/^' . preg_quote($parentTable, '/') . '\./',


### PR DESCRIPTION
## Summary
Currently GraphQL queries fail, when custom eloquent relationships are used.

A custom relationship library [BelongsToThrough](https://github.com/staudenmeir/belongs-to-through) by a Laravel Core Maintainer causes the SelectFields->handleRelation function to fail, because the getQualifiedForeignKeyName function is missing.

In my opinion 'unsupported' custom relationships should not automatically cause an Exception in this function, because the relation can still resolve without relying on SelectFields.

---

Type of change:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
