### PR TITLE
Remove unnecessary coalesce to empty array

### DIFF
--- a/src/Support/SelectFields.php
+++ b/src/Support/SelectFields.php
@@ -488,7 +488,7 @@ class SelectFields
                         return app($type->config['model'])->getTable() === $query->getParent()->getTable();
                     }
                 );
-                $typesFiltered = array_values($typesFiltered ?? []);
+                $typesFiltered = array_values($typesFiltered);
 
                 if (1 === \count($typesFiltered)) {
                     /* @var GraphqlType $type */


### PR DESCRIPTION
## Summary
Reported by phpstan [1]:
> Variable $typesFiltered on left side of ?? always exists and is not nullable.

And yep indeed, `array_filter` cannot return `null` or undefine the var, so this is not necessary.

[1] https://github.com/rebing/graphql-laravel/actions/runs/16870256928/job/47783542319#step:8:14


---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
