### PR TITLE
feat: Add schema_attributes support for GraphQL routes

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -36,6 +36,7 @@ if ($routeConfig) {
                 $actions = array_filter([
                     'uses' => $schemaConfig['controller'] ?? $routeConfig['controller'] ?? GraphQLController::class . '@query',
                     'middleware' => $schemaConfig['middleware'] ?? $routeConfig['middleware'] ?? null,
+                    ... $schemaConfig['schema_attributes'] ?? []
                 ]);
 
                 // Support array syntax: `[Some::class, 'method']`

--- a/tests/Unit/RouteWithSchemaTest.php
+++ b/tests/Unit/RouteWithSchemaTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+use Rebing\GraphQL\Tests\Support\Objects\ExampleMiddleware;
+use Rebing\GraphQL\Tests\TestCase;
+
+class RouteWithSchemaTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        // Laravel registers routes for local filesystems by default.
+        // However, for the purpose of this test, we don't want it to register any routes.
+        $app['config']->set('filesystems.disks.local.serve', false);
+
+        $app['config']->set('graphql', [
+            'route' => [
+                'prefix' => 'graphql_test',
+            ],
+
+            'schemas' => [
+                'default' => [
+                    'middleware' => [ExampleMiddleware::class],
+                ],
+                'with_schema_attributes' => [
+                    'middleware' => [ExampleMiddleware::class],
+                    'schema_attributes' => [
+                        'domain' => 'api.example.com',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testRoutesWithSchemaAttributes(): void
+    {
+        $expected = [
+            'graphql' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
+                'domain' => null,
+                'action_middleware' => [ExampleMiddleware::class],
+                'action_excluded_middleware' => [],
+            ],
+            'graphql.default' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/default',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
+                'domain' => null,
+                'action_middleware' => [ExampleMiddleware::class],
+                'action_excluded_middleware' => [],
+            ],
+            'graphql.with_schema_attributes' => [
+                'methods' => [
+                    'GET',
+                    'POST',
+                    'HEAD',
+                ],
+                'uri' => 'graphql_test/with_schema_attributes',
+                'middleware' => [
+                    ExampleMiddleware::class,
+                ],
+                'domain' => 'api.example.com',
+                'action_middleware' => [ExampleMiddleware::class],
+                'action_excluded_middleware' => [],
+            ],
+        ];
+
+        $actual = Collection::make(
+            app('router')->getRoutes()->getRoutesByName()
+        )->map(function (Route $route) {
+            $action = $route->getAction();
+            return [
+                'methods' => $route->methods(),
+                'uri' => $route->uri(),
+                'middleware' => $route->middleware(),
+                'domain' => method_exists($route, 'getDomain') ? $route->getDomain() : null,
+                'action_middleware' => $action['middleware'] ?? [],
+                'action_excluded_middleware' => $action['excluded_middleware'] ?? [],
+            ];
+        })->all();
+
+        self::assertEquals($expected, $actual);
+    }
+}
+
+


### PR DESCRIPTION
## Summary
This PR adds support for `schema_attributes` configuration in GraphQL schemas, allowing developers to pass additional route attributes like `domain` and other Laravel route options directly to schema-specific routes.

## Changes
- **Enhanced route configuration**: Added support for `schema_attributes` in schema configuration
- **New test coverage**: Added `RouteWithSchemaTest` to verify `schema_attributes` functionality

### Example Usage
```php
'schemas' => [
    'api' => [
        'middleware' => ['auth'],
        'schema_attributes' => [
            'domain' => 'api.example.com',
            // Any other Laravel route attributes
        ],
    ],
],
```


