### PR TITLE
tests: add property make tests work on prefer-lowest

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -147,15 +147,12 @@ class TestCase extends BaseTestCase
      *                                       - named  arguments: ['model' => 'Post']
      *                                       - boolean flags: ['--all' => true]
      *                                       - arguments with values: ['--arg' => 'value']
-     * @param array<string,mixed> $interactiveInput Interactive responses to the command
-     *                                              I.e. anything the command `->ask()` or `->confirm()`, etc.
      */
-    protected function runCommand(Command $command, array $arguments = [], array $interactiveInput = []): CommandTester
+    protected function runCommand(Command $command, array $arguments = []): CommandTester
     {
         $command->setLaravel($this->app);
 
         $tester = new CommandTester($command);
-        $tester->setInputs($interactiveInput);
 
         $tester->execute($arguments);
 


### PR DESCRIPTION
## Summary
- Let's see if/how we can fix the tailing tests on master, see https://github.com/rebing/graphql-laravel/actions/runs/19417368047
- also fixed new phpstan error discovered via https://github.com/rebing/graphql-laravel/actions/runs/19803556487/job/56734324196#step:8:14

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
