### PR TITLE
Add middleware `ReadOnlyOperationMiddleware` to enforce GET requests are read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 [Next release](https://github.com/rebing/graphql-laravel/compare/9.17.0...master)
 
+### Added
+- `ExecutionMiddleware\ReadOnlyOperationMiddleware` rejects GET requests targeting mutations [\#1261 / mfn](https://github.com/rebing/graphql-laravel/pull/1261)
+
 2026-05-24, 10.0.0-RC4
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This package provides a code-first integration of GraphQL for Laravel. It is bas
   - [Query depth limiting](#query-depth-limiting)
   - [Query complexity analysis](#query-complexity-analysis)
   - [Batching limits](#batching-limits)
+  - [GET requests and read-only enforcement](#get-requests-and-read-only-enforcement)
   - [Recommended production configuration](#recommended-production-configuration)
 - [Error handling](#error-handling)
   - [Built-in error types](#built-in-error-types)
@@ -2622,6 +2623,45 @@ single HTTP request. Without a cap, this can be used to amplify the impact of
 expensive queries. Batching is disabled by default, and when enabled the
 `batching.max_batch_size` option (default: `10`) limits the number of operations
 per request.
+
+### GET requests and read-only enforcement
+
+By default each schema only accepts `POST` (`'method' => ['POST']`). If you
+opt a schema in to `GET` (e.g. for CDN-cacheable persisted queries), enable
+the `ReadOnlyOperationMiddleware` execution middleware so that mutations and
+subscriptions submitted via `GET` are rejected.
+
+The middleware is shipped pre-listed (commented out) in the published config:
+
+```php
+// config/graphql.php
+'execution_middleware' => [
+    Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware::class,
+    Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware::class,
+    Rebing\GraphQL\Support\ExecutionMiddleware\ReadOnlyOperationMiddleware::class,
+    Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware::class,
+],
+```
+
+Without this middleware, an operation submitted via `GET` is executed
+regardless of its type, which leaks mutation arguments into URLs, server
+access logs and CDN caches and bypasses defenses that assume `GET` is safe.
+This mirrors the protection that webonyx/graphql-php's
+`Server\Helper::executeOperation()` applies; we enforce it explicitly because
+the library calls `GraphQL::executeQuery()` directly.
+
+The rejection produces the standard GraphQL error
+`GET supports only query operation` with HTTP `200`. The middleware is opt-in
+so consumers running with the default `POST`-only configuration are unaffected.
+
+> **Ordering matters when APQ is enabled.** When used together with
+> `AutomaticPersistedQueriesMiddleware`, list `ReadOnlyOperationMiddleware`
+> *after* it (as shown above). APQ materialises the query body from the
+> cache; running this middleware first against an APQ-only request would
+> cause `OperationParams::getParsedQuery()` to throw
+> `No GraphQL query available`. The ordering relative to
+> `GraphqlExecutionMiddleware` is enforced by the framework, which always
+> appends `GraphqlExecutionMiddleware` last.
 
 ### Recommended production configuration
 

--- a/config/config.php
+++ b/config/config.php
@@ -280,6 +280,12 @@ return [
         Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware::class,
         // AutomaticPersistedQueriesMiddleware listed even if APQ is disabled, see the docs for the `'apq'` configuration
         Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware::class,
+        // Reject non-`query` operations (mutations, subscriptions) submitted via GET.
+        // When used together with `AutomaticPersistedQueriesMiddleware`, list this
+        // entry AFTER it (as below): APQ materialises the query body from cache,
+        // and running this middleware first would fail APQ-only requests with a
+        // "No GraphQL query available" error.
+        // \Rebing\GraphQL\Support\ExecutionMiddleware\ReadOnlyOperationMiddleware::class,
         Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware::class,
         // \Rebing\GraphQL\Support\ExecutionMiddleware\UnusedVariablesMiddleware::class,
     ],

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -8,6 +8,7 @@ use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error;
 use GraphQL\Error\FormattedError;
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Server\Exception\GetMethodSupportsOnlyQueryOperation;
 use GraphQL\Server\OperationParams as BaseOperationParams;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\NonNull;
@@ -648,6 +649,14 @@ class GraphQL
 
             // Don't report certain GraphQL errors
             if ($error instanceof ValidationError || $error instanceof AuthorizationError) {
+                continue;
+            }
+
+            // `ReadOnlyOperationMiddleware` raises this RequestError to refuse
+            // non-`query` operations submitted via GET. It's an expected client
+            // error (analogous to `ValidationError`/`AuthorizationError`) and
+            // should not be reported as a server bug.
+            if ($error instanceof GetMethodSupportsOnlyQueryOperation) {
                 continue;
             }
 

--- a/src/Support/ExecutionMiddleware/ReadOnlyOperationMiddleware.php
+++ b/src/Support/ExecutionMiddleware/ReadOnlyOperationMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Support\ExecutionMiddleware;
+
+use Closure;
+use GraphQL\Error\Error;
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Server\Exception\GetMethodSupportsOnlyQueryOperation;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\AST;
+use Rebing\GraphQL\Support\OperationParams;
+
+/**
+ * Rejects non-`query` operations submitted on read-only HTTP requests (i.e. GET).
+ *
+ * This middleware is opt-in: register it via the `execution_middleware` config
+ * (globally or per-schema) whenever any schema permits the GET method. Without
+ * it, mutations and subscriptions can be executed via GET, which leaks
+ * arguments into URLs, server logs and CDN caches.
+ *
+ * Ordering: it must be listed AFTER `AutomaticPersistedQueriesMiddleware` when
+ * APQ is enabled, because APQ materialises `$params->query` from cache.
+ * Running this middleware first against an APQ-only request would cause
+ * `OperationParams::getParsedQuery()` to throw "No GraphQL query available".
+ *
+ * It runs before `GraphqlExecutionMiddleware`; that ordering is enforced by
+ * the framework, which always appends `GraphqlExecutionMiddleware` last (see
+ * `GraphQL::appendGraphqlExecutionMiddleware()`).
+ */
+class ReadOnlyOperationMiddleware extends AbstractExecutionMiddleware
+{
+    public function handle(string $schemaName, Schema $schema, OperationParams $params, $rootValue, $contextValue, Closure $next): ExecutionResult
+    {
+        if (!$params->isReadOnly()) {
+            return $next($schemaName, $schema, $params, $rootValue, $contextValue);
+        }
+
+        $operationAST = AST::getOperationAST($params->getParsedQuery(), $params->operation);
+
+        // If the operation cannot be located (ambiguous or missing) defer to
+        // webonyx's own `FailedToDetermineOperationType` handling rather than
+        // pre-empting it here.
+        if (null !== $operationAST && 'query' !== $operationAST->operation) {
+            return new ExecutionResult(null, [
+                Error::createLocatedError(
+                    new GetMethodSupportsOnlyQueryOperation('GET supports only query operation'),
+                ),
+            ]);
+        }
+
+        return $next($schemaName, $schema, $params, $rootValue, $contextValue);
+    }
+}

--- a/tests/Unit/ReadOnlyOperationTests/ReadOnlyOperationSilencingTest.php
+++ b/tests/Unit/ReadOnlyOperationTests/ReadOnlyOperationSilencingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ReadOnlyOperationTests;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Mockery;
+use Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\ReadOnlyOperationMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware;
+use Rebing\GraphQL\Tests\TestCase;
+
+/**
+ * Verifies that rejections raised by `ReadOnlyOperationMiddleware` are
+ * silenced in `GraphQL::handleErrors()` and never reach Laravel's
+ * `ExceptionHandler::report()`. They are expected client errors, analogous
+ * to `ValidationError` and `AuthorizationError`, and should not produce
+ * server log noise.
+ */
+class ReadOnlyOperationSilencingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default.method', ['GET', 'POST']);
+        $app['config']->set('graphql.schemas.default.mutation', [
+            'simpleEcho' => SimpleEchoMutation::class,
+        ]);
+        $app['config']->set('graphql.execution_middleware', [
+            ValidateOperationParamsMiddleware::class,
+            AutomaticPersistedQueriesMiddleware::class,
+            ReadOnlyOperationMiddleware::class,
+            AddAuthUserContextValueMiddleware::class,
+        ]);
+    }
+
+    public function testRejectionIsNotReportedToExceptionHandler(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => 'mutation { simpleEcho(value: "value") }',
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertSame(
+            'GET supports only query operation',
+            $content['errors'][0]['message'],
+        );
+    }
+
+    protected function resolveApplicationExceptionHandler($app): void
+    {
+        $handlerMock = Mockery::mock(ExceptionHandler::class);
+        $handlerMock
+            ->shouldReceive('report')
+            ->never();
+
+        $app->instance(ExceptionHandler::class, $handlerMock);
+    }
+}

--- a/tests/Unit/ReadOnlyOperationTests/ReadOnlyOperationTest.php
+++ b/tests/Unit/ReadOnlyOperationTests/ReadOnlyOperationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ReadOnlyOperationTests;
+
+use Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\ReadOnlyOperationMiddleware;
+use Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware;
+use Rebing\GraphQL\Tests\TestCase;
+
+/**
+ * Behaviour tests for `ReadOnlyOperationMiddleware`.
+ *
+ * The default schema is reconfigured to accept `GET` so we can exercise the
+ * read-only enforcement path; without that, GET requests would never reach
+ * the controller.
+ */
+class ReadOnlyOperationTest extends TestCase
+{
+    private const MUTATION = 'mutation { simpleEcho(value: "value") }';
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('graphql.schemas.default.method', ['GET', 'POST']);
+        $app['config']->set('graphql.schemas.default.mutation', [
+            'simpleEcho' => SimpleEchoMutation::class,
+        ]);
+    }
+
+    public function testWithoutMiddlewareGetMutationStillExecutes(): void
+    {
+        // Sanity check: documents the gap the middleware closes. Without it
+        // in the pipeline a GET-submitted mutation runs end-to-end.
+        $response = $this->call('GET', '/graphql', [
+            'query' => self::MUTATION,
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertSame(
+            ['data' => ['simpleEcho' => 'value']],
+            $response->getData(true),
+        );
+    }
+
+    public function testGetQueryPassesWithMiddlewareEnabled(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $this->queries['examples'],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertArrayHasKey('data', $content);
+        self::assertArrayNotHasKey('errors', $content);
+    }
+
+    public function testGetMutationIsRejected(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => self::MUTATION,
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        unset($content['errors'][0]['extensions']);
+
+        self::assertEquals(
+            ['errors' => [['message' => 'GET supports only query operation']]],
+            $content,
+        );
+    }
+
+    public function testGetSubscriptionIsRejected(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        // The schema has no `Subscription` type registered, but the parser
+        // accepts the syntax and the middleware rejects on operation type
+        // alone — independent of execution.
+        $response = $this->call('GET', '/graphql', [
+            'query' => 'subscription { examples { test } }',
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        unset($content['errors'][0]['extensions']);
+
+        self::assertEquals(
+            ['errors' => [['message' => 'GET supports only query operation']]],
+            $content,
+        );
+    }
+
+    public function testPostMutationStillPasses(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        $response = $this->call('POST', '/graphql', [
+            'query' => self::MUTATION,
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertSame(
+            ['data' => ['simpleEcho' => 'value']],
+            $response->getData(true),
+        );
+    }
+
+    public function testGetMultiOperationSelectingQueryPasses(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        $document = <<<'GRAPHQL'
+query Q { examples { test } }
+mutation M { simpleEcho(value: "value") }
+GRAPHQL;
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $document,
+            'operationName' => 'Q',
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertArrayHasKey('data', $content);
+        self::assertArrayNotHasKey('errors', $content);
+    }
+
+    public function testGetMultiOperationSelectingMutationIsRejected(): void
+    {
+        $this->enableReadOnlyMiddleware();
+
+        $document = <<<'GRAPHQL'
+query Q { examples { test } }
+mutation M { simpleEcho(value: "value") }
+GRAPHQL;
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $document,
+            'operationName' => 'M',
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        unset($content['errors'][0]['extensions']);
+
+        self::assertEquals(
+            ['errors' => [['message' => 'GET supports only query operation']]],
+            $content,
+        );
+    }
+
+    public function testGetMultiOperationWithoutOperationNameDeferToWebonyx(): void
+    {
+        // When `operationName` is omitted on a multi-operation document
+        // `AST::getOperationAST()` returns null and we deliberately fall
+        // through to webonyx, which produces its own
+        // `FailedToDetermineOperationType` error rather than our message.
+        $this->enableReadOnlyMiddleware();
+
+        $document = <<<'GRAPHQL'
+query Q { examples { test } }
+mutation M { simpleEcho(value: "value") }
+GRAPHQL;
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => $document,
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getData(true);
+        self::assertArrayHasKey('errors', $content);
+        self::assertNotEquals(
+            'GET supports only query operation',
+            $content['errors'][0]['message'],
+        );
+    }
+
+    private function enableReadOnlyMiddleware(): void
+    {
+        $this->app['config']->set('graphql.execution_middleware', [
+            ValidateOperationParamsMiddleware::class,
+            AutomaticPersistedQueriesMiddleware::class,
+            ReadOnlyOperationMiddleware::class,
+            AddAuthUserContextValueMiddleware::class,
+        ]);
+    }
+}

--- a/tests/Unit/ReadOnlyOperationTests/SimpleEchoMutation.php
+++ b/tests/Unit/ReadOnlyOperationTests/SimpleEchoMutation.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\ReadOnlyOperationTests;
+
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Mutation;
+
+/**
+ * Minimal mutation fixture for `ReadOnlyOperation*Test`.
+ *
+ * Kept separate from the shared `UpdateExampleMutation` because that one
+ * carries additional required validation rules that aren't relevant here
+ * and would cause unrelated failures in the GET-mutation test paths.
+ */
+class SimpleEchoMutation extends Mutation
+{
+    /** @var array<string,string> */
+    protected $attributes = [
+        'name' => 'simpleEcho',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    public function args(): array
+    {
+        return [
+            'value' => [
+                'type' => Type::nonNull(Type::string()),
+            ],
+        ];
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,string> $args
+     * @param mixed $context
+     */
+    public function resolve($root, array $args, $context): string
+    {
+        return $args['value'];
+    }
+}


### PR DESCRIPTION
## Summary

GET requests are already disabled by default, but if enabled, provide an optional middleware to enforce read-only semantics (i.e. only allow queries, not mutations)

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer cs-fix`
