### PR TITLE
Make `AddAuthUserContextValueMiddleware` respect the guard from the config

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <roave-bc-check xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Roave/BackwardCompatibilityCheck/8.21.x/Resources/schema.xsd">
   <baseline>
+    <ignored-regex>#\[BC\] ADDED\: Parameter config was added to Method __construct\(\) of class Rebing\\GraphQL\\Support\\ExecutionMiddleware\\AddAuthUserContextValueMiddleware#</ignored-regex>
     <ignored-regex>#\[BC\] ADDED\: Parameter fieldArgs was added to Method validate\(\) of class Rebing\\GraphQL\\Support\\Privacy#</ignored-regex>
     <ignored-regex>#\[BC\] ADDED\: Parameter resolveInfo was added to Method validate\(\) of class Rebing\\GraphQL\\Support\\Privacy#</ignored-regex>
     <ignored-regex>#\[BC\] ADDED\: Parameter root was added to Method validate\(\) of class Rebing\\GraphQL\\Support\\Privacy#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: Parameter 0 of Rebing\\GraphQL\\Support\\Privacy\#validate\(\) changed name from queryArgs to root#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: Parameter 1 of Rebing\\GraphQL\\Support\\Privacy\#validate\(\) changed name from queryContext to fieldArgs#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: Rebing\\GraphQL\\Support\\Rules was marked "@internal"#</ignored-regex>
+    <ignored-regex>#\[BC\] CHANGED\: The number of required arguments for Rebing\\GraphQL\\Support\\ExecutionMiddleware\\AddAuthUserContextValueMiddleware\#__construct\(\) increased from 1 to 2#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: The number of required arguments for Rebing\\GraphQL\\Support\\Privacy\#validate\(\) increased from 1 to 2#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: The parameter \$args of Rebing\\GraphQL\\Support\\Privacy\#fire\(\) changed from no type to mixed#</ignored-regex>
     <ignored-regex>#\[BC\] CHANGED\: The parameter \$context of Rebing\\GraphQL\\Support\\Middleware\#handle\(\) changed from no type to mixed#</ignored-regex>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 ### Added
 - `ExecutionMiddleware\ReadOnlyOperationMiddleware` rejects GET requests targeting mutations [\#1261 / mfn](https://github.com/rebing/graphql-laravel/pull/1261)
 
+### Changed
+- `ExecutionMiddleware\AddAuthUserContextValueMiddleware` now resolves the auth guard from the config [\#1262 / mfn](https://github.com/rebing/graphql-laravel/pull/1262)
+
 2026-05-24, 10.0.0-RC4
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ them, in addition to the global middleware. For example:
         'types' => [
         
         ],
-        'middleware' => ['auth'],
+        'middleware' => ['auth:api'],
         // Which HTTP methods to support; must be given in UPPERCASE!
         // Default is POST only; enable GET explicitly if needed
         'method' => ['GET', 'POST'], 
@@ -531,6 +531,13 @@ them, in addition to the global middleware. For example:
         // Example: expose this schema on a dedicated subdomain
         'route_attributes' => [
             'domain' => 'api.example.com',
+        ],
+        // Per-schema route group attributes. The `guard` entry is consumed by
+        // the built-in `AddAuthUserContextValueMiddleware` to populate the
+        // GraphQL context value (`$ctx`) from the named guard. Defaults to
+        // the application's default guard when unset.
+        'group_attributes' => [
+            'guard' => 'api',
         ],
         // Override the default controller for this schema.
         // Supports string ('Class@method') and array ([Class::class, 'method']) formats.
@@ -1802,7 +1809,13 @@ If the field declares its own `args`, they are available in `$args`:
 > the GraphQL execution. By default, the built-in
 > `AddAuthUserContextValueMiddleware` execution middleware sets this directly to
 > the authenticated user model (i.e. `Auth::user()`), or `null` if no user is
-> authenticated. You can customize the context via your own execution middleware.
+> authenticated. The guard is resolved in this order:
+> `graphql.schemas.<name>.group_attributes.guard` (per-schema), then the
+> global `graphql.route.group_attributes.guard`, then the application's
+> default guard. This keeps the GraphQL context consistent with the guard
+> that authenticated the route — important in multi-guard apps where the
+> default guard (typically `web`) and the schema's actual guard (e.g. `api`)
+> differ. You can customize the context via your own execution middleware.
 
 > **Privacy vs Authorization.** `authorize()` on a Query or Mutation gates the
 > *entire* operation - if it fails, the whole request is rejected with an error.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -128,6 +128,22 @@ packages to hook into the resolver DI system. Register injectors via
   -public function authorize($root, array $args, $ctx, ?ResolveInfo $resolveInfo = null, ?Closure $getSelectFields = null): bool
   +public function authorize($root, array $args, $ctx, ?ResolveInfo $resolveInfo = null): bool
   ```
+- **Auth context guard now resolved per-schema** -
+  `AddAuthUserContextValueMiddleware` previously always called
+  `Auth::guard()->user()` (the application's default guard) to populate the
+  GraphQL context. It now resolves the guard from
+  `graphql.schemas.<name>.group_attributes.guard` (per-schema), then the
+  global `graphql.route.group_attributes.guard`, then the default. Multi-guard
+  apps that authenticated via a non-default guard (e.g. `auth:api`) but were
+  silently receiving the default-guard user (typically `web`) in `$ctx`
+  should now see the correct user. Verify your authorization logic still
+  behaves as expected. Set the `group_attributes.guard` key on each schema
+  (or globally) to match the auth middleware you use.
+
+  The middleware constructor signature changed from `(Factory $auth)` to
+  `(Factory $auth, Repository $config)`. Container resolution is unaffected.
+  If you subclass the middleware with a custom constructor, update the
+  `parent::__construct(...)` call to pass both dependencies.
 
 ## Upgrading from v1 to v2
 

--- a/src/Support/ExecutionMiddleware/AddAuthUserContextValueMiddleware.php
+++ b/src/Support/ExecutionMiddleware/AddAuthUserContextValueMiddleware.php
@@ -7,24 +7,54 @@ use Closure;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Type\Schema;
 use Illuminate\Contracts\Auth\Factory;
+use Illuminate\Contracts\Config\Repository;
 use Rebing\GraphQL\Support\OperationParams;
 
+/**
+ * Populates the GraphQL context value with the currently authenticated user
+ * from the schema's configured guard.
+ *
+ * The guard is resolved in this order:
+ * 1. `graphql.schemas.<name>.group_attributes.guard` — per-schema override.
+ * 2. `graphql.route.group_attributes.guard` — global fallback (the same key
+ *    Laravel route groups consume; see `src/routes.php`).
+ * 3. The application's default guard (`null` passed to `Factory::guard()`).
+ *
+ * This keeps the GraphQL context consistent with the guard that authenticated
+ * the route — important in multi-guard apps where the default guard
+ * (typically `web`) and the schema's actual guard (e.g. `api`) differ.
+ *
+ * If the caller already supplied a `$contextValue`, it is left untouched.
+ */
 class AddAuthUserContextValueMiddleware extends AbstractExecutionMiddleware
 {
-    /** @var Factory */
-    private $auth;
-
-    public function __construct(Factory $auth)
-    {
-        $this->auth = $auth;
+    public function __construct(
+        protected readonly Factory $auth,
+        protected readonly Repository $config,
+    ) {
     }
 
     public function handle(string $schemaName, Schema $schema, OperationParams $params, $rootValue, $contextValue, Closure $next): ExecutionResult
     {
         if (null === $contextValue) {
-            $contextValue = $this->auth->guard()->user();
+            $contextValue = $this->auth->guard($this->resolveGuard($schemaName))->user();
         }
 
         return $next($schemaName, $schema, $params, $rootValue, $contextValue);
+    }
+
+    protected function resolveGuard(string $schemaName): ?string
+    {
+        /** @var string|null $perSchema */
+        $perSchema = $this->config->get("graphql.schemas.{$schemaName}.group_attributes.guard");
+
+        if (null !== $perSchema) {
+            return $perSchema;
+        }
+
+        /** @var string|null $global */
+        $global = $this->config->get('graphql.route.group_attributes.guard');
+
+        return $global;
     }
 }

--- a/tests/Unit/AddAuthUserContextValueMiddlewareTests/AddAuthUserContextValueMiddlewareTest.php
+++ b/tests/Unit/AddAuthUserContextValueMiddlewareTests/AddAuthUserContextValueMiddlewareTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\AddAuthUserContextValueMiddlewareTests;
+
+use Illuminate\Auth\GenericUser;
+use Rebing\GraphQL\GraphQL;
+use Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware;
+use Rebing\GraphQL\Tests\TestCase;
+
+/**
+ * Behaviour tests for `AddAuthUserContextValueMiddleware` guard resolution.
+ *
+ * The middleware reads `graphql.schemas.<name>.group_attributes.guard` to
+ * decide which auth guard's user is injected into the GraphQL context.
+ * When that key is unset, the application's default guard is used.
+ */
+class AddAuthUserContextValueMiddlewareTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Register a second guard backed by the same provider; behavior is
+        // identical to the default `web` guard, but it's a distinct guard
+        // identity so we can verify the middleware addresses it correctly.
+        $app['config']->set('auth.guards.api', [
+            'driver' => 'session',
+            'provider' => 'users',
+        ]);
+
+        $app['config']->set('graphql.execution_middleware', [
+            AddAuthUserContextValueMiddleware::class,
+        ]);
+
+        $app['config']->set('graphql.schemas.web_schema', [
+            'query' => ['returnAuthId' => ReturnAuthIdQuery::class],
+        ]);
+
+        $app['config']->set('graphql.schemas.api_schema', [
+            'query' => ['returnAuthId' => ReturnAuthIdQuery::class],
+            'group_attributes' => ['guard' => 'api'],
+        ]);
+    }
+
+    public function testDefaultGuardIsUsedWhenSchemaHasNoGuardConfigured(): void
+    {
+        $this->actingAs(new GenericUser(['id' => 'web-user']));
+
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'web_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'web-user']], $result);
+    }
+
+    public function testConfiguredGuardIsUsed(): void
+    {
+        $this->actingAs(new GenericUser(['id' => 'api-user']), 'api');
+
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'api_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'api-user']], $result);
+    }
+
+    public function testSchemaGuardIsolatesContextFromDefaultGuardUser(): void
+    {
+        // Authenticate two different users on two different guards. Without
+        // the per-schema guard lookup the middleware would call
+        // `auth->guard()->user()` (the default guard); after the fix it
+        // honours the schema's `group_attributes.guard`.
+        $this->actingAs(new GenericUser(['id' => 'web-user']));
+        $this->actingAs(new GenericUser(['id' => 'api-user']), 'api');
+
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'api_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'api-user']], $result);
+    }
+
+    public function testNoAuthenticatedUserYieldsNullContext(): void
+    {
+        // No `actingAs` call: nobody is authenticated on either guard.
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'api_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'no-user']], $result);
+    }
+
+    public function testCallerSuppliedContextIsNotOverridden(): void
+    {
+        // Programmatic API path: when the caller supplies a context value
+        // explicitly, the middleware leaves it untouched. The
+        // schema-level guard config is irrelevant in this case.
+        $this->actingAs(new GenericUser(['id' => 'web-user']));
+
+        $customUser = new GenericUser(['id' => 'custom-user']);
+        /** @var GraphQL $graphql */
+        $graphql = $this->app->make(GraphQL::class);
+
+        $result = $graphql->query('{ returnAuthId }', null, [
+            'schema' => 'web_schema',
+            'context' => $customUser,
+        ]);
+
+        self::assertSame(['data' => ['returnAuthId' => 'custom-user']], $result);
+    }
+
+    public function testGlobalGroupAttributesGuardIsUsedAsFallback(): void
+    {
+        // When a schema has no `group_attributes.guard` of its own, the
+        // middleware falls back to the global `route.group_attributes.guard`
+        // (the same key Laravel route groups consume). This lets a
+        // single-guard app set the guard once globally.
+        $this->app['config']->set('graphql.route.group_attributes.guard', 'api');
+        $this->actingAs(new GenericUser(['id' => 'api-user']), 'api');
+
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'web_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'api-user']], $result);
+    }
+
+    public function testPerSchemaGuardOverridesGlobalGroupAttributesGuard(): void
+    {
+        // Per-schema config wins when both are present.
+        $this->app['config']->set('graphql.route.group_attributes.guard', 'web');
+        $this->actingAs(new GenericUser(['id' => 'web-user']));
+        $this->actingAs(new GenericUser(['id' => 'api-user']), 'api');
+
+        $result = $this->httpGraphql('{ returnAuthId }', ['schemaName' => 'api_schema']);
+
+        self::assertSame(['data' => ['returnAuthId' => 'api-user']], $result);
+    }
+}

--- a/tests/Unit/AddAuthUserContextValueMiddlewareTests/ReturnAuthIdQuery.php
+++ b/tests/Unit/AddAuthUserContextValueMiddlewareTests/ReturnAuthIdQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\AddAuthUserContextValueMiddlewareTests;
+
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Rebing\GraphQL\Support\Query;
+
+/**
+ * Returns the auth identifier injected as the GraphQL context value, so a
+ * test can verify which user the context contains. Returns "no-user" when
+ * the context is not an Authenticatable.
+ */
+class ReturnAuthIdQuery extends Query
+{
+    /** @var array<string,string> */
+    protected $attributes = [
+        'name' => 'returnAuthId',
+    ];
+
+    public function type(): Type
+    {
+        return Type::nonNull(Type::string());
+    }
+
+    /**
+     * @param mixed $root
+     * @param array<string,mixed> $args
+     * @param mixed $context
+     */
+    public function resolve($root, array $args, $context): string
+    {
+        if (!$context instanceof Authenticatable) {
+            return 'no-user';
+        }
+
+        return (string) $context->getAuthIdentifier();
+    }
+}


### PR DESCRIPTION
## Summary
Instead of _always_ using the default guard.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer cs-fix`
