### PR TITLE
Add opt-in CsrfGuard HTTP middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 ### Added
 - `ExecutionMiddleware\ReadOnlyOperationMiddleware` rejects GET requests targeting mutations [\#1261 / mfn](https://github.com/rebing/graphql-laravel/pull/1261)
+- `Support\Middleware\CsrfGuard` CSRF protection middleware [\#1265 / mfn](https://github.com/rebing/graphql-laravel/pull/1265)
 
 ### Changed
 - `ExecutionMiddleware\AddAuthUserContextValueMiddleware` now resolves the auth guard from the config [\#1262 / mfn](https://github.com/rebing/graphql-laravel/pull/1262)

--- a/README.md
+++ b/README.md
@@ -2804,6 +2804,46 @@ so consumers running with the default `POST`-only configuration are unaffected.
 > `GraphqlExecutionMiddleware` is enforced by the framework, which always
 > appends `GraphqlExecutionMiddleware` last.
 
+### CSRF protection
+
+When your GraphQL endpoint uses cookie-based authentication (Laravel sessions,
+Sanctum cookie-mode), it is vulnerable to Cross-Site Request Forgery. A
+malicious page can submit a form POST to your `/graphql` endpoint and the
+browser will attach the session cookie automatically -- executing mutations on
+behalf of the logged-in user.
+
+This does **not** apply when authentication uses explicit credentials only
+(Bearer tokens, API keys) because browsers never attach those automatically.
+
+The `CsrfGuard` middleware protects against this by ensuring that every request
+either came from the same origin (verified via the browser's `Sec-Fetch-Site`
+header), or carries indicators that would have forced a CORS preflight (custom
+headers, non-simple Content-Type):
+
+```php
+use Rebing\GraphQL\Support\Middleware\CsrfGuard;
+
+// config/graphql.php — apply to all schemas:
+'route' => [
+    'middleware' => [CsrfGuard::class],
+],
+
+// Or per-schema with custom options:
+'schemas' => [
+    'admin' => [
+        'middleware' => [CsrfGuard::class], // strict defaults
+    ],
+    'public' => [
+        'middleware' => [
+            CsrfGuard::using(strictWhenAmbiguous: false), // allow non-browser clients
+        ],
+    ],
+],
+```
+
+The middleware is opt-in and has strict safe defaults. See the PHPDoc on
+`CsrfGuard::using()` for a full explanation of each configurable flag.
+
 ### Recommended production configuration
 
 ```php

--- a/config/config.php
+++ b/config/config.php
@@ -15,6 +15,16 @@ return [
 
         // Any middleware for the graphql route group
         // This middleware will apply to all schemas
+        //
+        // To protect against CSRF when using cookie/session authentication,
+        // add the CsrfGuard middleware:
+        //
+        // \Rebing\GraphQL\Support\Middleware\CsrfGuard::class,
+        //
+        // Or with custom options (e.g. permissive mode for mixed browser/API clients):
+        //
+        // \Rebing\GraphQL\Support\Middleware\CsrfGuard::using(strictWhenAmbiguous: false),
+        //
         'middleware' => [],
 
         // Additional route group attributes
@@ -92,7 +102,11 @@ return [
                 // ExampleType::class,
             ],
 
-            // Laravel HTTP middleware
+            // Laravel HTTP middleware applied to this schema's route.
+            // Overrides the global route.middleware when set (non-null).
+            //
+            // Example with CSRF protection (recommended for session-authenticated schemas):
+            // 'middleware' => [\Rebing\GraphQL\Support\Middleware\CsrfGuard::class],
             'middleware' => null,
 
             // Which HTTP methods to support; must be given in UPPERCASE!

--- a/src/Support/Middleware/CsrfGuard.php
+++ b/src/Support/Middleware/CsrfGuard.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Support\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * HTTP route middleware that protects GraphQL endpoints against Cross-Site
+ * Request Forgery (CSRF) when cookie/session-based authentication is used.
+ *
+ * The guard ensures that every incoming request could NOT have been initiated
+ * by a cross-origin HTML form, link, or redirect -- i.e. that a spec-compliant
+ * browser would have performed a CORS preflight before sending it.
+ *
+ * ## When to enable
+ *
+ * Enable this middleware on any GraphQL schema that authenticates requests via
+ * ambient credentials (session cookies, Laravel Sanctum cookie-mode, etc.).
+ * It is NOT needed when the endpoint exclusively uses explicit credentials
+ * (Bearer tokens, API keys) that a browser would never attach automatically.
+ *
+ * ## How it works (decision tree)
+ *
+ * 1. Reject GET (configurable) -- GET requests can be triggered by `<img>`,
+ *    `<script>`, `<link>` tags cross-origin without any preflight.
+ * 2. If `Sec-Fetch-Site` is present and equals `same-origin` or `same-site`,
+ *    the browser certifies the request originated from the same site → ALLOW.
+ * 3. If `Sec-Fetch-Site` equals `cross-site` or `none` → REJECT.
+ * 4. If a custom header (default: `X-Requested-With`) is present → ALLOW
+ *    (custom headers force a CORS preflight).
+ * 5. If the `Content-Type` is non-simple (`application/json`, etc.) → ALLOW
+ *    (non-simple content types force a CORS preflight).
+ * 6. Otherwise the request is ambiguous (no Fetch-Metadata, no custom header,
+ *    simple Content-Type). Behaviour depends on `$strictWhenAmbiguous`:
+ *    - `true` (default): REJECT -- assumes the worst case.
+ *    - `false`: ALLOW -- permits non-browser clients that send none of the
+ *      above signals (e.g. legacy HTTP clients, curl without extra headers).
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+ * @see https://web.dev/articles/fetch-metadata
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+ */
+class CsrfGuard
+{
+    /**
+     * Content types that browsers can send from HTML forms without triggering
+     * a CORS preflight request.
+     *
+     * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype
+     * @see https://fetch.spec.whatwg.org/#cors-safelisted-request-header
+     */
+    private const SIMPLE_CONTENT_TYPES = [
+        'application/x-www-form-urlencoded',
+        'multipart/form-data',
+        'text/plain',
+    ];
+
+    /**
+     * Sec-Fetch-Site values indicating the request came from the same origin
+     * or a same-site context.  These are trustworthy because the header is set
+     * by the browser and cannot be spoofed by JavaScript on a cross-origin page.
+     */
+    private const TRUSTED_FETCH_SITE_VALUES = [
+        'same-origin',
+        'same-site',
+    ];
+
+    /** Sec-Fetch-Site values indicating the request was initiated cross-origin. */
+    private const HOSTILE_FETCH_SITE_VALUES = [
+        'cross-site',
+        'none',
+    ];
+
+    public function __construct(
+        private readonly bool $rejectGet = true,
+        private readonly bool $checkFetchMetadata = true,
+        private readonly bool $allowCustomHeader = true,
+        private readonly string $customHeaderName = 'X-Requested-With',
+        private readonly bool $allowNonSimpleContentType = true,
+        private readonly bool $strictWhenAmbiguous = true,
+    ) {
+    }
+
+    /**
+     * Create a middleware string with custom parameters for per-route configuration.
+     *
+     * Use this factory when different schemas require different CSRF policies.
+     * Each parameter corresponds to a step in the decision tree documented above.
+     *
+     * Example:
+     *
+     *     // Strict (default) -- suitable for session-authenticated browser SPAs:
+     *     CsrfGuard::using()
+     *
+     *     // Permissive -- allows non-browser clients that don't send Sec-Fetch-Site
+     *     // or custom headers (mobile apps, legacy integrations):
+     *     CsrfGuard::using(strictWhenAmbiguous: false)
+     *
+     *     // Custom header name (Apollo ecosystem convention):
+     *     CsrfGuard::using(customHeaderName: 'Apollo-Require-Preflight')
+     *
+     * @param bool $rejectGet
+     *                        Whether to unconditionally reject GET requests.
+     *
+     *     GET requests can be triggered cross-origin by navigation (`<a>`),
+     *     resource embeds (`<img>`, `<script>`), or `window.open()` without any
+     *     CORS preflight.  Any query parameters (including the full GraphQL query
+     *     string) are visible in Referer headers, proxy logs, and browser history.
+     *
+     *     Disable only if you intentionally serve GET queries (e.g. for CDN-cached
+     *     persisted queries) and have alternative protections in place (e.g.
+     *     ReadOnlyOperationMiddleware to block mutations via GET).
+     *
+     *     Default: `true`
+     *
+     * @param bool $checkFetchMetadata
+     *                                 Whether to inspect the `Sec-Fetch-Site` request header.
+     *
+     *     Modern browsers (Chrome 76+, Firefox 90+, Safari 16.4+, Edge 79+) send
+     *     this header on every request.  It reliably indicates whether the request
+     *     was initiated from the same origin, same site, or cross-site.  Unlike
+     *     custom headers or content-type checks, this signal requires zero client
+     *     cooperation -- it simply works.
+     *
+     *     When enabled:
+     *     - `same-origin` / `same-site` → allow immediately (short-circuit)
+     *     - `cross-site` / `none` → reject immediately
+     *     - absent → fall through to subsequent checks
+     *
+     *     Disable only if your deployment strips `Sec-Fetch-*` headers (unusual).
+     *
+     *     Default: `true`
+     *
+     * @param bool $allowCustomHeader
+     *                                Whether to allow requests that include a specific custom HTTP header.
+     *
+     *     Browsers cannot send custom headers on "simple" (non-preflighted)
+     *     cross-origin requests.  Requiring a custom header is the mechanism
+     *     recommended by OWASP and used by Apollo Server/Router.  Any JavaScript
+     *     GraphQL client (Apollo Client, urql, Relay) sets `X-Requested-With`
+     *     or an equivalent header by default when configured to do so.
+     *
+     *     This check passes if the header specified by `$customHeaderName` is
+     *     present in the request, regardless of its value.
+     *
+     *     Disable if you want to rely exclusively on Fetch-Metadata and
+     *     Content-Type checks (steps 2-3 and 5).
+     *
+     *     Default: `true`
+     *
+     * @param string $customHeaderName
+     *                                 The name of the custom header to check (case-insensitive).
+     *
+     *     Common choices:
+     *     - `X-Requested-With` (jQuery/Axios convention, widely supported)
+     *     - `Apollo-Require-Preflight` (Apollo ecosystem convention)
+     *     - `GraphQL-Require-Preflight` (GraphQL-over-HTTP community convention)
+     *
+     *     The header name itself does not matter for security -- any non-standard
+     *     header forces a CORS preflight.  Choose whichever your client library
+     *     sends or is easiest to configure.
+     *
+     *     Default: `'X-Requested-With'`
+     *
+     * @param bool $allowNonSimpleContentType
+     *                                        Whether to allow requests whose Content-Type is NOT one of the three
+     *                                        CORS-safelisted form types (`application/x-www-form-urlencoded`,
+     *                                        `multipart/form-data`, `text/plain`).
+     *
+     *     The CORS spec guarantees that a browser will preflight any request
+     *     with a non-safelisted Content-Type.  Since standard GraphQL clients
+     *     send `application/json`, this check alone is sufficient to block
+     *     form-based CSRF for JSON payloads.
+     *
+     *     However, file uploads use `multipart/form-data` (a simple type).
+     *     If your endpoint supports uploads, clients must also send the custom
+     *     header (step 4) or the request must pass Fetch-Metadata (step 2).
+     *     All mainstream JavaScript upload libraries do this by default.
+     *
+     *     Disable if you want to force all clients to use the custom header
+     *     regardless of Content-Type (belt-and-suspenders approach).
+     *
+     *     Default: `true`
+     *
+     * @param bool $strictWhenAmbiguous
+     *                                  What to do when none of the above checks produced a definitive answer.
+     *
+     *     This situation arises when:
+     *     - The browser does not send `Sec-Fetch-Site` (pre-2019 browsers), AND
+     *     - No custom header is present, AND
+     *     - The Content-Type is "simple" (or absent)
+     *
+     *     In strict mode (default), such requests are rejected.  This is the
+     *     safest choice: it assumes any ambiguous request might be a forged form
+     *     submission from an old browser.
+     *
+     *     In permissive mode, ambiguous requests are allowed through.  Use this
+     *     when non-browser clients (mobile apps, server-to-server, CLI tools)
+     *     call the endpoint without sending Sec-Fetch-Site or custom headers
+     *     and you cannot modify them to do so.  The trade-off is that users on
+     *     very old browsers (pre-2019) would not be protected.
+     *
+     *     Default: `true`
+     *
+     * @return string Middleware string for use in route/schema configuration
+     */
+    public static function using(
+        bool $rejectGet = true,
+        bool $checkFetchMetadata = true,
+        bool $allowCustomHeader = true,
+        string $customHeaderName = 'X-Requested-With',
+        bool $allowNonSimpleContentType = true,
+        bool $strictWhenAmbiguous = true,
+    ): string {
+        $params = [];
+
+        if (!$rejectGet) {
+            $params[] = 'no-reject-get';
+        }
+
+        if (!$checkFetchMetadata) {
+            $params[] = 'no-fetch-metadata';
+        }
+
+        if (!$allowCustomHeader) {
+            $params[] = 'no-custom-header';
+        }
+
+        if ('X-Requested-With' !== $customHeaderName) {
+            $params[] = 'header:' . $customHeaderName;
+        }
+
+        if (!$allowNonSimpleContentType) {
+            $params[] = 'no-content-type-check';
+        }
+
+        if (!$strictWhenAmbiguous) {
+            $params[] = 'permissive';
+        }
+
+        if ([] === $params) {
+            return static::class;
+        }
+
+        return static::class . ':' . implode(',', $params);
+    }
+
+    public function handle(Request $request, Closure $next, string ...$params): mixed
+    {
+        /** @var list<string> $params */
+        [$rejectGet, $checkFetchMetadata, $allowCustomHeader, $customHeaderName, $allowNonSimpleContentType, $strictWhenAmbiguous] = $this->resolveOptions($params);
+
+        if ($rejectGet && $this->isGetRequest($request)) {
+            $this->reject('GET requests are not allowed by CSRF guard');
+        }
+
+        if ($checkFetchMetadata) {
+            $fetchSiteVerdict = $this->evaluateFetchMetadata($request);
+
+            if (true === $fetchSiteVerdict) {
+                return $next($request);
+            }
+
+            if (false === $fetchSiteVerdict) {
+                $this->reject('Cross-site requests are not allowed');
+            }
+
+            // null = header absent, fall through to other checks
+        }
+
+        if ($allowCustomHeader && $this->hasCustomHeader($request, $customHeaderName)) {
+            return $next($request);
+        }
+
+        if ($allowNonSimpleContentType && $this->hasNonSimpleContentType($request)) {
+            return $next($request);
+        }
+
+        if ($strictWhenAmbiguous) {
+            $this->reject('Request lacks indicators that it was not forged (no Sec-Fetch-Site, no custom header, simple Content-Type)');
+        }
+
+        return $next($request);
+    }
+
+    private function isGetRequest(Request $request): bool
+    {
+        return 'GET' === $request->getRealMethod();
+    }
+
+    /**
+     * Evaluate the Sec-Fetch-Site header.
+     *
+     * @return bool|null true = trusted, false = hostile, null = absent/unknown
+     */
+    private function evaluateFetchMetadata(Request $request): ?bool
+    {
+        $value = $request->header('Sec-Fetch-Site');
+
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        $value = strtolower($value);
+
+        if (\in_array($value, self::TRUSTED_FETCH_SITE_VALUES, true)) {
+            return true;
+        }
+
+        if (\in_array($value, self::HOSTILE_FETCH_SITE_VALUES, true)) {
+            return false;
+        }
+
+        // Unknown value -- treat as absent (fall through)
+        return null;
+    }
+
+    private function hasCustomHeader(Request $request, string $headerName): bool
+    {
+        return $request->hasHeader($headerName);
+    }
+
+    private function hasNonSimpleContentType(Request $request): bool
+    {
+        $contentType = $request->header('Content-Type', '');
+
+        if ('' === $contentType) {
+            return false;
+        }
+
+        foreach (self::SIMPLE_CONTENT_TYPES as $simpleType) {
+            if (str_starts_with(strtolower($contentType), $simpleType)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<string> $params
+     * @return array{bool, bool, bool, string, bool, bool}
+     */
+    private function resolveOptions(array $params): array
+    {
+        $rejectGet = $this->rejectGet;
+        $checkFetchMetadata = $this->checkFetchMetadata;
+        $allowCustomHeader = $this->allowCustomHeader;
+        $customHeaderName = $this->customHeaderName;
+        $allowNonSimpleContentType = $this->allowNonSimpleContentType;
+        $strictWhenAmbiguous = $this->strictWhenAmbiguous;
+
+        foreach ($params as $param) {
+            match (true) {
+                'no-reject-get' === $param => $rejectGet = false,
+                'no-fetch-metadata' === $param => $checkFetchMetadata = false,
+                'no-custom-header' === $param => $allowCustomHeader = false,
+                str_starts_with($param, 'header:') => $customHeaderName = substr($param, 7),
+                'no-content-type-check' === $param => $allowNonSimpleContentType = false,
+                'permissive' === $param => $strictWhenAmbiguous = false,
+                default => null, // Ignore unknown params for forward compatibility
+            };
+        }
+
+        return [$rejectGet, $checkFetchMetadata, $allowCustomHeader, $customHeaderName, $allowNonSimpleContentType, $strictWhenAmbiguous];
+    }
+
+    private function reject(string $reason): never
+    {
+        throw new BadRequestHttpException($reason);
+    }
+}

--- a/tests/Unit/CsrfGuardTest/CsrfGuardPerSchemaTest.php
+++ b/tests/Unit/CsrfGuardTest/CsrfGuardPerSchemaTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\CsrfGuardTest;
+
+use Rebing\GraphQL\Support\Middleware\CsrfGuard;
+use Rebing\GraphQL\Tests\Support\Objects\ExamplesQuery;
+use Rebing\GraphQL\Tests\TestCase;
+
+/**
+ * Tests that different schemas can have independently configured CsrfGuard policies.
+ */
+class CsrfGuardPerSchemaTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // No global route middleware -- each schema configures its own
+        $app['config']->set('graphql.route.middleware', []);
+
+        // "strict" schema: full CSRF guard with strict defaults
+        $app['config']->set('graphql.schemas.strict', [
+            'query' => ['examples' => ExamplesQuery::class],
+            'middleware' => [CsrfGuard::class],
+            'method' => ['POST'],
+        ]);
+
+        // "permissive" schema: CSRF guard but allows ambiguous requests
+        $app['config']->set('graphql.schemas.permissive', [
+            'query' => ['examples' => ExamplesQuery::class],
+            'middleware' => [CsrfGuard::using(strictWhenAmbiguous: false)],
+            'method' => ['POST'],
+        ]);
+
+        // "unprotected" schema: explicitly no CSRF middleware
+        // We must set a non-empty middleware array to avoid inheriting group
+        // middleware (empty arrays are filtered by array_filter in routes.php).
+        // Using a dummy middleware that always passes.
+        $app['config']->set('graphql.schemas.unprotected', [
+            'query' => ['examples' => ExamplesQuery::class],
+            'method' => ['POST'],
+            // middleware => null means "use group default" (which is empty here)
+        ]);
+    }
+
+    public function testStrictSchemaRejectsFormPost(): void
+    {
+        // No Sec-Fetch-Site, no custom header, simple Content-Type (default)
+        $response = $this->call('POST', '/graphql/strict', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Request lacks indicators', (string) $response->getContent());
+    }
+
+    public function testStrictSchemaAllowsJsonPost(): void
+    {
+        $response = $this->json('POST', '/graphql/strict', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testPermissiveSchemaAllowsFormPost(): void
+    {
+        // No Sec-Fetch-Site, no custom header, simple Content-Type --
+        // but permissive mode allows it through.
+        $response = $this->call('POST', '/graphql/permissive', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testPermissiveSchemaStillRejectsCrossSite(): void
+    {
+        // Sec-Fetch-Site: cross-site is a definitive attack signal --
+        // even permissive mode rejects it.
+        $response = $this->json('POST', '/graphql/permissive', [
+            'query' => '{ examples { test } }',
+        ], ['Sec-Fetch-Site' => 'cross-site']);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Cross-site', (string) $response->getContent());
+    }
+
+    public function testUnprotectedSchemaAllowsAnything(): void
+    {
+        // No CSRF middleware at all (null middleware = group default = empty)
+        $response = $this->call('POST', '/graphql/unprotected', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+}

--- a/tests/Unit/CsrfGuardTest/CsrfGuardTest.php
+++ b/tests/Unit/CsrfGuardTest/CsrfGuardTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types = 1);
+namespace Rebing\GraphQL\Tests\Unit\CsrfGuardTest;
+
+use Rebing\GraphQL\Support\Middleware\CsrfGuard;
+use Rebing\GraphQL\Tests\TestCase;
+
+/**
+ * Integration tests for the CsrfGuard HTTP middleware.
+ *
+ * Each test sends a real HTTP request to the GraphQL endpoint with specific
+ * headers/content-types and verifies that the middleware correctly allows or
+ * rejects the request at the HTTP layer.
+ */
+class CsrfGuardTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Enable GET so we can test GET rejection
+        $app['config']->set('graphql.schemas.default.method', ['GET', 'POST']);
+
+        // Apply CsrfGuard with strict defaults to the default schema
+        $app['config']->set('graphql.route.middleware', [CsrfGuard::class]);
+    }
+
+    // ------------------------------------------------------------------
+    // GET rejection
+    // ------------------------------------------------------------------
+
+    public function testGetRequestIsRejected(): void
+    {
+        $response = $this->call('GET', '/graphql', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString(
+            'GET requests are not allowed',
+            (string) $response->getContent(),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Sec-Fetch-Site checks
+    // ------------------------------------------------------------------
+
+    public function testSameOriginFetchMetadataAllowsRequest(): void
+    {
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_SEC_FETCH_SITE' => 'same-origin'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testSameSiteFetchMetadataAllowsRequest(): void
+    {
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_SEC_FETCH_SITE' => 'same-site'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testCrossSiteFetchMetadataRejectsJsonRequest(): void
+    {
+        $response = $this->json('POST', '/graphql', [
+            'query' => '{ examples { test } }',
+        ], ['Sec-Fetch-Site' => 'cross-site']);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString(
+            'Cross-site requests are not allowed',
+            (string) $response->getContent(),
+        );
+    }
+
+    public function testNoneFetchMetadataRejectsRequest(): void
+    {
+        $response = $this->json('POST', '/graphql', [
+            'query' => '{ examples { test } }',
+        ], ['Sec-Fetch-Site' => 'none']);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString(
+            'Cross-site requests are not allowed',
+            (string) $response->getContent(),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Custom header checks
+    // ------------------------------------------------------------------
+
+    public function testCustomHeaderAllowsFormEncodedRequest(): void
+    {
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    // ------------------------------------------------------------------
+    // Content-Type checks
+    // ------------------------------------------------------------------
+
+    public function testApplicationJsonAllowsRequest(): void
+    {
+        $response = $this->json('POST', '/graphql', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testApplicationGraphqlAllowsRequest(): void
+    {
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/graphql'],
+            '{ examples { test } }',
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testFormEncodedPostWithoutAnyIndicatorIsRejected(): void
+    {
+        // Simulates an HTML form submission: no Sec-Fetch-Site, no custom header,
+        // and a simple Content-Type.  This is exactly what a CSRF attack looks like.
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+        );
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString(
+            'Request lacks indicators',
+            (string) $response->getContent(),
+        );
+    }
+
+    public function testTextPlainContentTypeIsRejected(): void
+    {
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'text/plain'],
+            '{ examples { test } }',
+        );
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString(
+            'Request lacks indicators',
+            (string) $response->getContent(),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // File upload: multipart/form-data + X-Requested-With
+    // ------------------------------------------------------------------
+
+    public function testMultipartWithCustomHeaderIsAllowed(): void
+    {
+        // Simulate what a JavaScript file upload client does: multipart body
+        // with X-Requested-With header.
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    public function testMultipartWithoutCustomHeaderIsRejected(): void
+    {
+        // Simulates a cross-origin form with enctype="multipart/form-data"
+        // and no custom header — should be blocked.
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+        );
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    // ------------------------------------------------------------------
+    // strictWhenAmbiguous: false (permissive mode)
+    // ------------------------------------------------------------------
+
+    public function testPermissiveModeAllowsAmbiguousRequest(): void
+    {
+        // Reconfigure with permissive mode for this test
+        $this->app['config']->set('graphql.route.middleware', [
+            CsrfGuard::using(strictWhenAmbiguous: false),
+        ]);
+        $this->reloadRoutes();
+
+        // No Sec-Fetch-Site, no custom header, default (simple) Content-Type
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    // ------------------------------------------------------------------
+    // rejectGet: false
+    // ------------------------------------------------------------------
+
+    public function testGetAllowedWhenRejectGetDisabled(): void
+    {
+        $this->app['config']->set('graphql.route.middleware', [
+            CsrfGuard::using(rejectGet: false, strictWhenAmbiguous: false),
+        ]);
+        $this->reloadRoutes();
+
+        $response = $this->call('GET', '/graphql', [
+            'query' => '{ examples { test } }',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $response->getData(true);
+        self::assertArrayHasKey('data', $data);
+    }
+
+    // ------------------------------------------------------------------
+    // Custom header name
+    // ------------------------------------------------------------------
+
+    public function testCustomHeaderNameIsRespected(): void
+    {
+        $this->app['config']->set('graphql.route.middleware', [
+            CsrfGuard::using(customHeaderName: 'Apollo-Require-Preflight'),
+        ]);
+        $this->reloadRoutes();
+
+        // Default X-Requested-With should NOT work
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        self::assertSame(400, $response->getStatusCode());
+
+        // The configured header should work
+        $response = $this->call(
+            'POST',
+            '/graphql',
+            ['query' => '{ examples { test } }'],
+            [],
+            [],
+            ['HTTP_APOLLO_REQUIRE_PREFLIGHT' => '1'],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Reload routes so middleware changes take effect mid-test.
+     */
+    private function reloadRoutes(): void
+    {
+        $router = $this->app['router'];
+
+        // Clear existing routes
+        $router->getRoutes()->refreshNameLookups();
+        $router->getRoutes()->refreshActionLookups();
+
+        // Re-register GraphQL routes with new config
+        $routesFile = $this->app->basePath('vendor/rebing/graphql-laravel/src/routes.php');
+
+        if (!file_exists($routesFile)) {
+            $routesFile = __DIR__ . '/../../../src/routes.php';
+        }
+
+        require $routesFile;
+    }
+}


### PR DESCRIPTION
## Summary
Layered CSRF protection for cookie-authenticated endpoints:
- Sec-Fetch-Site validation (modern browsers)
- Custom header check (X-Requested-With / configurable)
- Content-Type enforcement (reject simple form types) Configurable per-schema via static CsrfGuard::using() factory.

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer cs-fix`
