### PR TITLE
Fix CI errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "webonyx/graphql-php": "^15.31.0"
     },
     "require-dev": {
-        "brianium/paratest": "^7.8.5|^8.0",
+        "brianium/paratest": "~7.8.5|^7.12|^8.0",
         "ext-pdo_sqlite": "*",
         "eliashaeussler/deep-closure-comparator": "^1.2",
         "fakerphp/faker": "^1.24",

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,13 @@
         "allow-plugins": {
             "php-http/discovery": false,
             "tbachert/spi": false
+        },
+        "policy": {
+            "abandoned": {
+                "ignore": {
+                    "eliashaeussler/deep-closure-comparator": "Marked abandoned upstream (suggested replacement: sebastian/comparator). The suggested replacement does not provide closure-equality assertions on its own - those rely on the built-in ClosureComparator added in sebastian/comparator 7.1.0, which is only guaranteed once the phpunit floor reaches ^12.3.0. Revisit when the floor moves or an actively-maintained alternative emerges."
+                }
+            }
         }
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,4 +28,13 @@ parameters:
         -
           message: '/Call to an undefined method Mockery\\/'
           identifier: method.notFound
+        # PHPUnit 13.2 soft-deprecated expectExceptionMessage() in favour of
+        # expectExceptionMessageIsOrContains(), which only exists in >=13.2.
+        # We still support phpunit ^11.5|^12.0|^13.0, so we cannot migrate yet.
+        # https://github.com/sebastianbergmann/phpunit/issues/6560
+        -
+          message: '/Call to deprecated method expectExceptionMessage\(\) of class PHPUnit\\Framework\\TestCase/'
+          identifier: method.deprecated
+          paths:
+              - tests/
 


### PR DESCRIPTION
## Summary
- paratest: adjust versions to keep CI prefer-lowest working
  Fixes https://github.com/rebing/graphql-laravel/actions/runs/27116118462/job/80023254270
- phpstan: ignore phpunit deprecations for now
  Once we hit the situation that we need to support a phpunit version which really dropped the old version, we may introduce a helper for the remaining phpunit version we still need to support.
  Fixes https://github.com/rebing/graphql-laravel/actions/runs/27116211217/job/80023526798
- composer audit: ignore abandoned https://github.com/eliashaeussler/deep-closure-comparator package
  We can't rid of it right now due to our CI test matrix, still requiring older versions of phpunit

---

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

Checklist:
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer cs-fix`
